### PR TITLE
 fix: cap bulk invoice limit and fix mass payout fee underestimation

### DIFF
--- a/app/api/routes-d/bulk-invoices/create/route.ts
+++ b/app/api/routes-d/bulk-invoices/create/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
   BulkInvoiceSchema,
+  MAX_BULK_INVOICES,
   enforceBulkRateLimit,
   getOrCreateUserFromRequest,
   processBulkInvoices,
@@ -18,7 +19,7 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json()
     const shape = z.object({
-      invoices: z.array(z.unknown()).min(1, 'invoices must not be empty').max(100, 'Max 100 invoices per request'),
+      invoices: z.array(z.unknown()).min(1, 'invoices must not be empty').max(MAX_BULK_INVOICES, `Max ${MAX_BULK_INVOICES} invoices per request`),
       sendEmails: z.boolean().optional().default(false),
     })
     const parsedBody = shape.safeParse(body)

--- a/app/api/routes-d/bulk-invoices/upload-csv/route.ts
+++ b/app/api/routes-d/bulk-invoices/upload-csv/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
+  MAX_BULK_INVOICES,
   enforceBulkRateLimit,
   getOrCreateUserFromRequest,
   parseBooleanLike,
@@ -37,8 +38,8 @@ export async function POST(request: NextRequest) {
     const parsedCsv = parseCsvToInvoices(csvText)
     if ('error' in parsedCsv) return NextResponse.json({ error: parsedCsv.error }, { status: 400 })
 
-    if (parsedCsv.totalCount > 100) {
-      return NextResponse.json({ error: 'Max 100 invoices per request' }, { status: 429 })
+    if (parsedCsv.totalCount > MAX_BULK_INVOICES) {
+      return NextResponse.json({ error: `Max ${MAX_BULK_INVOICES} invoices per request` }, { status: 429 })
     }
 
     const sendEmails = parseBooleanLike(sendEmailsRaw) ?? false


### PR DESCRIPTION
closes #163 
 - Extract MAX_BULK_INVOICES=100 constant and enforce it as a hard cap inside processBulkInvoices to prevent route-level bypass
- Fix fee calculation to include platform fee (0.5%) per item and Yellow Card bank transfer fee (0.3 USDC) for BANK type payouts