### PR TITLE
fix(kyc): support direct cloudinary uploads up to 25mb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ NEXT_PUBLIC_MOONPAY_API_KEY=pk_test_xxxxx
 MOONPAY_SECRET_KEY=sk_test_xxxxx
 MOONPAY_WEBHOOK_KEY=wk_xxxxx
 
+# Cloudinary - Direct KYC document uploads
+# Used by /api/routes-d/kyc/upload-url for signed uploads
+CLOUDINARY_CLOUD_NAME=your-cloud-name
+CLOUDINARY_API_KEY=your-cloudinary-api-key
+CLOUDINARY_API_SECRET=your-cloudinary-api-secret
+
 # ---------- Stellar (backend/server-only) ----------
 # Backend network selection for funding operations.
 # Values: testnet | mainnet (alias: public)

--- a/app/api/routes-d/kyc/submit/route.ts
+++ b/app/api/routes-d/kyc/submit/route.ts
@@ -3,6 +3,150 @@ import { submitKYCData } from "@/lib/sep12-kyc";
 import { getAuthContext } from "@/app/api/routes-d/auto-swap/_shared";
 import { prisma } from "@/lib/db";
 
+const MAX_FILE_COUNT = 6;
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "application/pdf",
+]);
+const CLOUDINARY_HOST_SUFFIX = "res.cloudinary.com";
+
+const DOCUMENT_FIELDS = [
+  "photo_id_front",
+  "photo_id_back",
+  "photo_proof_residence",
+  "photo_selfie",
+  "photo_additional_1",
+  "photo_additional_2",
+] as const;
+
+type DocumentField = (typeof DOCUMENT_FIELDS)[number];
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  pdf: "application/pdf",
+};
+
+class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BadRequestError";
+  }
+}
+
+function isDocumentField(value: string): value is DocumentField {
+  return (DOCUMENT_FIELDS as readonly string[]).includes(value);
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalIdType(
+  value: unknown
+): "passport" | "drivers_license" | "national_id" | undefined {
+  if (value === "passport") return "passport";
+  if (value === "drivers_license") return "drivers_license";
+  if (value === "national_id") return "national_id";
+  return undefined;
+}
+
+function inferMimeFromPathname(pathname: string): string | undefined {
+  const extension = pathname.split(".").pop()?.toLowerCase();
+  if (!extension) return undefined;
+  return MIME_BY_EXTENSION[extension];
+}
+
+function inferExtensionFromMimeType(mimeType: string): string {
+  if (mimeType === "application/pdf") return "pdf";
+  if (mimeType === "image/png") return "png";
+  return "jpg";
+}
+
+function validateDocumentFile(file: File, field: DocumentField): void {
+  if (file.size <= 0) {
+    throw new BadRequestError(`Document ${field} is empty`);
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    throw new BadRequestError(`Document ${field} exceeds the 25MB limit`);
+  }
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    throw new BadRequestError(
+      `Document ${field} must be JPEG, PNG, or PDF (received ${file.type})`
+    );
+  }
+}
+
+async function toValidatedFileFromUrl(
+  value: string,
+  field: DocumentField
+): Promise<File> {
+  let documentUrl: URL;
+  try {
+    documentUrl = new URL(value);
+  } catch {
+    throw new BadRequestError(`Document URL for ${field} is invalid`);
+  }
+
+  if (documentUrl.protocol !== "https:") {
+    throw new BadRequestError(`Document URL for ${field} must use HTTPS`);
+  }
+
+  if (!documentUrl.hostname.endsWith(CLOUDINARY_HOST_SUFFIX)) {
+    throw new BadRequestError(
+      `Document URL for ${field} must come from Cloudinary storage`
+    );
+  }
+
+  const response = await fetch(documentUrl.toString());
+  if (!response.ok) {
+    throw new BadRequestError(
+      `Unable to download uploaded document for ${field}`
+    );
+  }
+
+  const blob = await response.blob();
+  const derivedMimeType = blob.type || inferMimeFromPathname(documentUrl.pathname);
+  if (!derivedMimeType || !ALLOWED_MIME_TYPES.has(derivedMimeType)) {
+    throw new BadRequestError(`Document URL for ${field} has unsupported format`);
+  }
+
+  const extension = inferExtensionFromMimeType(derivedMimeType);
+  const file = new File([blob], `${field}.${extension}`, {
+    type: derivedMimeType,
+  });
+  validateDocumentFile(file, field);
+  return file;
+}
+
+async function resolveDocumentFromFormData(
+  formData: FormData,
+  field: DocumentField
+): Promise<File | undefined> {
+  const rawValue = formData.get(field);
+  if (rawValue instanceof File && rawValue.size > 0) {
+    validateDocumentFile(rawValue, field);
+    return rawValue;
+  }
+
+  const rawUrlValue = parseOptionalString(rawValue);
+  if (rawUrlValue) {
+    return toValidatedFileFromUrl(rawUrlValue, field);
+  }
+
+  const explicitUrl = parseOptionalString(formData.get(`${field}_url`));
+  if (explicitUrl) {
+    return toValidatedFileFromUrl(explicitUrl, field);
+  }
+
+  return undefined;
+}
+
 /**
  * POST /api/kyc/submit
  * Submit KYC information to SEP-12 anchor
@@ -36,23 +180,106 @@ export async function POST(req: NextRequest) {
     }
 
     const stellarAddress = wallet.stellarAddress;
-    const formData = await req.formData();
+    const contentType = req.headers.get("content-type") || "";
 
-    // Extract form data
+    let first_name: string | undefined;
+    let last_name: string | undefined;
+    let email_address: string | undefined;
+    let phone_number: string | undefined;
+    let address_country_code: string | undefined;
+    let address_city: string | undefined;
+    let address_line_1: string | undefined;
+    let birth_date: string | undefined;
+    let id_type: "passport" | "drivers_license" | "national_id" | undefined;
+    let id_number: string | undefined;
+
+    const documentFiles: Partial<Record<DocumentField, File>> = {};
+
+    if (contentType.includes("application/json")) {
+      const body = (await req.json()) as Record<string, unknown>;
+      first_name = parseOptionalString(body.first_name);
+      last_name = parseOptionalString(body.last_name);
+      email_address = parseOptionalString(body.email_address);
+      phone_number = parseOptionalString(body.phone_number);
+      address_country_code = parseOptionalString(body.address_country_code);
+      address_city = parseOptionalString(body.address_city);
+      address_line_1 = parseOptionalString(body.address_line_1);
+      birth_date = parseOptionalString(body.birth_date);
+      id_type = parseOptionalIdType(body.id_type);
+      id_number = parseOptionalString(body.id_number);
+
+      const rawDocuments = body.documents;
+      if (rawDocuments && typeof rawDocuments === "object") {
+        for (const [key, rawUrl] of Object.entries(
+          rawDocuments as Record<string, unknown>
+        )) {
+          if (!isDocumentField(key)) continue;
+          const documentUrl = parseOptionalString(rawUrl);
+          if (!documentUrl) continue;
+          documentFiles[key] = await toValidatedFileFromUrl(documentUrl, key);
+        }
+      }
+    } else {
+      const formData = await req.formData();
+      first_name = parseOptionalString(formData.get("first_name"));
+      last_name = parseOptionalString(formData.get("last_name"));
+      email_address = parseOptionalString(formData.get("email_address"));
+      phone_number = parseOptionalString(formData.get("phone_number"));
+      address_country_code = parseOptionalString(
+        formData.get("address_country_code")
+      );
+      address_city = parseOptionalString(formData.get("address_city"));
+      address_line_1 = parseOptionalString(formData.get("address_line_1"));
+      birth_date = parseOptionalString(formData.get("birth_date"));
+      id_type = parseOptionalIdType(parseOptionalString(formData.get("id_type")));
+      id_number = parseOptionalString(formData.get("id_number"));
+
+      for (const field of DOCUMENT_FIELDS) {
+        const resolved = await resolveDocumentFromFormData(formData, field);
+        if (resolved) {
+          documentFiles[field] = resolved;
+        }
+      }
+    }
+
+    const uploadedDocumentCount = Object.keys(documentFiles).length;
+    if (uploadedDocumentCount > MAX_FILE_COUNT) {
+      throw new BadRequestError("Maximum of 6 KYC documents can be uploaded");
+    }
+
+    const missingFields: string[] = [];
+    if (!first_name) missingFields.push("first_name");
+    if (!last_name) missingFields.push("last_name");
+    if (!email_address) missingFields.push("email_address");
+    if (!address_country_code) missingFields.push("address_country_code");
+    if (missingFields.length > 0) {
+      throw new BadRequestError(
+        `Missing required KYC fields: ${missingFields.join(", ")}`
+      );
+    }
+    if (!first_name || !last_name || !email_address || !address_country_code) {
+      throw new BadRequestError("Missing required KYC fields");
+    }
+
+    const requiredFirstName = first_name;
+    const requiredLastName = last_name;
+    const requiredEmailAddress = email_address;
+    const requiredCountryCode = address_country_code;
+
     const kycData = {
-      first_name: formData.get("first_name") as string,
-      last_name: formData.get("last_name") as string,
-      email_address: formData.get("email_address") as string,
-      phone_number: formData.get("phone_number") as string || undefined,
-      address_country_code: formData.get("address_country_code") as string,
-      address_city: formData.get("address_city") as string || undefined,
-      address_line_1: formData.get("address_line_1") as string || undefined,
-      birth_date: formData.get("birth_date") as string || undefined,
-      id_type: formData.get("id_type") as any,
-      id_number: formData.get("id_number") as string || undefined,
-      photo_id_front: formData.get("photo_id_front") as File || undefined,
-      photo_id_back: formData.get("photo_id_back") as File || undefined,
-      photo_proof_residence: formData.get("photo_proof_residence") as File || undefined,
+      first_name: requiredFirstName,
+      last_name: requiredLastName,
+      email_address: requiredEmailAddress,
+      phone_number,
+      address_country_code: requiredCountryCode,
+      address_city,
+      address_line_1,
+      birth_date,
+      id_type,
+      id_number,
+      photo_id_front: documentFiles.photo_id_front,
+      photo_id_back: documentFiles.photo_id_back,
+      photo_proof_residence: documentFiles.photo_proof_residence,
     };
 
     const result = await submitKYCData(stellarAddress, authToken, kycData);
@@ -60,8 +287,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       success: true,
       data: result,
+      uploadedDocumentCount,
     });
   } catch (error: any) {
+    if (error?.name === "BadRequestError") {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
     console.error("Error submitting KYC data:", error);
     return NextResponse.json(
       { error: error.message || "Failed to submit KYC data" },

--- a/app/api/routes-d/kyc/upload-url/route.ts
+++ b/app/api/routes-d/kyc/upload-url/route.ts
@@ -1,0 +1,173 @@
+import { randomUUID, createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthContext } from "@/app/api/routes-d/auto-swap/_shared";
+
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "application/pdf",
+]);
+
+const DOCUMENT_FIELDS = [
+  "photo_id_front",
+  "photo_id_back",
+  "photo_proof_residence",
+  "photo_selfie",
+  "photo_additional_1",
+  "photo_additional_2",
+] as const;
+
+type DocumentField = (typeof DOCUMENT_FIELDS)[number];
+
+function isDocumentField(value: string): value is DocumentField {
+  return (DOCUMENT_FIELDS as readonly string[]).includes(value);
+}
+
+function sanitizeSegment(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 48);
+}
+
+function createCloudinarySignature(
+  params: Record<string, string | number>,
+  apiSecret: string
+): string {
+  const payload = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== "")
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  return createHash("sha1")
+    .update(`${payload}${apiSecret}`)
+    .digest("hex");
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const auth = await getAuthContext(req);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: 401 });
+    }
+
+    let body: {
+      field?: unknown;
+      fileName?: unknown;
+      fileType?: unknown;
+      fileSize?: unknown;
+    };
+    try {
+      body = (await req.json()) as {
+        field?: unknown;
+        fileName?: unknown;
+        fileType?: unknown;
+        fileSize?: unknown;
+      };
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const field =
+      typeof body.field === "string" && isDocumentField(body.field)
+        ? body.field
+        : null;
+    if (!field) {
+      return NextResponse.json(
+        { error: "Invalid document field requested" },
+        { status: 400 }
+      );
+    }
+
+    const fileName =
+      typeof body.fileName === "string" ? body.fileName.trim() : "";
+    const fileType =
+      typeof body.fileType === "string" ? body.fileType.trim() : "";
+    const fileSize =
+      typeof body.fileSize === "number" && Number.isFinite(body.fileSize)
+        ? body.fileSize
+        : NaN;
+
+    if (!fileName) {
+      return NextResponse.json(
+        { error: "fileName is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!ALLOWED_MIME_TYPES.has(fileType)) {
+      return NextResponse.json(
+        {
+          error: "Only JPEG, PNG, and PDF documents are accepted",
+          allowedMimeTypes: Array.from(ALLOWED_MIME_TYPES),
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!Number.isFinite(fileSize) || fileSize <= 0) {
+      return NextResponse.json(
+        { error: "Invalid file size provided" },
+        { status: 400 }
+      );
+    }
+
+    if (fileSize > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        { error: "File exceeds 25MB size limit" },
+        { status: 400 }
+      );
+    }
+
+    const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+    const apiKey = process.env.CLOUDINARY_API_KEY;
+    const apiSecret = process.env.CLOUDINARY_API_SECRET;
+
+    if (!cloudName || !apiKey || !apiSecret) {
+      return NextResponse.json(
+        { error: "Cloudinary environment variables are not configured" },
+        { status: 500 }
+      );
+    }
+
+    const timestamp = Math.floor(Date.now() / 1000);
+    const folder = `kyc_docs/${auth.user.id}`;
+    const basename = sanitizeSegment(fileName.replace(/\.[^/.]+$/, "")) || "doc";
+    const publicId = `${field}_${basename}_${randomUUID().slice(0, 8)}`;
+
+    const paramsToSign: Record<string, string | number> = {
+      folder,
+      public_id: publicId,
+      timestamp,
+    };
+
+    if (fileType.startsWith("image/")) {
+      paramsToSign.transformation = "q_auto:good";
+    }
+
+    const signature = createCloudinarySignature(paramsToSign, apiSecret);
+
+    return NextResponse.json({
+      uploadUrl: `https://api.cloudinary.com/v1_1/${cloudName}/auto/upload`,
+      uploadParams: {
+        ...paramsToSign,
+        api_key: apiKey,
+        signature,
+      },
+      constraints: {
+        maxFileSizeBytes: MAX_FILE_SIZE_BYTES,
+        allowedMimeTypes: Array.from(ALLOWED_MIME_TYPES),
+      },
+    });
+  } catch (error: any) {
+    console.error("Error creating Cloudinary upload signature:", error);
+    return NextResponse.json(
+      { error: error.message || "Failed to generate upload URL" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/KYCVerificationForm.tsx
+++ b/components/KYCVerificationForm.tsx
@@ -1,31 +1,239 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { KYCStatus, getStatusMessage } from "@/lib/sep12-kyc";
 
 interface KYCVerificationFormProps {
   currentStatus?: KYCStatus;
   onSubmit: (formData: FormData) => Promise<void>;
+  requestHeaders?: Record<string, string>;
+}
+
+const MAX_FILE_COUNT = 6;
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "application/pdf"] as const;
+const ALLOWED_MIME_TYPE_SET = new Set<string>(ALLOWED_MIME_TYPES);
+const ACCEPT_ATTRIBUTE = ALLOWED_MIME_TYPES.join(",");
+
+const DOCUMENT_CONFIG = [
+  {
+    field: "photo_id_front",
+    label: "ID Front Photo",
+    required: true,
+  },
+  {
+    field: "photo_id_back",
+    label: "ID Back Photo (if applicable)",
+    required: false,
+  },
+  {
+    field: "photo_proof_residence",
+    label: "Proof of Residence",
+    required: true,
+  },
+  {
+    field: "photo_selfie",
+    label: "Selfie (optional)",
+    required: false,
+  },
+  {
+    field: "photo_additional_1",
+    label: "Additional Supporting Document 1 (optional)",
+    required: false,
+  },
+  {
+    field: "photo_additional_2",
+    label: "Additional Supporting Document 2 (optional)",
+    required: false,
+  },
+] as const;
+
+type DocumentField = (typeof DOCUMENT_CONFIG)[number]["field"];
+
+type CloudinarySignatureResponse = {
+  uploadUrl: string;
+  uploadParams: Record<string, string | number>;
+};
+
+type CloudinaryUploadResponse = {
+  secure_url?: string;
+  error?: {
+    message?: string;
+  };
+};
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(0)}MB`;
 }
 
 export function KYCVerificationForm({
   currentStatus,
   onSubmit,
+  requestHeaders,
 }: KYCVerificationFormProps) {
   const [step, setStep] = useState(1);
   const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [uploadStatus, setUploadStatus] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<
+    Partial<Record<DocumentField, number>>
+  >({});
 
-  const statusInfo = currentStatus
-    ? getStatusMessage(currentStatus)
-    : null;
+  const statusInfo = currentStatus ? getStatusMessage(currentStatus) : null;
+  const uploadProgressRows = useMemo(
+    () =>
+      DOCUMENT_CONFIG.filter(
+        ({ field }) => typeof uploadProgress[field] === "number"
+      ),
+    [uploadProgress]
+  );
+
+  const uploadDocument = async (
+    field: DocumentField,
+    file: File
+  ): Promise<string> => {
+    const signedUploadResponse = await fetch("/api/routes-d/kyc/upload-url", {
+      method: "POST",
+      headers: {
+        ...requestHeaders,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        field,
+        fileName: file.name,
+        fileType: file.type,
+        fileSize: file.size,
+      }),
+    });
+
+    if (!signedUploadResponse.ok) {
+      const payload = (await signedUploadResponse
+        .json()
+        .catch(() => ({}))) as { error?: string };
+      throw new Error(payload.error || "Failed to prepare document upload");
+    }
+
+    const signedPayload =
+      (await signedUploadResponse.json()) as CloudinarySignatureResponse;
+    if (!signedPayload.uploadUrl || !signedPayload.uploadParams) {
+      throw new Error("Upload URL response was invalid");
+    }
+
+    const uploadBody = new FormData();
+    for (const [key, value] of Object.entries(signedPayload.uploadParams)) {
+      uploadBody.append(key, String(value));
+    }
+    uploadBody.append("file", file);
+
+    setUploadProgress((current) => ({ ...current, [field]: 0 }));
+
+    return new Promise<string>((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open("POST", signedPayload.uploadUrl);
+
+      xhr.upload.onprogress = (event) => {
+        if (!event.lengthComputable) return;
+        const percent = Math.min(
+          100,
+          Math.round((event.loaded / event.total) * 100)
+        );
+        setUploadProgress((current) => ({ ...current, [field]: percent }));
+      };
+
+      xhr.onload = () => {
+        let payload: CloudinaryUploadResponse = {};
+        try {
+          payload = JSON.parse(xhr.responseText) as CloudinaryUploadResponse;
+        } catch {
+          // Ignore parse failures and use generic error below
+        }
+
+        if (
+          xhr.status >= 200 &&
+          xhr.status < 300 &&
+          typeof payload.secure_url === "string"
+        ) {
+          setUploadProgress((current) => ({ ...current, [field]: 100 }));
+          resolve(payload.secure_url);
+          return;
+        }
+
+        reject(
+          new Error(
+            payload.error?.message || "Cloudinary upload failed for document"
+          )
+        );
+      };
+
+      xhr.onerror = () => {
+        reject(new Error("Document upload failed due to a network error"));
+      };
+
+      xhr.send(uploadBody);
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
+    setFormError(null);
+    setUploadStatus(null);
+    setUploadProgress({});
 
     try {
       const formData = new FormData(e.currentTarget);
+
+      const selectedDocuments: Array<{
+        field: DocumentField;
+        label: (typeof DOCUMENT_CONFIG)[number]["label"];
+        file: File;
+      }> = [];
+
+      for (const { field, label } of DOCUMENT_CONFIG) {
+        const rawValue = formData.get(field);
+        if (!(rawValue instanceof File) || rawValue.size === 0) continue;
+        selectedDocuments.push({
+          field,
+          label,
+          file: rawValue,
+        });
+      }
+
+      if (selectedDocuments.length > MAX_FILE_COUNT) {
+        throw new Error(`Maximum ${MAX_FILE_COUNT} files can be uploaded`);
+      }
+
+      for (const { field, file } of selectedDocuments) {
+        if (!ALLOWED_MIME_TYPE_SET.has(file.type)) {
+          throw new Error(
+            `${field} must be one of: JPEG, PNG, or PDF. Received ${file.type}`
+          );
+        }
+        if (file.size > MAX_FILE_SIZE_BYTES) {
+          throw new Error(
+            `${field} exceeds ${formatBytes(MAX_FILE_SIZE_BYTES)} limit`
+          );
+        }
+      }
+
+      for (let index = 0; index < selectedDocuments.length; index += 1) {
+        const { field, label, file } = selectedDocuments[index];
+        setUploadStatus(
+          `Uploading ${index + 1} of ${selectedDocuments.length}: ${label}`
+        );
+        const secureUrl = await uploadDocument(field, file);
+        formData.set(field, secureUrl);
+      }
+
+      if (selectedDocuments.length > 0) {
+        setUploadStatus("Submitting KYC verification...");
+      }
+
       await onSubmit(formData);
+      setUploadStatus(null);
+    } catch (error: any) {
+      setFormError(error?.message || "Failed to submit KYC verification");
+      setUploadStatus(null);
     } finally {
       setLoading(false);
     }
@@ -43,6 +251,11 @@ export function KYCVerificationForm({
           </div>
         )}
       </div>
+      {formError && (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {formError}
+        </div>
+      )}
 
       {currentStatus === "ACCEPTED" ? (
         <div className="bg-green-50 border border-green-200 rounded-lg p-6 text-center">
@@ -176,46 +389,52 @@ export function KYCVerificationForm({
                 className="w-full px-3 py-2 border rounded"
               />
 
-              <div className="space-y-2">
-                <label className="block text-sm font-medium">
-                  ID Front Photo
-                </label>
-                <input
-                  name="photo_id_front"
-                  type="file"
-                  accept="image/*"
-                  className="w-full"
-                />
+              {DOCUMENT_CONFIG.map(({ field, label, required }) => (
+                <div key={field} className="space-y-2">
+                  <label className="block text-sm font-medium">{label}</label>
+                  <input
+                    name={field}
+                    type="file"
+                    accept={ACCEPT_ATTRIBUTE}
+                    required={required}
+                    className="w-full"
+                  />
+                </div>
+              ))}
+
+              <div className="rounded border border-blue-200 bg-blue-50 p-3 text-xs text-blue-700">
+                Accepted formats: JPEG, PNG, PDF. Maximum {MAX_FILE_COUNT} files
+                total, up to {formatBytes(MAX_FILE_SIZE_BYTES)} per file.
               </div>
 
-              <div className="space-y-2">
-                <label className="block text-sm font-medium">
-                  ID Back Photo (if applicable)
-                </label>
-                <input
-                  name="photo_id_back"
-                  type="file"
-                  accept="image/*"
-                  className="w-full"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <label className="block text-sm font-medium">
-                  Proof of Residence
-                </label>
-                <input
-                  name="photo_proof_residence"
-                  type="file"
-                  accept="image/*"
-                  className="w-full"
-                />
-              </div>
+              {uploadStatus && (
+                <div className="space-y-2 rounded border border-slate-200 p-3">
+                  <p className="text-xs text-slate-700">{uploadStatus}</p>
+                  {uploadProgressRows.map(({ field, label }) => {
+                    const progress = uploadProgress[field] ?? 0;
+                    return (
+                      <div key={field} className="space-y-1">
+                        <div className="flex justify-between text-xs text-slate-600">
+                          <span>{label}</span>
+                          <span>{progress}%</span>
+                        </div>
+                        <div className="h-2 overflow-hidden rounded bg-slate-200">
+                          <div
+                            className="h-full bg-blue-500 transition-all"
+                            style={{ width: `${progress}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
 
               <div className="flex gap-3">
                 <button
                   type="button"
                   onClick={() => setStep(2)}
+                  disabled={loading}
                   className="flex-1 border py-2 rounded hover:bg-gray-50"
                 >
                   Back
@@ -225,7 +444,7 @@ export function KYCVerificationForm({
                   disabled={loading}
                   className="flex-1 bg-green-500 text-white py-2 rounded hover:bg-green-600 disabled:opacity-50"
                 >
-                  {loading ? "Submitting..." : "Submit for Verification"}
+                  {loading ? "Uploading & Submitting..." : "Submit for Verification"}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
Summary
  This PR fixes KYC upload failures for files larger than 4MB by switching to direct-to-Cloudinary uploads and submitting document URLs instead of large file
  payloads through Next.js API routes.

  What Changed

  - Added signed upload endpoint: POST /api/routes-d/kyc/upload-url
  - Updated KYC form to:
      - Validate file type (JPEG, PNG, PDF)
      - Enforce 25MB max per file
      - Enforce max 6 files
      - Upload directly to Cloudinary with progress UI
  - Updated POST /api/routes-d/kyc/submit to accept URL-based docs and validate/resolve them server-side before SEP-12 submission
  - Added Cloudinary env vars to .env.example

  Acceptance Criteria Mapping

  - Uploads up to 25MB:
  - JPEG/PNG/PDF only: 
  - Validate before upload: 
  - Upload progress bar: 
  - Image compression on upload: (q_auto:good transform for images)
  - Max file count (6): 

  Notes

  - Requires CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET.
  - Existing repo-wide TypeScript errors remain in unrelated file components/DevModeBanner.tsx.

  Closes
  Closes #239
