### PR TITLE
Centralize report fee rates configuration

### DIFF
--- a/app/api/routes-d/finance/_shared.ts
+++ b/app/api/routes-d/finance/_shared.ts
@@ -1,13 +1,13 @@
 import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { PLATFORM_FEE_RATE, WITHDRAWAL_FEE_RATE } from '@/lib/fee-rates'
+
+export { PLATFORM_FEE_RATE, WITHDRAWAL_FEE_RATE }
 
 /**
  * Finance module shared utilities
- * Fee rate constants (aligned with tax-reports module)
  */
-export const PLATFORM_FEE_RATE = 0.005 // 0.5%
-export const WITHDRAWAL_FEE_RATE = 0.005 // 0.5%
 
 /**
  * Supported period types for P&L reports

--- a/app/api/routes-d/tax-reports/_shared.ts
+++ b/app/api/routes-d/tax-reports/_shared.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from 'next/server'
 import { prisma } from '@/lib/db'
 import { getOrCreateUserFromRequest } from '@/app/api/routes-d/bulk-invoices/_shared'
+import { PLATFORM_FEE_RATE, WITHDRAWAL_FEE_RATE } from '@/lib/fee-rates'
 
-export const PLATFORM_FEE_RATE = 0.005 // 0.5%
-export const WITHDRAWAL_FEE_RATE = 0.005 // 0.5%
+export { PLATFORM_FEE_RATE, WITHDRAWAL_FEE_RATE }
 
 export function getYearBounds(year: number) {
   const start = new Date(Date.UTC(year, 0, 1, 0, 0, 0))

--- a/lib/fee-rates.ts
+++ b/lib/fee-rates.ts
@@ -1,0 +1,19 @@
+const DEFAULT_PLATFORM_FEE_RATE = 0.005 // 0.5%
+const DEFAULT_WITHDRAWAL_FEE_RATE = 0.005 // 0.5%
+
+function parseFeeRate(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+
+  const parsed = Number.parseFloat(value)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+
+  return parsed
+}
+
+/**
+ * Centralized report fee rates.
+ *
+ * These defaults preserve current behavior and can be overridden at runtime via env vars.
+ */
+export const PLATFORM_FEE_RATE = parseFeeRate(process.env.REPORT_PLATFORM_FEE_RATE, DEFAULT_PLATFORM_FEE_RATE)
+export const WITHDRAWAL_FEE_RATE = parseFeeRate(process.env.REPORT_WITHDRAWAL_FEE_RATE, DEFAULT_WITHDRAWAL_FEE_RATE)


### PR DESCRIPTION
# PR: Centralize Report Fee Rates

## Overview
This PR removes duplicated hardcoded fee constants from the tax reports shared module and aligns report fee calculation with a single centralized configuration source.

## Problem
`PLATFORM_FEE_RATE` was hardcoded as `0.005` in:
- `app/api/routes-d/tax-reports/_shared.ts`

A duplicate hardcoded value also existed in:
- `app/api/routes-d/finance/_shared.ts`

This created risk of drift and inconsistent fee calculations across reporting features.

## Solution Implemented
A new centralized configuration module was introduced:
- `lib/fee-rates.ts`

It now exports report fee rates from one place:
- `PLATFORM_FEE_RATE`
- `WITHDRAWAL_FEE_RATE`

Both rates retain current defaults (`0.005`) and support runtime overrides via environment variables:
- `REPORT_PLATFORM_FEE_RATE`
- `REPORT_WITHDRAWAL_FEE_RATE`

## Files Changed
- `lib/fee-rates.ts` (new)
- `app/api/routes-d/tax-reports/_shared.ts`
- `app/api/routes-d/finance/_shared.ts`

## Behavior and Compatibility
- Existing behavior remains unchanged by default (0.5% for platform and withdrawal fees).
- Existing imports from shared modules were preserved via re-exports.
- Report modules now read fee rates from one source of truth.

## Validation
- Type/error check completed for all touched files.
- No TypeScript/import errors in updated modules.

## Branch and Commit
- Branch: `fix/centralize-platform-fee-rate`
- Commit: `60a5b44`
- Commit message: `Centralize report fee rates configuration`

## Reviewer Notes
Please verify:
1. Rate values in report outputs still match expected defaults when env vars are not set.
2. `REPORT_PLATFORM_FEE_RATE` and `REPORT_WITHDRAWAL_FEE_RATE` correctly override defaults.
3. Tax and finance report calculations remain aligned.
Closes #184 