### PR TITLE
Implement Dispute Management System (API Routes)

### DIFF
--- a/app/api/routes-d/disputes/[id]/route.ts
+++ b/app/api/routes-d/disputes/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getAuthContext, isAdminEmail } from '@/app/api/routes-d/disputes/_shared'
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const auth = await getAuthContext(request)
+    if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: 401 })
+
+    const { id } = await params
+
+    const dispute = await prisma.dispute.findUnique({
+      where: { id },
+      include: {
+        invoice: { select: { id: true, invoiceNumber: true, amount: true, clientEmail: true, userId: true } },
+        messages: { orderBy: { createdAt: 'asc' } },
+      },
+    })
+    if (!dispute) return NextResponse.json({ error: 'Dispute not found' }, { status: 404 })
+
+    const admin = isAdminEmail(auth.email)
+    const isFreelancer = auth.user.id === dispute.invoice.userId
+    const isClient = auth.email.toLowerCase() === dispute.invoice.clientEmail.toLowerCase()
+    if (!admin && !isFreelancer && !isClient) {
+      return NextResponse.json({ error: 'Not authorized to view this dispute' }, { status: 403 })
+    }
+
+    return NextResponse.json({
+      dispute: {
+        id: dispute.id,
+        invoice: {
+          id: dispute.invoice.id,
+          invoiceNumber: dispute.invoice.invoiceNumber,
+          amount: Number(dispute.invoice.amount),
+        },
+        initiatedBy: dispute.initiatedBy,
+        reason: dispute.reason,
+        requestedAction: dispute.requestedAction,
+        status: dispute.status,
+        resolution: dispute.resolution ?? undefined,
+        createdAt: dispute.createdAt.toISOString(),
+      },
+      messages: dispute.messages.map((m) => ({
+        id: m.id,
+        senderType: m.senderType,
+        senderEmail: m.senderEmail,
+        message: m.message,
+        attachments: (m.attachments as any) ?? [],
+        createdAt: m.createdAt.toISOString(),
+      })),
+    })
+  } catch (error) {
+    console.error('Dispute get error:', error)
+    return NextResponse.json({ error: 'Failed to get dispute' }, { status: 500 })
+  }
+}
+

--- a/app/api/routes-d/disputes/_shared.ts
+++ b/app/api/routes-d/disputes/_shared.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export type DisputeParty = 'client' | 'freelancer'
+export type DisputeSenderType = DisputeParty | 'admin'
+
+export function parseAdminEmailsEnv(): string[] {
+  const raw =
+    process.env.ADMIN_EMAILS ||
+    process.env.DISPUTE_ADMIN_EMAILS ||
+    ''
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+export function isAdminEmail(email?: string | null): boolean {
+  if (!email) return false
+  const e = email.trim().toLowerCase()
+  const admins = parseAdminEmailsEnv()
+  return admins.includes(e)
+}
+
+export async function getAuthContext(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return { error: 'Unauthorized' as const }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return { error: 'Invalid token' as const }
+
+  let user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    const email = (claims as any).email || `${claims.userId}@privy.local`
+    user = await prisma.user.create({ data: { privyId: claims.userId, email } })
+  }
+
+  const email = ((claims as any).email as string | undefined) || user.email
+
+  return { user, claims, email }
+}
+
+export function senderTypeForDispute(params: {
+  isAdmin: boolean
+  isFreelancer: boolean
+  isClient: boolean
+}): DisputeSenderType | null {
+  const { isAdmin, isFreelancer, isClient } = params
+  if (isAdmin) return 'admin'
+  if (isFreelancer) return 'freelancer'
+  if (isClient) return 'client'
+  return null
+}
+
+export const DisputeCreateSchema = z.object({
+  invoiceId: z.string().min(1),
+  initiatorEmail: z.string().email(),
+  reason: z.string().min(5).max(5000),
+  requestedAction: z.enum(['refund', 'partial_refund', 'revision']),
+  evidence: z.array(z.string().url()).optional(),
+})
+
+export const DisputeRespondSchema = z.object({
+  disputeId: z.string().min(1),
+  senderEmail: z.string().email(),
+  message: z.string().min(1).max(5000),
+  attachments: z.array(z.string().url()).optional(),
+})
+
+export const DisputeResolveSchema = z.object({
+  disputeId: z.string().min(1),
+  resolution: z.string().min(3).max(10000),
+  action: z.enum(['refund_full', 'refund_partial', 'no_refund']),
+  refundAmount: z.number().positive().optional(),
+  resolvedBy: z.enum(['admin', 'mutual_agreement']),
+})
+

--- a/app/api/routes-d/disputes/create/route.ts
+++ b/app/api/routes-d/disputes/create/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import {
+  DisputeCreateSchema,
+  getAuthContext,
+  type DisputeParty,
+} from '@/app/api/routes-d/disputes/_shared'
+import { sendDisputeInitiatedEmail } from '@/lib/email'
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request)
+    if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: 401 })
+
+    const body = await request.json()
+    const parsed = DisputeCreateSchema.safeParse(body)
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message || 'Invalid request' }, { status: 400 })
+
+    const { invoiceId, initiatorEmail, reason, requestedAction, evidence } = parsed.data
+
+    // Prevent spoofing
+    if (initiatorEmail.toLowerCase() !== auth.email.toLowerCase()) {
+      return NextResponse.json({ error: 'initiatorEmail must match authenticated user email' }, { status: 403 })
+    }
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id: invoiceId },
+      include: { user: { select: { id: true, email: true, name: true } } },
+    })
+    if (!invoice) return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+    if (invoice.status !== 'paid') return NextResponse.json({ error: 'Only paid invoices can be disputed' }, { status: 400 })
+
+    const isFreelancer = auth.user.id === invoice.userId
+    const isClient = initiatorEmail.toLowerCase() === invoice.clientEmail.toLowerCase()
+
+    if (!isFreelancer && !isClient) {
+      return NextResponse.json({ error: 'Not authorized to dispute this invoice' }, { status: 403 })
+    }
+
+    const initiatedBy: DisputeParty = isClient ? 'client' : 'freelancer'
+
+    const existing = await prisma.dispute.findUnique({ where: { invoiceId: invoice.id } })
+    if (existing) return NextResponse.json({ error: 'A dispute already exists for this invoice' }, { status: 409 })
+
+    const created = await prisma.$transaction(async (tx) => {
+      const dispute = await tx.dispute.create({
+        data: {
+          invoiceId: invoice.id,
+          initiatedBy,
+          initiatorEmail,
+          reason,
+          requestedAction,
+          status: 'open',
+        },
+        select: { id: true, invoiceId: true, status: true, initiatedBy: true, reason: true, createdAt: true },
+      })
+
+      await tx.invoice.update({
+        where: { id: invoice.id },
+        data: { status: 'disputed' },
+      })
+
+      await tx.disputeMessage.create({
+        data: {
+          disputeId: dispute.id,
+          senderType: initiatedBy,
+          senderEmail: initiatorEmail,
+          message: reason,
+          attachments: evidence ?? undefined,
+        },
+      })
+
+      return dispute
+    })
+
+    const otherPartyEmail =
+      initiatedBy === 'client' ? invoice.user.email : invoice.clientEmail
+
+    if (otherPartyEmail) {
+      await sendDisputeInitiatedEmail({
+        to: otherPartyEmail,
+        invoiceNumber: invoice.invoiceNumber,
+        initiatedBy,
+        reason,
+        requestedAction,
+      })
+    }
+
+    return NextResponse.json({
+      success: true,
+      dispute: {
+        id: created.id,
+        invoiceId: created.invoiceId,
+        status: 'open',
+        initiatedBy: created.initiatedBy,
+        reason: created.reason,
+        createdAt: created.createdAt.toISOString(),
+      },
+    })
+  } catch (error: any) {
+    // Unique constraint protection for concurrent requests
+    if (error?.code === 'P2002') {
+      return NextResponse.json({ error: 'A dispute already exists for this invoice' }, { status: 409 })
+    }
+    console.error('Dispute create error:', error)
+    return NextResponse.json({ error: 'Failed to create dispute' }, { status: 500 })
+  }
+}
+

--- a/app/api/routes-d/disputes/list/route.ts
+++ b/app/api/routes-d/disputes/list/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { getAuthContext, isAdminEmail } from '@/app/api/routes-d/disputes/_shared'
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request)
+    if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: 401 })
+
+    const status = request.nextUrl.searchParams.get('status') || undefined
+    const invoiceId = request.nextUrl.searchParams.get('invoiceId') || undefined
+
+    const admin = isAdminEmail(auth.email)
+
+    const where: any = {}
+    if (status) where.status = status
+    if (invoiceId) where.invoiceId = invoiceId
+
+    if (!admin) {
+      where.OR = [
+        { invoice: { userId: auth.user.id } },
+        { invoice: { clientEmail: auth.email } },
+        { initiatorEmail: auth.email },
+      ]
+    }
+
+    const disputes = await prisma.dispute.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        invoiceId: true,
+        initiatedBy: true,
+        reason: true,
+        status: true,
+        createdAt: true,
+        invoice: { select: { invoiceNumber: true } },
+      },
+    })
+
+    return NextResponse.json({
+      disputes: disputes.map((d) => ({
+        id: d.id,
+        invoiceId: d.invoiceId,
+        invoiceNumber: d.invoice.invoiceNumber,
+        initiatedBy: d.initiatedBy,
+        reason: d.reason,
+        status: d.status,
+        createdAt: d.createdAt.toISOString(),
+      })),
+    })
+  } catch (error) {
+    console.error('Disputes list error:', error)
+    return NextResponse.json({ error: 'Failed to list disputes' }, { status: 500 })
+  }
+}
+

--- a/app/api/routes-d/disputes/resolve/route.ts
+++ b/app/api/routes-d/disputes/resolve/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import {
+  DisputeResolveSchema,
+  getAuthContext,
+  isAdminEmail,
+} from '@/app/api/routes-d/disputes/_shared'
+import { sendDisputeResolvedEmail } from '@/lib/email'
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request)
+    if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: 401 })
+
+    const body = await request.json()
+    const parsed = DisputeResolveSchema.safeParse(body)
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message || 'Invalid request' }, { status: 400 })
+
+    const { disputeId, resolution, action, refundAmount, resolvedBy } = parsed.data
+
+    const dispute = await prisma.dispute.findUnique({
+      where: { id: disputeId },
+      include: { invoice: { include: { user: { select: { id: true, email: true } } } } },
+    })
+    if (!dispute) return NextResponse.json({ error: 'Dispute not found' }, { status: 404 })
+    if (dispute.status === 'resolved' || dispute.status === 'closed') {
+      return NextResponse.json({ error: 'Dispute already resolved' }, { status: 400 })
+    }
+
+    const admin = isAdminEmail(auth.email)
+    const isFreelancer = auth.user.id === dispute.invoice.userId
+    const isClient = auth.email.toLowerCase() === dispute.invoice.clientEmail.toLowerCase()
+
+    if (resolvedBy === 'admin' && !admin) {
+      return NextResponse.json({ error: 'Admin privileges required' }, { status: 403 })
+    }
+    if (resolvedBy === 'mutual_agreement' && !(isClient || isFreelancer)) {
+      return NextResponse.json({ error: 'Not authorized to resolve this dispute' }, { status: 403 })
+    }
+
+    if (action === 'refund_partial') {
+      if (!refundAmount || Number.isNaN(refundAmount)) {
+        return NextResponse.json({ error: 'refundAmount is required for refund_partial' }, { status: 400 })
+      }
+      const invAmount = Number(dispute.invoice.amount)
+      if (refundAmount <= 0 || refundAmount >= invAmount) {
+        return NextResponse.json({ error: 'refundAmount must be > 0 and < invoice amount' }, { status: 400 })
+      }
+    }
+
+    const invAmount = Number(dispute.invoice.amount)
+    const computedRefund =
+      action === 'refund_full' ? invAmount : action === 'refund_partial' ? refundAmount! : 0
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const now = new Date()
+
+      const disputeUpdated = await tx.dispute.update({
+        where: { id: dispute.id },
+        data: {
+          status: 'resolved',
+          resolution,
+          resolvedBy,
+          resolvedAt: now,
+          updatedAt: now,
+        },
+        select: { id: true, status: true, resolution: true, resolvedAt: true },
+      })
+
+      // Refund ledger entry (no external provider integration in this repo yet)
+      if (computedRefund > 0) {
+        await tx.transaction.create({
+          data: {
+            userId: dispute.invoice.userId,
+            type: 'refund',
+            status: 'completed',
+            amount: computedRefund,
+            currency: dispute.invoice.currency,
+            completedAt: now,
+          },
+        })
+      }
+
+      // Invoice status transitions
+      let invoiceStatus = dispute.invoice.status
+      if (action === 'no_refund') invoiceStatus = 'paid'
+      if (action === 'refund_full') invoiceStatus = 'refunded'
+      if (action === 'refund_partial') invoiceStatus = 'partially_refunded'
+
+      await tx.invoice.update({
+        where: { id: dispute.invoice.id },
+        data: { status: invoiceStatus },
+      })
+
+      await tx.disputeMessage.create({
+        data: {
+          disputeId: dispute.id,
+          senderType: resolvedBy === 'admin' ? 'admin' : (isClient ? 'client' : 'freelancer'),
+          senderEmail: auth.email,
+          message: `Resolution: ${resolution}\n\nAction: ${action}${action === 'refund_partial' ? ` (${computedRefund} ${dispute.invoice.currency})` : ''}`,
+          attachments: undefined,
+        },
+      })
+
+      return disputeUpdated
+    })
+
+    const notifyTargets = [dispute.invoice.clientEmail, dispute.invoice.user.email].filter(Boolean)
+    for (const to of notifyTargets) {
+      await sendDisputeResolvedEmail({
+        to,
+        invoiceNumber: dispute.invoice.invoiceNumber,
+        resolution,
+        action,
+        refundAmount: action === 'refund_partial' ? computedRefund : undefined,
+        currency: dispute.invoice.currency,
+      })
+    }
+
+    return NextResponse.json({
+      success: true,
+      dispute: {
+        id: updated.id,
+        status: 'resolved',
+        resolution: updated.resolution,
+        resolvedAt: updated.resolvedAt ? updated.resolvedAt.toISOString() : new Date().toISOString(),
+      },
+    })
+  } catch (error) {
+    console.error('Dispute resolve error:', error)
+    return NextResponse.json({ error: 'Failed to resolve dispute' }, { status: 500 })
+  }
+}
+

--- a/app/api/routes-d/disputes/respond/route.ts
+++ b/app/api/routes-d/disputes/respond/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import {
+  DisputeRespondSchema,
+  getAuthContext,
+  isAdminEmail,
+  senderTypeForDispute,
+} from '@/app/api/routes-d/disputes/_shared'
+import { sendDisputeMessageEmail } from '@/lib/email'
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getAuthContext(request)
+    if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: 401 })
+
+    const body = await request.json()
+    const parsed = DisputeRespondSchema.safeParse(body)
+    if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message || 'Invalid request' }, { status: 400 })
+
+    const { disputeId, senderEmail, message, attachments } = parsed.data
+
+    // Prevent spoofing
+    if (senderEmail.toLowerCase() !== auth.email.toLowerCase()) {
+      return NextResponse.json({ error: 'senderEmail must match authenticated user email' }, { status: 403 })
+    }
+
+    const dispute = await prisma.dispute.findUnique({
+      where: { id: disputeId },
+      include: { invoice: { include: { user: { select: { id: true, email: true } } } } },
+    })
+    if (!dispute) return NextResponse.json({ error: 'Dispute not found' }, { status: 404 })
+    if (dispute.status === 'resolved' || dispute.status === 'closed') {
+      return NextResponse.json({ error: 'Dispute is not accepting new messages' }, { status: 400 })
+    }
+
+    const admin = isAdminEmail(auth.email)
+    const isFreelancer = auth.user.id === dispute.invoice.userId
+    const isClient = senderEmail.toLowerCase() === dispute.invoice.clientEmail.toLowerCase()
+
+    const senderType = senderTypeForDispute({ isAdmin: admin, isFreelancer, isClient })
+    if (!senderType) return NextResponse.json({ error: 'Not authorized to respond to this dispute' }, { status: 403 })
+
+    const created = await prisma.$transaction(async (tx) => {
+      const msg = await tx.disputeMessage.create({
+        data: {
+          disputeId: dispute.id,
+          senderType,
+          senderEmail,
+          message,
+          attachments: attachments ?? undefined,
+        },
+        select: { id: true, disputeId: true, senderType: true, message: true, createdAt: true },
+      })
+
+      await tx.dispute.update({ where: { id: dispute.id }, data: { updatedAt: new Date() } })
+      return msg
+    })
+
+    const otherPartyEmail =
+      senderType === 'client'
+        ? dispute.invoice.user.email
+        : senderType === 'freelancer'
+          ? dispute.invoice.clientEmail
+          : null
+
+    if (otherPartyEmail) {
+      await sendDisputeMessageEmail({
+        to: otherPartyEmail,
+        invoiceNumber: dispute.invoice.invoiceNumber,
+        senderType,
+        message,
+      })
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: {
+        id: created.id,
+        disputeId: created.disputeId,
+        senderType: created.senderType,
+        message: created.message,
+        createdAt: created.createdAt.toISOString(),
+      },
+    })
+  } catch (error) {
+    console.error('Dispute respond error:', error)
+    return NextResponse.json({ error: 'Failed to add dispute message' }, { status: 500 })
+  }
+}
+


### PR DESCRIPTION
## PR: Implement Dispute Management System (API Routes)

### Summary
Adds a structured **dispute management API** under `app/api/routes-d/disputes/` to support initiating disputes on paid invoices, exchanging evidence/messages, listing disputes, viewing dispute history, and resolving disputes (admin or mutual agreement).

## Close Issue #21 

### What’s Included
- **New API module**: `app/api/routes-d/disputes/`
  - `POST /api/routes-d/disputes/create` — initiate a dispute on a paid invoice
  - `POST /api/routes-d/disputes/respond` — submit messages/evidence
  - `POST /api/routes-d/disputes/resolve` — resolve dispute + optional refund action
  - `GET /api/routes-d/disputes/list` — list disputes (scoped to user; admin sees all)
  - `GET /api/routes-d/disputes/[id]` — dispute details + full message history
- **Shared utilities**: `_shared.ts` for auth context, validation, and admin email checks.

### Business Rules / Behavior
- **Only paid invoices can be disputed**
- **Only invoice owner (freelancer) or the client (by invoice `clientEmail`) can initiate/respond**
- **No duplicate disputes per invoice** (returns `409`)
- **Dispute history is tracked** via `dispute_messages`
- **Resolution** supports: `refund_full`, `refund_partial`, `no_refund`
- **Admin authorization** supported via env allowlist:
  - `ADMIN_EMAILS` or `DISPUTE_ADMIN_EMAILS` (comma-separated emails)

### Files Added
- `app/api/routes-d/disputes/_shared.ts`
- `app/api/routes-d/disputes/create/route.ts`
- `app/api/routes-d/disputes/respond/route.ts`
- `app/api/routes-d/disputes/resolve/route.ts`
- `app/api/routes-d/disputes/list/route.ts`
- `app/api/routes-d/disputes/[id]/route.ts`

### How to Test (Quick)
> All endpoints require `Authorization: Bearer <privy_token>`.

#### 1) Create a dispute
`POST /api/routes-d/disputes/create`

Request body: