### PR TITLE
Add contacts API route handlers

### DIFF
--- a/app/api/routes-d/contacts/[id]/route.ts
+++ b/app/api/routes-d/contacts/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+type ContactDelegate = {
+  findUnique: (args: Record<string, unknown>) => Promise<Record<string, unknown> | null>
+}
+
+function getContactDelegate(): ContactDelegate {
+  return (prisma as unknown as { contact: ContactDelegate }).contact
+}
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+
+  if (!claims) {
+    return null
+  }
+
+  return prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const contactDelegate = getContactDelegate()
+  const contact = await contactDelegate.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      email: true,
+      company: true,
+      notes: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+
+  if (!contact) {
+    return NextResponse.json({ error: 'Contact not found' }, { status: 404 })
+  }
+
+  if (contact.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return NextResponse.json({
+    contact: {
+      id: contact.id,
+      name: contact.name,
+      email: contact.email,
+      company: contact.company ?? null,
+      notes: contact.notes ?? null,
+      createdAt: contact.createdAt,
+      updatedAt: contact.updatedAt,
+    },
+  })
+}

--- a/app/api/routes-d/contacts/route.ts
+++ b/app/api/routes-d/contacts/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type ContactDelegate = {
+  findMany: (args: Record<string, unknown>) => Promise<Array<Record<string, unknown>>>
+  create: (args: Record<string, unknown>) => Promise<Record<string, unknown>>
+}
+
+function getContactDelegate(): ContactDelegate {
+  return (prisma as unknown as { contact: ContactDelegate }).contact
+}
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+
+  if (!claims) {
+    return null
+  }
+
+  return prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+}
+
+function normalizeOptionalString(value: unknown, maxLength: number): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  if (trimmed.length > maxLength) return undefined
+
+  return trimmed
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const search = request.nextUrl.searchParams.get('search')?.trim() || ''
+  const contactDelegate = getContactDelegate()
+
+  const contacts = await contactDelegate.findMany({
+    where: {
+      userId: user.id,
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { email: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    },
+    orderBy: { name: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      company: true,
+      notes: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({
+    contacts: contacts.map((contact) => ({
+      id: contact.id,
+      name: contact.name,
+      email: contact.email,
+      company: contact.company ?? null,
+      notes: contact.notes ?? null,
+      createdAt: contact.createdAt,
+    })),
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const name = typeof body?.name === 'string' ? body.name.trim() : ''
+  const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : ''
+  const company = normalizeOptionalString(body?.company, 100)
+  const notes = normalizeOptionalString(body?.notes, 500)
+
+  if (!name || name.length > 100) {
+    return NextResponse.json({ error: 'Name is required and must be at most 100 characters' }, { status: 400 })
+  }
+
+  if (!email || !EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 })
+  }
+
+  if (company === undefined) {
+    return NextResponse.json({ error: 'Company must be at most 100 characters' }, { status: 400 })
+  }
+
+  if (notes === undefined) {
+    return NextResponse.json({ error: 'Notes must be at most 500 characters' }, { status: 400 })
+  }
+
+  const contactDelegate = getContactDelegate()
+
+  try {
+    const contact = await contactDelegate.create({
+      data: {
+        userId: user.id,
+        name,
+        email,
+        company,
+        notes,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        company: true,
+        notes: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json(
+      {
+        id: contact.id,
+        name: contact.name,
+        email: contact.email,
+        company: contact.company ?? null,
+        notes: contact.notes ?? null,
+        createdAt: contact.createdAt,
+      },
+      { status: 201 },
+    )
+  } catch (error: unknown) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'P2002'
+    ) {
+      return NextResponse.json(
+        { error: 'A contact with this email already exists' },
+        { status: 409 },
+      )
+    }
+
+    throw error
+  }
+}


### PR DESCRIPTION
Refs #298
Closes #300
Closes #301
Closes #302

## What this PR adds
- `GET /api/routes-d/contacts`
- `POST /api/routes-d/contacts`
- `GET /api/routes-d/contacts/[id]`

## Behavior covered
- authenticates requests using the existing bearer-token pattern
- lists only the current user's contacts, ordered by name ascending
- supports optional case-insensitive `?search=` filtering by name or email
- creates contacts with validation for required fields and field length limits
- returns `409 Conflict` when the same user tries to create a duplicate contact email
- fetches a single contact by ID with an explicit ownership check
- returns `403 Forbidden` when a contact exists but belongs to a different user
- returns `404 Not Found` when the requested contact does not exist
- returns `401 Unauthorized` for unauthenticated requests across all three handlers

## Files changed
- `app/api/routes-d/contacts/route.ts`
- `app/api/routes-d/contacts/[id]/route.ts`

## Validation details
- `name` is required and capped at 100 characters
- `email` is required and validated before create
- `company` is optional and capped at 100 characters
- `notes` is optional and capped at 500 characters
- empty optional strings are normalized to `null`

## Verification
- `./node_modules/.bin/eslint "app/api/routes-d/contacts/route.ts" "app/api/routes-d/contacts/[id]/route.ts"`
- `npm run lint`

## Important note
- This PR intentionally stays within the route files requested by the issues.
- The repo still needs the pending Contact schema/model work from `#299` for the handlers to be runnable end-to-end against Prisma at runtime.