### PR TITLE
feat: implement get transaction by id route

### DIFF
--- a/app/api/routes-d/transactions/[id]/route.ts
+++ b/app/api/routes-d/transactions/[id]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { verifyAuthToken } from "@/lib/auth";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const authToken = request.headers
+    .get("authorization")
+    ?.replace("Bearer ", "");
+  const claims = await verifyAuthToken(authToken || "");
+  if (!claims) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+  });
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const transaction = await prisma.transaction.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      type: true,
+      status: true,
+      amount: true,
+      currency: true,
+      txHash: true,
+      invoiceId: true,
+      userId: true,
+      createdAt: true,
+      completedAt: true,
+    },
+  });
+
+  if (!transaction) {
+    return NextResponse.json(
+      { error: "Transaction not found" },
+      { status: 404 }
+    );
+  }
+
+  if (transaction.userId !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    transaction: {
+      id: transaction.id,
+      type: transaction.type,
+      status: transaction.status,
+      amount: Number(transaction.amount),
+      currency: transaction.currency,
+      stellarTxHash: transaction.txHash,
+      invoiceId: transaction.invoiceId,
+      createdAt: transaction.createdAt,
+      updatedAt: transaction.completedAt,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Implement \GET /api/routes-d/transactions/[id]\ route with auth and ownership enforcement.

## Changes

- **New route:** \pp/api/routes-d/transactions/[id]/route.ts\

## Behavior

- Returns full transaction object with \mount\ as number (not Decimal string)
- Maps \	xHash\ to \stellarTxHash\ in response
- 401 if unauthenticated
- 403 if transaction belongs to another user
- 404 if transaction not found

## Validation

- Lint: 0 errors
- Build: passes

Closes #306