### PR TITLE
Fix assigned issues: withdrawals, auth, audit masking, payout fees, and rounding (v2)

### DIFF
--- a/app/api/routes-d/collaboration/sub-contractors/route.ts
+++ b/app/api/routes-d/collaboration/sub-contractors/route.ts
@@ -86,6 +86,17 @@ export async function GET(request: NextRequest) {
       (sum: number, c: any) => sum + Number(c.sharePercentage),
       0,
     );
+    if (totalAllocated > 100) {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid collaborator allocation: total allocated share exceeds 100%",
+          totalAllocatedPercentage: totalAllocated,
+        },
+        { status: 409 },
+      );
+    }
+
     const leadShare = 100 - totalAllocated;
 
     return NextResponse.json({

--- a/app/api/routes-d/local/offline-verification/verify/route.ts
+++ b/app/api/routes-d/local/offline-verification/verify/route.ts
@@ -137,8 +137,8 @@ export async function PATCH(request: NextRequest) {
     const ngnAmount = Number(manualPayment.amountPaid);
     const usdcAmount = ngnAmount / exchangeRate;
 
-    // Round to 2 decimal places for USDC
-    const usdcAmountRounded = Math.floor(usdcAmount * 100) / 100;
+    // Round to nearest cent to avoid systematic truncation loss
+    const usdcAmountRounded = Math.round(usdcAmount * 100) / 100;
 
     if (usdcAmountRounded <= 0) {
       return NextResponse.json(

--- a/app/api/routes-d/payouts/mass/route.ts
+++ b/app/api/routes-d/payouts/mass/route.ts
@@ -44,7 +44,7 @@ function calculateEstimatedFees(items: MassPayoutItem[]): number {
     const platformFee = amount * PLATFORM_FEE_RATE;
 
     // Stellar gas fee per transaction (conservative USDC estimate)
-    const gasFeeUSDC = 0.001;
+    const gasFeeUSDC = 0.1;
 
     if (item.type === 'BANK') {
       // BANK payouts incur Yellow Card withdrawal fee on top
@@ -248,7 +248,7 @@ export async function POST(request: NextRequest) {
         data: {
           userId,
           totalAmount,
-          itemCount: body.items.length,
+          totalRecipients: body.items.length,
           status: 'processing'
         }
       });
@@ -317,9 +317,12 @@ export async function POST(request: NextRequest) {
     });
 
     // Update batch status
-    const finalStatus = failureCount === 0 ? 'completed' :
-      successCount === 0 ? 'partial_failure' :
-        'partial_failure';
+    const finalStatus =
+      failureCount === 0
+        ? 'completed'
+        : successCount === 0
+          ? 'failed'
+          : 'partial_failure';
 
     await prisma.payoutBatch.update({
       where: { id: batch.batch.id },

--- a/app/api/withdrawals/create/route.ts
+++ b/app/api/withdrawals/create/route.ts
@@ -1,0 +1,2 @@
+export { POST } from '../route'
+


### PR DESCRIPTION
## Summary
- Fix manual verification conversion rounding to nearest cent (issue #180).
- Add explicit overflow guard when collaborator allocations exceed 100% (issue #178).
- Increase conservative gas estimate in mass payouts and fix payout batch field/status handling (issue #176).
- Enforce authenticated access for audit stream and mask metadata for non-owner collaborators (issue #174).
- Harden auto-swap rule persistence per-user by using lookup + update/create fallback (issue #165).
- Add compatibility endpoint for POST /api/withdrawals/create that routes to the Yellow Card-backed withdrawals handler (issue #10).

## Validation
- Attempted 
pm run lint, but 
ext lint is misconfigured in this repo and fails with: Invalid project directory provided...\\LancePay\\lint.
- Ran 
px tsc --noEmit; current branch fails due to a pre-existing JSX syntax error in components/DevModeBanner.tsx unrelated to this change.

## Linked Issues
Closes #10
Closes #165
Closes #174
Closes #176
Closes #178
Closes #180