### PR TITLE
feat: add profile, notifications, and earnings API routes

### DIFF
--- a/app/api/routes-d/analytics/earnings/route.ts
+++ b/app/api/routes-d/analytics/earnings/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+// ── GET /api/routes-d/analytics/earnings — earnings summary ─────────
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    // Date range helpers
+    const now = new Date()
+    const startOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const startOfLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    const endOfLastMonth = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999)
+
+    const baseWhere = {
+      userId: user.id,
+      type: 'payment',
+      status: 'completed',
+    }
+
+    // Total earned (all time)
+    const totalResult = await prisma.transaction.aggregate({
+      where: baseWhere,
+      _sum: { amount: true },
+    })
+
+    // This month
+    const thisMonthResult = await prisma.transaction.aggregate({
+      where: {
+        ...baseWhere,
+        createdAt: { gte: startOfThisMonth },
+      },
+      _sum: { amount: true },
+    })
+
+    // Last month
+    const lastMonthResult = await prisma.transaction.aggregate({
+      where: {
+        ...baseWhere,
+        createdAt: {
+          gte: startOfLastMonth,
+          lte: endOfLastMonth,
+        },
+      },
+      _sum: { amount: true },
+    })
+
+    return NextResponse.json({
+      earnings: {
+        totalEarned: Number(totalResult._sum.amount ?? 0),
+        thisMonth: Number(thisMonthResult._sum.amount ?? 0),
+        lastMonth: Number(lastMonthResult._sum.amount ?? 0),
+        currency: 'USDC',
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Earnings analytics GET error')
+    return NextResponse.json({ error: 'Failed to get earnings' }, { status: 500 })
+  }
+}

--- a/app/api/routes-d/notifications/route.ts
+++ b/app/api/routes-d/notifications/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+// ── GET /api/routes-d/notifications — list notifications for current user ──
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    // Check for ?unread=true filter
+    const { searchParams } = new URL(request.url)
+    const unreadOnly = searchParams.get('unread') === 'true'
+
+    const where: any = { userId: user.id }
+    if (unreadOnly) {
+      where.isRead = false
+    }
+
+    const notifications = await prisma.notification.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        message: true,
+        isRead: true,
+        createdAt: true,
+      },
+    })
+
+    const unreadCount = await prisma.notification.count({
+      where: { userId: user.id, isRead: false },
+    })
+
+    return NextResponse.json({
+      notifications,
+      unreadCount,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Notifications GET error')
+    return NextResponse.json({ error: 'Failed to get notifications' }, { status: 500 })
+  }
+}

--- a/app/api/routes-d/profile/route.ts
+++ b/app/api/routes-d/profile/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+// ── GET /api/routes-d/profile — get current user's profile ──────────
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      include: {
+        wallet: { select: { address: true } },
+        _count: { select: { bankAccounts: true } },
+      },
+    })
+
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    return NextResponse.json({
+      profile: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        timezone: (user as any).timezone ?? null,
+        createdAt: user.createdAt,
+        wallet: user.wallet ?? null,
+        bankAccountCount: user._count.bankAccounts,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Profile GET error')
+    return NextResponse.json({ error: 'Failed to get profile' }, { status: 500 })
+  }
+}
+
+// ── PATCH /api/routes-d/profile — update display name and timezone ───
+
+function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const body = await request.json()
+    const updateData: Record<string, any> = {}
+
+    // Validate and collect name
+    if (body.name !== undefined) {
+      if (typeof body.name !== 'string' || body.name.trim() === '') {
+        return NextResponse.json({ error: 'Name must be a non-empty string' }, { status: 400 })
+      }
+      if (body.name.length > 100) {
+        return NextResponse.json({ error: 'Name must be 100 characters or fewer' }, { status: 400 })
+      }
+      updateData.name = body.name.trim()
+    }
+
+    // Validate and collect timezone
+    if (body.timezone !== undefined) {
+      if (typeof body.timezone !== 'string' || !isValidTimezone(body.timezone)) {
+        return NextResponse.json(
+          { error: 'Invalid timezone. Must be a valid IANA timezone (e.g. "Africa/Lagos", "UTC")' },
+          { status: 400 }
+        )
+      }
+      updateData.timezone = body.timezone
+    }
+
+    const updated = await prisma.user.update({
+      where: { id: user.id },
+      data: updateData,
+    })
+
+    return NextResponse.json({
+      id: updated.id,
+      name: updated.name,
+      timezone: (updated as any).timezone ?? null,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Profile PATCH error')
+    return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 })
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,9 @@ model User {
   twoFactorEnabled Boolean  @default(false)
   twoFactorSecret  String?
   taxPercentage    Float    @default(0)
+  timezone         String?
 
+  notifications          Notification[]
   virtualAccount         VirtualAccount?
   wallet                 Wallet?
   bankAccounts           BankAccount[]
@@ -798,4 +800,19 @@ model PaymentMethod {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+model Notification {
+  id        String   @id @default(uuid())
+  userId    String
+  type      String   // e.g. "invoice_paid", "withdrawal_complete", "system"
+  title     String
+  message   String
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isRead])
+  @@index([createdAt])
 }


### PR DESCRIPTION
## Summary

- Implemented GET and PATCH handlers for user profile at `/api/routes-d/profile` with wallet info, bank account count, and timezone/name update support
- Implemented GET handler for notifications at `/api/routes-d/notifications` with unread filtering and unread count
- Implemented GET handler for earnings analytics at `/api/routes-d/analytics/earnings` with total, this-month, and last-month aggregations from completed payment transactions
- Added `timezone` field to User model and `Notification` model with indexes to Prisma schema

## Files changed
- `app/api/routes-d/profile/route.ts` (new) - GET and PATCH profile handlers
- `app/api/routes-d/notifications/route.ts` (new) - GET notifications handler
- `app/api/routes-d/analytics/earnings/route.ts` (new) - GET earnings summary handler
- `prisma/schema.prisma` (modified) - Added `timezone` to User, added Notification model with relation

## Schema changes

Run after merging:
```bash
npx prisma migrate dev --name add-user-timezone-and-notifications
```

## Test plan

- [ ] GET `/api/routes-d/profile` returns 200 with profile object (no privyId)
- [ ] GET `/api/routes-d/profile` returns wallet as null when user has no wallet
- [ ] GET `/api/routes-d/profile` returns 401 for unauthenticated requests
- [ ] PATCH `/api/routes-d/profile` updates name and timezone
- [ ] PATCH `/api/routes-d/profile` rejects invalid timezone with 400
- [ ] PATCH `/api/routes-d/profile` rejects name > 100 chars with 400
- [ ] PATCH `/api/routes-d/profile` with empty body returns 200 unchanged
- [ ] GET `/api/routes-d/notifications` returns notifications array + unreadCount
- [ ] GET `/api/routes-d/notifications?unread=true` filters to unread only
- [ ] GET `/api/routes-d/notifications` returns empty array when no notifications
- [ ] GET `/api/routes-d/analytics/earnings` returns correct totalEarned, thisMonth, lastMonth
- [ ] Earnings values are numbers (not strings or null), 0 when no transactions
- [ ] All routes return 401 for missing/invalid auth tokens

Closes #290
Closes #293
Closes #294
Closes #296