### PR TITLE
feat: implement GET /api/routes-d/wallet to return user wallet info

### DIFF
--- a/app/api/routes-d/wallet/route.ts
+++ b/app/api/routes-d/wallet/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 401 })
+
+    const wallet = await prisma.wallet.findUnique({ where: { userId: user.id } })
+    if (!wallet) {
+      return NextResponse.json({ wallet: null }, { status: 200 })
+    }
+
+    return NextResponse.json({
+      wallet: {
+        id: wallet.id,
+        stellarAddress: wallet.address,
+        network: 'testnet',
+        createdAt: wallet.createdAt,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Wallet GET error')
+    return NextResponse.json({ error: 'Failed to get wallet' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Description

Implemented `GET /api/routes-d/wallet` to return the authenticated user's Stellar wallet details.

### Changes Made

- Created route file `app/api/routes-d/wallet/route.ts`
- Auth verification using standard Bearer token and `verifyAuthToken`
- User lookup by `privyId` from auth claims
- Wallet lookup by `userId` in Prisma
- If no wallet exists, return `{ wallet: null }` with HTTP 200
- If wallet exists, return:
  - `id`
  - `stellarAddress` (public address only, from `wallet.address`)
  - `network` set to `'testnet'`
  - `createdAt`
- Security: no private key or seed phrase returned (wallet model does not include them)

### Acceptance Criteria Met

- ✅ `200` returned with wallet object
- ✅ `200` returned with `{ "wallet": null }` when wallet absent
- ✅ Response does not include private keys or seed phrase
- ✅ `401` returned for unauthenticated requests

Closes #336