### PR TITLE
feat(analytics): add GET /api/routes-d/analytics/invoices endpoint

### DIFF
--- a/app/api/routes-d/analytics/invoices/route.ts
+++ b/app/api/routes-d/analytics/invoices/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
+type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  // Count invoices grouped by status
+  const grouped = await prisma.invoice.groupBy({
+    by: ['status'],
+    where: { userId: user.id },
+    _count: { id: true },
+  })
+
+  // Aggregate total count and total invoiced amount
+  const totals = await prisma.invoice.aggregate({
+    where: { userId: user.id },
+    _count: { id: true },
+    _sum: { amount: true },
+  })
+
+  // Build a map from the grouped results, defaulting all known statuses to 0
+  const countByStatus = INVOICE_STATUSES.reduce<Record<InvoiceStatus, number>>(
+    (acc, status) => {
+      acc[status] = 0
+      return acc
+    },
+    {} as Record<InvoiceStatus, number>,
+  )
+
+  for (const row of grouped) {
+    if (INVOICE_STATUSES.includes(row.status as InvoiceStatus)) {
+      countByStatus[row.status as InvoiceStatus] = row._count.id
+    }
+  }
+
+  return NextResponse.json({
+    invoices: {
+      total: totals._count.id,
+      pending: countByStatus.pending,
+      paid: countByStatus.paid,
+      overdue: countByStatus.overdue,
+      cancelled: countByStatus.cancelled,
+      totalInvoiced: Number(totals._sum.amount ?? 0),
+    },
+  })
+}


### PR DESCRIPTION


# Pull Request Description: Analytics Invoices Endpoint

## 🚀 Overview
Implementación del endpoint `GET /api/routes-d/analytics/invoices` para obtener estadísticas detalladas sobre las facturas del usuario autenticado, agrupadas por estado.

## ✨ Changes
- **Nuevo Endpoint:** [app/api/routes-d/analytics/invoices/route.ts](cci:7://file:///Users/kevinbrenes/LancePay/app/api/routes-d/analytics/invoices/route.ts:0:0-0:0).
- **Lógica de Agrupación:** Se utiliza `prisma.invoice.groupBy` para contar facturas por los estados: `pending`, `paid`, `overdue`, y `cancelled`.
- **Cálculo de Totales:** Uso de `prisma.invoice.aggregate` para obtener el conteo total y la suma acumulada de montos (`totalInvoiced`).
- **Normalización de Datos:** Se asegura que los 4 estados estén presentes en la respuesta, incluso si su conteo es `0`.
- **Seguridad:** Validación de token mediante `verifyAuthToken`.

## 📋 Acceptance Criteria
- [x] Regresa `200` con los conteos por estado.
- [x] Los cuatro estados están presentes (usa `0` si no hay facturas).
- [x] `totalInvoiced` es un número (conversión de `Decimal` a `Number`).
- [x] Regresa `401` si no hay autenticación válida.

## 📦 API Response Example
```json
{
  "invoices": {
    "total": 24,
    "pending": 5,
    "paid": 16,
    "overdue": 2,
    "cancelled": 1,
    "totalInvoiced": 12400.00
  }
}
```
## Closes #297 