### PR TITLE
fix: change USDC from base to Stellar under moonpay widget

### DIFF
--- a/components/payments/MoonPayWidget.tsx
+++ b/components/payments/MoonPayWidget.tsx
@@ -13,7 +13,7 @@ export function useMoonPayWidget() {
   const openWidget = useCallback(async ({
     walletAddress,
     amount,
-    currencyCode = 'usdc_base',
+    currencyCode = 'usdc_xlm',
     invoiceId
   }: MoonPayWidgetProps) => {
     const { loadMoonPay } = await import('@moonpay/moonpay-js')


### PR DESCRIPTION
## Description

This PR just changes one line from usdc_base to usdc_xlm (reading documentation, it wasn't usdc_stellar), but I included a full explanation on how to make sure this works properly (as it needs to be configured in the project's Moonpay Dashboard.

So, what needs to be done is that under https://dashboard.moonpay.com/dashboard/on-ramp/cryptos, you can add more supported cryptocurrencies. Search USDC and mark USD Coin (Stellar) as enabled, that way, payment won't fail and it will pass successfully.

Here's how it looks like:
<img width="1280" height="825" alt="image" src="https://github.com/user-attachments/assets/9eb635ae-8f34-46f7-9c6e-76ad3f68d80b" />

Also, heres a quick Loom on how to do it:

https://www.loom.com/share/4d4fd746a4794818b7bceca822885afc

And that's it! This PR will close #7.

Any compliments on Drips are greatly appreciated, lmk if there are any more issues I can help with!