### PR TITLE
Add routes-d contact, transaction, and bank account APIs

### DIFF
--- a/app/api/routes-d/bank-accounts/route.ts
+++ b/app/api/routes-d/bank-accounts/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+async function getAuthenticatedUserId(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+
+  if (!claims) {
+    return null
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+
+  return user?.id ?? null
+}
+
+function maskAccountNumber(accountNumber: string) {
+  if (accountNumber.length <= 4) {
+    return accountNumber
+  }
+
+  return `${'*'.repeat(Math.max(0, accountNumber.length - 4))}${accountNumber.slice(-4)}`
+}
+
+export async function GET(request: NextRequest) {
+  const userId = await getAuthenticatedUserId(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const bankAccounts = await prisma.bankAccount.findMany({
+    where: { userId },
+    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+    select: {
+      id: true,
+      bankName: true,
+      bankCode: true,
+      accountNumber: true,
+      accountName: true,
+      isDefault: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({
+    bankAccounts: bankAccounts.map((bankAccount: (typeof bankAccounts)[number]) => ({
+      ...bankAccount,
+      accountNumber: maskAccountNumber(bankAccount.accountNumber),
+    })),
+  })
+}

--- a/app/api/routes-d/contacts/[id]/route.ts
+++ b/app/api/routes-d/contacts/[id]/route.ts
@@ -4,6 +4,8 @@ import { verifyAuthToken } from '@/lib/auth'
 
 type ContactDelegate = {
   findUnique: (args: Record<string, unknown>) => Promise<Record<string, unknown> | null>
+  findFirst: (args: Record<string, unknown>) => Promise<Record<string, unknown> | null>
+  update: (args: Record<string, unknown>) => Promise<Record<string, unknown>>
 }
 
 function getContactDelegate(): ContactDelegate {
@@ -65,6 +67,156 @@ export async function GET(
       notes: contact.notes ?? null,
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
+    },
+  })
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function normalizeOptionalString(value: unknown, maxLength: number): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return undefined
+  if (trimmed.length > maxLength) return undefined
+
+  return trimmed
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const contactDelegate = getContactDelegate()
+  const existingContact = await contactDelegate.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      userId: true,
+      name: true,
+      email: true,
+      company: true,
+      notes: true,
+      updatedAt: true,
+    },
+  })
+
+  if (!existingContact) {
+    return NextResponse.json({ error: 'Contact not found' }, { status: 404 })
+  }
+
+  if (existingContact.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data: Record<string, unknown> = {}
+
+  if (Object.prototype.hasOwnProperty.call(body, 'name')) {
+    const name = normalizeOptionalString(body?.name, 100)
+    if (!name) {
+      return NextResponse.json(
+        { error: 'Name must be a non-empty string with at most 100 characters' },
+        { status: 400 },
+      )
+    }
+    data.name = name
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'email')) {
+    if (typeof body?.email !== 'string') {
+      return NextResponse.json({ error: 'Email must be a valid email address' }, { status: 400 })
+    }
+
+    const email = body.email.trim().toLowerCase()
+    if (!EMAIL_REGEX.test(email)) {
+      return NextResponse.json({ error: 'Email must be a valid email address' }, { status: 400 })
+    }
+
+    if (email !== existingContact.email) {
+      const duplicateContact = await contactDelegate.findFirst({
+        where: {
+          userId: user.id,
+          email,
+          id: { not: existingContact.id },
+        },
+        select: { id: true },
+      })
+
+      if (duplicateContact) {
+        return NextResponse.json(
+          { error: 'A contact with this email already exists' },
+          { status: 409 },
+        )
+      }
+    }
+
+    data.email = email
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'company')) {
+    const company = normalizeOptionalString(body?.company, 100)
+    if (company === undefined && body?.company !== null) {
+      return NextResponse.json(
+        { error: 'Company must be at most 100 characters' },
+        { status: 400 },
+      )
+    }
+    data.company = company ?? null
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'notes')) {
+    const notes = normalizeOptionalString(body?.notes, 500)
+    if (notes === undefined && body?.notes !== null) {
+      return NextResponse.json(
+        { error: 'Notes must be at most 500 characters' },
+        { status: 400 },
+      )
+    }
+    data.notes = notes ?? null
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({
+      contact: {
+        id: existingContact.id,
+        name: existingContact.name,
+        email: existingContact.email,
+        company: existingContact.company ?? null,
+        notes: existingContact.notes ?? null,
+        updatedAt: existingContact.updatedAt,
+      },
+    })
+  }
+
+  const updatedContact = await contactDelegate.update({
+    where: { id: existingContact.id },
+    data,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      company: true,
+      notes: true,
+      updatedAt: true,
+    },
+  })
+
+  return NextResponse.json({
+    contact: {
+      id: updatedContact.id,
+      name: updatedContact.name,
+      email: updatedContact.email,
+      company: updatedContact.company ?? null,
+      notes: updatedContact.notes ?? null,
+      updatedAt: updatedContact.updatedAt,
     },
   })
 }

--- a/app/api/routes-d/transactions/route.ts
+++ b/app/api/routes-d/transactions/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const ALLOWED_TYPES = new Set(['payment', 'withdrawal'])
+const ALLOWED_STATUSES = new Set(['pending', 'completed', 'failed'])
+
+async function getAuthenticatedUserId(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+
+  if (!claims) {
+    return null
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+
+  return user?.id ?? null
+}
+
+export async function GET(request: NextRequest) {
+  const userId = await getAuthenticatedUserId(request)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const page = Math.max(1, parseInt(url.searchParams.get('page') || '1', 10) || 1)
+  const limit = Math.min(100, Math.max(1, parseInt(url.searchParams.get('limit') || '20', 10) || 20))
+  const skip = (page - 1) * limit
+  const type = url.searchParams.get('type')
+  const status = url.searchParams.get('status')
+
+  if (type && !ALLOWED_TYPES.has(type)) {
+    return NextResponse.json(
+      { error: 'Invalid type. Allowed values are payment or withdrawal' },
+      { status: 400 },
+    )
+  }
+
+  if (status && !ALLOWED_STATUSES.has(status)) {
+    return NextResponse.json(
+      { error: 'Invalid status. Allowed values are pending, completed, or failed' },
+      { status: 400 },
+    )
+  }
+
+  const where = {
+    userId,
+    ...(type ? { type } : {}),
+    ...(status ? { status } : {}),
+  }
+
+  const [transactions, total] = await Promise.all([
+    prisma.transaction.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: limit,
+      include: {
+        invoice: {
+          select: {
+            invoiceNumber: true,
+          },
+        },
+      },
+    }),
+    prisma.transaction.count({ where }),
+  ])
+
+  return NextResponse.json({
+    transactions: transactions.map((transaction: (typeof transactions)[number]) => ({
+      id: transaction.id,
+      type: transaction.type,
+      status: transaction.status,
+      amount: Number(transaction.amount),
+      currency: transaction.currency,
+      description: transaction.invoice?.invoiceNumber
+        ? `Invoice ${transaction.invoice.invoiceNumber} paid`
+        : transaction.type === 'withdrawal'
+          ? 'Withdrawal initiated'
+          : null,
+      createdAt: transaction.createdAt,
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  })
+}

--- a/prisma/migrations/20260327093000_add_contact_model/migration.sql
+++ b/prisma/migrations/20260327093000_add_contact_model/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Contact" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "company" TEXT,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Contact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Contact_userId_email_key" ON "Contact"("userId", "email");
+
+-- AddForeignKey
+ALTER TABLE "Contact" ADD CONSTRAINT "Contact_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   virtualAccount         VirtualAccount?
   wallet                 Wallet?
   bankAccounts           BankAccount[]
+  contacts               Contact[]
   invoices               Invoice[]
   clientInvoices         Invoice[]             @relation("ClientInvoices")
   paymentMethods         PaymentMethod[]
@@ -97,6 +98,21 @@ model BankAccount {
   user          User           @relation(fields: [userId], references: [id])
   withdrawals   Transaction[]  @relation("WithdrawalBank")
   autoSwapRules AutoSwapRule[]
+}
+
+model Contact {
+  id        String   @id @default(uuid())
+  userId    String
+  name      String
+  email     String
+  company   String?
+  notes     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, email])
 }
 
 model VirtualAccount {


### PR DESCRIPTION
## Summary
This PR resolves four assigned outes-d issues in one branch by adding the missing contact schema support and implementing the requested API handlers for contact updates, paginated transaction listing, and bank account listing.

## Issues linked
Closes #299
Closes #303
Closes #305
Closes #308

## What changed
- Added the Contact Prisma model with:
  - id, userId, 
ame, email, company, 
otes, createdAt, updatedAt
  - @@unique([userId, email]) to prevent duplicate contact emails per user
  - contacts Contact[] relation on User
- Added a Prisma migration for the Contact model.
- Extended PATCH /api/routes-d/contacts/[id] to support partial updates.
- Added GET /api/routes-d/transactions with pagination and optional 	ype / status filters.
- Added GET /api/routes-d/bank-accounts ordered with the default account first and masked account numbers in the response.

## Endpoint behavior
### PATCH /api/routes-d/contacts/[id]
- Verifies auth.
- Verifies ownership of the contact.
- Accepts partial updates for 
ame, email, company, and 
otes.
- Leaves unspecified fields unchanged.
- Returns 409 if the new email already exists for another contact owned by the same user.
- Returns 200 with unchanged contact for an empty body.

### GET /api/routes-d/transactions
- Verifies auth.
- Supports query params:
  - page default 1
  - limit default 20, max 100
  - 	ype in payment | withdrawal
  - status in pending | completed | failed
- Returns 	ransactions plus a pagination object.
- Converts Prisma decimal amounts to numbers in the response.

### GET /api/routes-d/bank-accounts
- Verifies auth.
- Returns all bank accounts for the authenticated user.
- Orders by isDefault desc, createdAt asc.
- Returns an empty array if the user has no bank accounts.
- Masks ccountNumber in the API response.

## Files changed
- prisma/schema.prisma
- prisma/migrations/20260327093000_add_contact_model/migration.sql
- pp/api/routes-d/contacts/[id]/route.ts
- pp/api/routes-d/transactions/route.ts
- pp/api/routes-d/bank-accounts/route.ts

## Validation
### Completed
- Confirmed all requested handlers/files are present and wired only within the allowed route files plus the required Prisma schema/migration changes.

### Environment limitations / existing repo issues
- 
px tsc --noEmit does not pass on the current codebase due to unrelated pre-existing issues, including missing packages such as swagger-ui-react, @ai-sdk/openai, and i, plus unrelated type errors in other route files.
- 
px prisma validate could not complete in this environment because Prisma attempted to download engine binaries and network access to Prisma's binary host failed.

## Scope notes
This PR stays within the requested scope for the four issues:
- schema + migration for contacts
- PATCH handler for a single contact
- GET transactions route
- GET bank accounts route

No pages, components, or unrelated existing routes were modified.