### PR TITLE
fix: implement avatar update route

### DIFF
--- a/app/api/routes-d/profile/avatar/route.ts
+++ b/app/api/routes-d/profile/avatar/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { verifyAuthToken } from "@/lib/auth";
+
+function isValidHttpsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const authToken = request.headers
+    .get("authorization")
+    ?.replace("Bearer ", "");
+  const claims = await verifyAuthToken(authToken || "");
+  if (!claims) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { avatarUrl } = body;
+
+  if (avatarUrl === undefined) {
+    return NextResponse.json(
+      { error: "avatarUrl is required" },
+      { status: 400 }
+    );
+  }
+
+  if (avatarUrl !== null) {
+    if (typeof avatarUrl !== "string") {
+      return NextResponse.json(
+        { error: "avatarUrl must be a string or null" },
+        { status: 400 }
+      );
+    }
+
+    if (avatarUrl.length > 512) {
+      return NextResponse.json(
+        { error: "avatarUrl must not exceed 512 characters" },
+        { status: 400 }
+      );
+    }
+
+    if (!isValidHttpsUrl(avatarUrl)) {
+      return NextResponse.json(
+        { error: "avatarUrl must be a valid HTTPS URL" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const user = await prisma.user.update({
+    where: { privyId: claims.userId },
+    data: { avatarUrl },
+    select: { avatarUrl: true },
+  });
+
+  return NextResponse.json(user);
+}

--- a/prisma/migrations/20260326000001_add_user_avatar_url/migration.sql
+++ b/prisma/migrations/20260326000001_add_user_avatar_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "avatarUrl" VARCHAR(512);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   role             String   @default("freelancer")
   name             String?
   phone            String?
+  avatarUrl        String?  @db.VarChar(512)
   referralCode     String?  @unique
   referredById     String?
   createdAt        DateTime @default(now())


### PR DESCRIPTION
## Summary

Implement \PATCH /api/routes-d/profile/avatar\ route for updating user avatar URL.

## Changes

- **Schema:** Added \vatarUrl\ field (VARCHAR 512) to User model with migration
- **New route:** \pp/api/routes-d/profile/avatar/route.ts\

## Behavior

- Accepts \{ avatarUrl: string | null }\
- Validates HTTPS-only URLs, rejects http://
- Max length: 512 characters
- \
ull\ clears the avatar
- 400 on invalid input
- 401 if unauthenticated

## Validation

- Lint: 0 errors
- Build: passes

Closes #295