### PR TITLE
feat: implement real-time fee estimation API for cross-border payments

### DIFF
--- a/app/api/routes-d/route.ts
+++ b/app/api/routes-d/route.ts
@@ -10,6 +10,9 @@ export async function GET() {
         status: '/api/routes-d/bulk-invoices/status?jobId={id}',
         template: '/api/routes-d/bulk-invoices/template',
       },
+      utils: {
+        feeQuote: '/api/routes-d/utils/fee-quote?amount={usd_amount}',
+      },
     },
   })
 }

--- a/app/api/routes-d/utils/fee-quote/route.ts
+++ b/app/api/routes-d/utils/fee-quote/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUsdToNgnRate } from "@/lib/exchange-rate";
+import { server } from "@/lib/stellar";
+
+/**
+ * Fee Configuration Constants
+ * These can be updated based on provider contracts
+ */
+const FEE_CONFIG = {
+  // On-ramp fees (MoonPay/Transak)
+  onRamp: {
+    percentageFee: 0.035, // 3.5%
+    fixedFee: 0.50, // $0.50 fixed fee
+  },
+  // Off-ramp fees (Yellow Card)
+  offRamp: {
+    percentageFee: 0.015, // 1.5%
+    fixedFee: 0.25, // $0.25 fixed fee in USDC equivalent
+  },
+  // Stellar network fee is dynamic, fetched from network
+};
+
+/**
+ * Cache for exchange rates and fees
+ */
+interface CacheEntry {
+  data: {
+    exchangeRate: number;
+    stellarBaseFee: number;
+    timestamp: string;
+  };
+  expiresAt: number;
+}
+
+let cache: CacheEntry | null = null;
+const CACHE_DURATION = 60 * 1000; // 60 seconds
+
+/**
+ * Get cached or fresh exchange rate and network fees
+ */
+async function getRatesAndFees() {
+  const now = Date.now();
+
+  // Return from cache if still valid
+  if (cache && now < cache.expiresAt) {
+    return cache.data;
+  }
+
+  // Fetch fresh data
+  const [rateData, stellarBaseFeeStroops] = await Promise.all([
+    getUsdToNgnRate(),
+    server.fetchBaseFee(),
+  ]);
+
+  // Convert Stellar base fee from stroops to XLM (1 XLM = 10,000,000 stroops)
+  // Then approximate to USD (XLM is typically ~$0.10, but the fee is negligible)
+  const stellarBaseFee = Number(stellarBaseFeeStroops) / 10_000_000 * 0.10;
+
+  const data = {
+    exchangeRate: rateData.rate,
+    stellarBaseFee,
+    timestamp: new Date().toISOString(),
+  };
+
+  // Update cache
+  cache = {
+    data,
+    expiresAt: now + CACHE_DURATION,
+  };
+
+  return data;
+}
+
+/**
+ * Calculate fee breakdown for a given USD amount
+ */
+function calculateFees(usdAmount: number, exchangeRate: number, stellarBaseFee: number) {
+  // Step 1: Calculate on-ramp fee
+  const onRampFee = (usdAmount * FEE_CONFIG.onRamp.percentageFee) + FEE_CONFIG.onRamp.fixedFee;
+
+  // Step 2: Network fee (Stellar)
+  const networkFee = stellarBaseFee;
+
+  // Step 3: Calculate net USDC after on-ramp and network fees
+  const netUsdc = usdAmount - onRampFee - networkFee;
+
+  // Step 4: Calculate off-ramp fee
+  const offRampFee = (netUsdc * FEE_CONFIG.offRamp.percentageFee) + FEE_CONFIG.offRamp.fixedFee;
+
+  // Step 5: Final USDC after all fees
+  const finalUsdc = netUsdc - offRampFee;
+
+  // Step 6: Convert to NGN
+  const finalNgnValue = finalUsdc * exchangeRate;
+
+  // Step 7: Calculate effective rate (NGN received per USD sent)
+  const effectiveRate = finalNgnValue / usdAmount;
+
+  return {
+    netUsdcValue: parseFloat(finalUsdc.toFixed(2)),
+    finalNgnValue: parseFloat(finalNgnValue.toFixed(2)),
+    feeBreakdown: {
+      onRamp: parseFloat(onRampFee.toFixed(2)),
+      network: parseFloat(networkFee.toFixed(2)),
+      offRamp: parseFloat(offRampFee.toFixed(2)),
+    },
+    effectiveRate: parseFloat(effectiveRate.toFixed(2)),
+  };
+}
+
+/**
+ * GET /api/routes-d/utils/fee-quote?amount={usd_amount}
+ * 
+ * Returns a detailed breakdown of fees for cross-border payments
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // Extract amount from query parameters
+    const { searchParams } = new URL(request.url);
+    const amountParam = searchParams.get("amount");
+
+    // Validate amount parameter
+    if (!amountParam) {
+      return NextResponse.json(
+        { error: "Missing required parameter: amount" },
+        { status: 400 }
+      );
+    }
+
+    const usdAmount = parseFloat(amountParam);
+
+    // Validate amount value
+    if (isNaN(usdAmount) || usdAmount <= 0) {
+      return NextResponse.json(
+        { error: "Amount must be a positive number" },
+        { status: 400 }
+      );
+    }
+
+    // Get current rates and fees
+    const { exchangeRate, stellarBaseFee, timestamp } = await getRatesAndFees();
+
+    // Calculate fee breakdown
+    const calculation = calculateFees(usdAmount, exchangeRate, stellarBaseFee);
+
+    // Return response
+    return NextResponse.json({
+      usdAmount: parseFloat(usdAmount.toFixed(2)),
+      netUsdcValue: calculation.netUsdcValue,
+      finalNgnValue: calculation.finalNgnValue,
+      feeBreakdown: calculation.feeBreakdown,
+      effectiveRate: calculation.effectiveRate,
+      timestamp,
+    });
+
+  } catch (error) {
+    console.error("Error calculating fee quote:", error);
+    
+    return NextResponse.json(
+      { error: "Failed to calculate fee quote. Please try again later." },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/FEE_QUOTE_API.md
+++ b/docs/FEE_QUOTE_API.md
@@ -1,0 +1,314 @@
+# Fee Quote API - Implementation Documentation
+
+## Overview
+The Fee Quote API provides real-time transparency for cross-border payment costs, giving freelancers a complete breakdown of fees from USD card payments to NGN bank deposits.
+
+## Endpoint
+
+```
+GET /api/routes-d/utils/fee-quote?amount={usd_amount}
+```
+
+## Implementation Details
+
+### Flow Diagram
+```
+USD (Card) 
+  ↓
+  → On-ramp Fee (MoonPay/Transak: 3.5% + $0.50)
+  ↓
+USDC (Stellar Network)
+  ↓
+  → Network Fee (Stellar: ~$0.00001)
+  ↓
+USDC (Ready for off-ramp)
+  ↓
+  → Off-ramp Fee (Yellow Card: 1.5% + $0.25)
+  ↓
+NGN (Bank Account)
+```
+
+### Fee Configuration
+
+**On-ramp Fees (MoonPay/Transak):**
+- Percentage: 3.5%
+- Fixed Fee: $0.50
+- Total: `(amount * 0.035) + 0.50`
+
+**Network Fees (Stellar):**
+- Dynamic fee fetched from Stellar network
+- Typically ~$0.00001 (negligible)
+- Converted from stroops to USD
+
+**Off-ramp Fees (Yellow Card):**
+- Percentage: 1.5%
+- Fixed Fee: $0.25 (in USDC)
+- Total: `(netUsdc * 0.015) + 0.25`
+
+### Calculation Formula
+
+```
+1. On-ramp Fee = (USD Amount × 3.5%) + $0.50
+2. Network Fee = Stellar Base Fee (dynamic, ~$0.00001)
+3. Net USDC = USD Amount - On-ramp Fee - Network Fee
+4. Off-ramp Fee = (Net USDC × 1.5%) + $0.25
+5. Final USDC = Net USDC - Off-ramp Fee
+6. Final NGN = Final USDC × Exchange Rate
+7. Effective Rate = Final NGN ÷ Original USD Amount
+```
+
+### Caching Strategy
+
+- **Exchange rates**: Cached for 60 seconds
+- **Stellar network fees**: Cached for 60 seconds
+- **Benefits**: 
+  - Reduces API calls to external providers
+  - Improves response time
+  - Prevents rate limiting
+
+### Response Format
+
+```json
+{
+  "usdAmount": 100.00,
+  "netUsdcValue": 94.31,
+  "finalNgnValue": 150895.98,
+  "feeBreakdown": {
+    "onRamp": 4.00,
+    "network": 0.00,
+    "offRamp": 1.69
+  },
+  "effectiveRate": 1508.96,
+  "timestamp": "2026-01-24T01:00:00Z"
+}
+```
+
+### Field Descriptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `usdAmount` | number | Original USD amount requested |
+| `netUsdcValue` | number | Final USDC after all fees (before NGN conversion) |
+| `finalNgnValue` | number | Final NGN amount recipient receives |
+| `feeBreakdown.onRamp` | number | Fee charged by MoonPay/Transak (USD) |
+| `feeBreakdown.network` | number | Stellar network transaction fee (USD) |
+| `feeBreakdown.offRamp` | number | Fee charged by Yellow Card (USDC) |
+| `effectiveRate` | number | NGN received per USD sent (after all fees) |
+| `timestamp` | string | ISO 8601 timestamp of calculation |
+
+## API Integration
+
+### Example Requests
+
+**Basic Quote:**
+```bash
+curl "http://localhost:3000/api/routes-d/utils/fee-quote?amount=100"
+```
+
+**Large Amount:**
+```bash
+curl "http://localhost:3000/api/routes-d/utils/fee-quote?amount=10000"
+```
+
+### Example Responses
+
+**Success (200):**
+```json
+{
+  "usdAmount": 100.00,
+  "netUsdcValue": 94.31,
+  "finalNgnValue": 150895.98,
+  "feeBreakdown": {
+    "onRamp": 4.00,
+    "network": 0.00,
+    "offRamp": 1.69
+  },
+  "effectiveRate": 1508.96,
+  "timestamp": "2026-01-24T05:07:38.421Z"
+}
+```
+
+**Missing Amount (400):**
+```json
+{
+  "error": "Missing required parameter: amount"
+}
+```
+
+**Invalid Amount (400):**
+```json
+{
+  "error": "Amount must be a positive number"
+}
+```
+
+**Server Error (500):**
+```json
+{
+  "error": "Failed to calculate fee quote. Please try again later."
+}
+```
+
+## Testing Checklist
+
+### ✅ Functional Tests
+
+1. **Basic Quote Test**
+   - Request: `?amount=100`
+   - Verify: All fees add up to original amount
+   - Expected: `netUsdcValue + onRamp + network + offRamp ≈ 100`
+
+2. **Zero/Negative Amount Test**
+   - Request: `?amount=0` or `?amount=-10`
+   - Expected: 400 error with message
+
+3. **Missing Parameter Test**
+   - Request: `/fee-quote` (no amount)
+   - Expected: 400 error with message
+
+4. **Large Amount Test**
+   - Request: `?amount=10000`
+   - Verify: Fees scale correctly
+   - Check: Percentage fees are proportional
+
+5. **Rate Volatility Test**
+   - Make two requests 60+ seconds apart
+   - Verify: `finalNgnValue` updates with new exchange rate
+   - Check: `timestamp` changes
+
+6. **Decimal Precision Test**
+   - Request: `?amount=99.99`
+   - Verify: No rounding errors
+   - Check: All calculations to 2 decimal places
+
+### ✅ Performance Tests
+
+1. **Cache Validation**
+   - Make multiple requests within 60 seconds
+   - Verify: Fast response times (cached data)
+
+2. **Cache Expiry**
+   - Wait 60+ seconds, make new request
+   - Verify: Fresh data fetched, new timestamp
+
+### ✅ Integration Tests
+
+1. **Exchange Rate Integration**
+   - Verify: Uses `lib/exchange-rate.ts`
+   - Check: Fallback rate works when API unavailable
+
+2. **Stellar Network Integration**
+   - Verify: Fetches real base fee from Stellar
+   - Check: Proper conversion from stroops to USD
+
+## Example Test Results
+
+```
+Test 1: $100 USD
+- USD Amount: $100.00
+- On-ramp Fee: $4.00 (3.5% + $0.50)
+- Network Fee: $0.00 (negligible)
+- Off-ramp Fee: $1.69 (1.5% of $95.50 + $0.25)
+- Net USDC: $94.31
+- Final NGN: ₦150,895.98
+- Effective Rate: ₦1,508.96 per USD
+
+Test 2: $10,000 USD
+- USD Amount: $10,000.00
+- On-ramp Fee: $350.50
+- Network Fee: $0.00
+- Off-ramp Fee: $144.99
+- Net USDC: $9,504.51
+- Final NGN: ₦15,207,211.98
+- Effective Rate: ₦1,520.72 per USD
+```
+
+## Notes for Frontend Integration
+
+### Display Example
+
+```typescript
+const response = await fetch(`/api/routes-d/utils/fee-quote?amount=${amount}`);
+const quote = await response.json();
+
+// Display to user:
+console.log(`You send: $${quote.usdAmount}`);
+console.log(`Recipient receives: ₦${quote.finalNgnValue.toLocaleString()}`);
+console.log(`Total fees: $${(quote.feeBreakdown.onRamp + quote.feeBreakdown.network + quote.feeBreakdown.offRamp).toFixed(2)}`);
+console.log(`Effective rate: ₦${quote.effectiveRate} per $1 USD`);
+```
+
+### User-Facing Fee Breakdown
+
+```
+Your Payment Breakdown:
+━━━━━━━━━━━━━━━━━━━━━━━
+You send:              $100.00 USD
+━━━━━━━━━━━━━━━━━━━━━━━
+
+Fees:
+  Card → USDC           -$4.00
+  Network               -$0.00
+  USDC → NGN            -$1.69
+                       ━━━━━━
+  Total fees:           -$5.69
+
+━━━━━━━━━━━━━━━━━━━━━━━
+Recipient receives:   ₦150,896
+━━━━━━━━━━━━━━━━━━━━━━━
+
+Exchange rate: ₦1,509/$1 (after fees)
+Market rate: ₦1,600/$1
+```
+
+## Error Handling
+
+The API includes robust error handling:
+
+1. **Parameter Validation**: Ensures amount is provided and valid
+2. **Rate Fetching**: Falls back to default rate if API unavailable
+3. **Network Issues**: Returns 500 with user-friendly message
+4. **Logging**: All errors logged to console for debugging
+
+## Future Enhancements
+
+1. **Tiered Fees**: Implement volume-based fee discounts
+2. **Multiple Providers**: Support for different on/off-ramp providers
+3. **Route Optimization**: Suggest cheapest payment route
+4. **Historical Rates**: Show fee history over time
+5. **Fee Alerts**: Notify when fees drop below threshold
+6. **Currency Options**: Support more currencies beyond NGN
+
+## Maintenance
+
+### Updating Fee Percentages
+
+To update fee rates, modify the `FEE_CONFIG` object in [route.ts](../app/api/routes-d/utils/fee-quote/route.ts):
+
+```typescript
+const FEE_CONFIG = {
+  onRamp: {
+    percentageFee: 0.035, // Update this
+    fixedFee: 0.50,       // and/or this
+  },
+  offRamp: {
+    percentageFee: 0.015, // Update this
+    fixedFee: 0.25,       // and/or this
+  },
+};
+```
+
+### Updating Cache Duration
+
+To modify cache duration (currently 60 seconds):
+
+```typescript
+const CACHE_DURATION = 60 * 1000; // Change this value (milliseconds)
+```
+
+## Support
+
+For questions or issues with the fee quote API:
+- Check the project's main README
+- Review the test file for usage examples
+- Contact the development team via project channels

--- a/test-fee-quote.js
+++ b/test-fee-quote.js
@@ -1,0 +1,93 @@
+/**
+ * Simple test script for the fee-quote API logic
+ * Run with: node test-fee-quote.js
+ */
+
+const FEE_CONFIG = {
+  onRamp: {
+    percentageFee: 0.035, // 3.5%
+    fixedFee: 0.50,
+  },
+  offRamp: {
+    percentageFee: 0.015, // 1.5%
+    fixedFee: 0.25,
+  },
+};
+
+function calculateFees(usdAmount, exchangeRate, stellarBaseFee = 0.00001) {
+  // Step 1: Calculate on-ramp fee
+  const onRampFee = (usdAmount * FEE_CONFIG.onRamp.percentageFee) + FEE_CONFIG.onRamp.fixedFee;
+
+  // Step 2: Network fee (Stellar)
+  const networkFee = stellarBaseFee;
+
+  // Step 3: Calculate net USDC after on-ramp and network fees
+  const netUsdc = usdAmount - onRampFee - networkFee;
+
+  // Step 4: Calculate off-ramp fee
+  const offRampFee = (netUsdc * FEE_CONFIG.offRamp.percentageFee) + FEE_CONFIG.offRamp.fixedFee;
+
+  // Step 5: Final USDC after all fees
+  const finalUsdc = netUsdc - offRampFee;
+
+  // Step 6: Convert to NGN
+  const finalNgnValue = finalUsdc * exchangeRate;
+
+  // Step 7: Calculate effective rate
+  const effectiveRate = finalNgnValue / usdAmount;
+
+  return {
+    netUsdcValue: parseFloat(finalUsdc.toFixed(2)),
+    finalNgnValue: parseFloat(finalNgnValue.toFixed(2)),
+    feeBreakdown: {
+      onRamp: parseFloat(onRampFee.toFixed(2)),
+      network: parseFloat(networkFee.toFixed(2)),
+      offRamp: parseFloat(offRampFee.toFixed(2)),
+    },
+    effectiveRate: parseFloat(effectiveRate.toFixed(2)),
+  };
+}
+
+// Test scenarios
+console.log("=== Fee Quote Calculator Tests ===\n");
+
+// Test 1: Basic Quote for $100
+console.log("Test 1: $100 USD");
+const test1 = calculateFees(100, 1600);
+console.log(JSON.stringify({
+  usdAmount: 100.00,
+  ...test1,
+  timestamp: new Date().toISOString()
+}, null, 2));
+console.log(`\nVerification: ${test1.netUsdcValue} + ${test1.feeBreakdown.onRamp} + ${test1.feeBreakdown.network} + ${test1.feeBreakdown.offRamp} ≈ 100.00`);
+const total = test1.netUsdcValue + test1.feeBreakdown.onRamp + test1.feeBreakdown.network + test1.feeBreakdown.offRamp;
+console.log(`Total: ${total.toFixed(2)}\n`);
+
+// Test 2: Large amount $10,000
+console.log("\nTest 2: $10,000 USD");
+const test2 = calculateFees(10000, 1600);
+console.log(JSON.stringify({
+  usdAmount: 10000.00,
+  ...test2,
+  timestamp: new Date().toISOString()
+}, null, 2));
+
+// Test 3: Small amount $10
+console.log("\nTest 3: $10 USD (small amount)");
+const test3 = calculateFees(10, 1600);
+console.log(JSON.stringify({
+  usdAmount: 10.00,
+  ...test3,
+  timestamp: new Date().toISOString()
+}, null, 2));
+
+// Test 4: Different exchange rate
+console.log("\nTest 4: $100 USD with different exchange rate (1700 NGN/USD)");
+const test4 = calculateFees(100, 1700);
+console.log(JSON.stringify({
+  usdAmount: 100.00,
+  ...test4,
+  timestamp: new Date().toISOString()
+}, null, 2));
+
+console.log("\n=== All Tests Complete ===");


### PR DESCRIPTION

Closes Issues #45 

<img width="845" height="757" alt="Screenshot from 2026-01-24 05-08-10" src="https://github.com/user-attachments/assets/70c8fe07-b46a-487f-969e-ab1bf6110d9d" />


- Add /api/routes-d/utils/fee-quote endpoint for transparent fee calculation
- Calculate on-ramp (MoonPay/Transak), network (Stellar), and off-ramp (Yellow Card) fees
- Integrate with existing exchange rate and Stellar utilities
- Implement 60-second caching for rates and network fees
- Add comprehensive API documentation in docs/FEE_QUOTE_API.md
- Include test script for validating fee calculations
- Update routes index to include new fee-quote endpoint

Provides freelancers full transparency into payment chain costs with accurate USD->USDC->NGN conversion and detailed fee breakdown.