### PR TITLE
feat: implement GET /api/routes-d/audit-log/[id] to get single audit …

### DIFF
--- a/app/api/routes-d/audit-log/[id]/route.ts
+++ b/app/api/routes-d/audit-log/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+    })
+
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const event = await prisma.auditEvent.findUnique({
+      where: { id: params.id },
+    })
+
+    if (!event) return NextResponse.json({ error: 'Audit event not found' }, { status: 404 })
+
+    if (event.actorId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+    const metadata = event.metadata as any
+
+    return NextResponse.json({
+      event: {
+        id: event.id,
+        action: event.eventType,
+        resourceType: 'invoice',
+        resourceId: event.invoiceId,
+        metadata: event.metadata,
+        ipAddress: metadata?.ip || '',
+        userAgent: metadata?.userAgent || '',
+        createdAt: event.createdAt,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Audit log GET error')
+    return NextResponse.json({ error: 'Failed to get audit event' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Description

Implemented the GET handler for `/api/routes-d/audit-log/[id]` to retrieve a single audit event by ID, as specified in the requirements.

### Changes Made

- Created the route file `app/api/routes-d/audit-log/[id]/route.ts`
- Implemented authentication verification using Bearer token and `verifyAuthToken`
- Added database query to find `AuditEvent` by ID using Prisma
- Added ownership check: returns 403 if `event.actorId !== user.id`
- Added proper error handling:
  - 401 for missing or invalid auth token
  - 404 for non-existent event ID
  - 403 for unauthorized access to other users' events
- Returns 200 with the event object in the required JSON format, mapping schema fields appropriately

### Acceptance Criteria Met

- ✅ Returns `200` with the full event object
- ✅ Returns `403` (not `404`) if event belongs to a different user
- ✅ Returns `404` if event ID does not exist
- ✅ Returns `401` for unauthenticated requests

Closes #338