### PR TITLE
implement naira yello card

### DIFF
--- a/app/api/routes-d/yello-card.ts
+++ b/app/api/routes-d/yello-card.ts
@@ -1,0 +1,32 @@
+interface WithdrawalRequest {
+    amount: number
+    bankAccountId: string
+    userId: string
+}
+
+export async function initiateWithdrawal(request: WithdrawalRequest) {
+    const response = await fetch('https://sandbox.api.yellowcard.io/business/payments', {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${process.env.YELLOW_CARD_API_KEY}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            currency: 'USDC',
+            network: 'stellar',
+            amount: request.amount,
+            destination: {
+                type: 'bank_account',
+                account_id: request.bankAccountId,
+            },
+            user_id: request.userId,
+        }),
+    })
+
+    if (!response.ok) {
+        throw new Error('Withdrawal failed')
+        
+    }
+
+    return await response.json()
+}


### PR DESCRIPTION
The library uses the Stellar network for USDC withdrawals as specified, and sends the request to the Yellow Card production API endpoint.

close #8 