### PR TITLE
feat: Add routes-b API endpoints for bank accounts, profile, and exchange rate

### DIFF
--- a/app/api/routes-b/bank-accounts/[id]/route.ts
+++ b/app/api/routes-b/bank-accounts/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+// DELETE /api/routes-b/bank-accounts/[id] — remove a bank account
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { id } = params
+
+    const account = await prisma.bankAccount.findUnique({
+      where: { id }
+    })
+
+    if (!account) {
+      return NextResponse.json({ error: 'Bank account not found' }, { status: 404 })
+    }
+
+    if (account.userId !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    // If this is the default account and other accounts exist, promote the oldest remaining one
+    if (account.isDefault) {
+      const next = await prisma.bankAccount.findFirst({
+        where: { userId: user.id, id: { not: id } },
+        orderBy: { createdAt: 'asc' },
+      })
+      if (next) {
+        await prisma.bankAccount.update({
+          where: { id: next.id },
+          data: { isDefault: true }
+        })
+      }
+    }
+
+    await prisma.bankAccount.delete({ where: { id } })
+
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    console.error('Error deleting bank account:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/bank-accounts/route.ts
+++ b/app/api/routes-b/bank-accounts/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+// GET /api/routes-b/bank-accounts — list user's saved bank accounts
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const bankAccounts = await prisma.bankAccount.findMany({
+      where: { userId: user.id },
+      orderBy: [
+        { isDefault: 'desc' },
+        { createdAt: 'asc' }
+      ],
+      select: {
+        id: true,
+        bankName: true,
+        bankCode: true,
+        accountNumber: true,
+        accountName: true,
+        isDefault: true,
+        createdAt: true,
+      }
+    })
+
+    return NextResponse.json({ bankAccounts })
+  } catch (error) {
+    console.error('Error fetching bank accounts:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// POST /api/routes-b/bank-accounts — add a new bank account
+export async function POST(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { bankName, bankCode, accountNumber, accountName } = body
+
+    // Validation
+    if (!bankName || typeof bankName !== 'string' || bankName.trim().length === 0 || bankName.length > 100) {
+      return NextResponse.json({ error: 'bankName must be a non-empty string (max 100 chars)' }, { status: 400 })
+    }
+
+    if (!bankCode || typeof bankCode !== 'string' || !/^\d{3,10}$/.test(bankCode)) {
+      return NextResponse.json({ error: 'bankCode must be 3-10 digits' }, { status: 400 })
+    }
+
+    if (!accountNumber || typeof accountNumber !== 'string' || !/^\d{10}$/.test(accountNumber)) {
+      return NextResponse.json({ error: 'accountNumber must be exactly 10 digits (Nigerian NUBAN)' }, { status: 400 })
+    }
+
+    if (!accountName || typeof accountName !== 'string' || accountName.trim().length === 0 || accountName.length > 100) {
+      return NextResponse.json({ error: 'accountName must be a non-empty string (max 100 chars)' }, { status: 400 })
+    }
+
+    // Check for duplicate account
+    const existing = await prisma.bankAccount.findFirst({
+      where: {
+        userId: user.id,
+        accountNumber,
+        bankCode
+      }
+    })
+
+    if (existing) {
+      return NextResponse.json({ error: 'This bank account is already linked' }, { status: 409 })
+    }
+
+    // First account auto-default logic
+    const existingCount = await prisma.bankAccount.count({ where: { userId: user.id } })
+    const isDefault = existingCount === 0
+
+    const bankAccount = await prisma.bankAccount.create({
+      data: {
+        userId: user.id,
+        bankName: bankName.trim(),
+        bankCode,
+        accountNumber,
+        accountName: accountName.trim(),
+        isDefault,
+      },
+      select: {
+        id: true,
+        bankName: true,
+        bankCode: true,
+        accountNumber: true,
+        accountName: true,
+        isDefault: true,
+        createdAt: true,
+      }
+    })
+
+    return NextResponse.json(bankAccount, { status: 201 })
+  } catch (error) {
+    console.error('Error creating bank account:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/exchange-rate/route.ts
+++ b/app/api/routes-b/exchange-rate/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+
+// GET /api/routes-b/exchange-rate — get current USDC to NGN exchange rate
+export async function GET() {
+  try {
+    const res = await fetch('https://open.er-api.com/v6/latest/USD')
+    
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: 'Unable to fetch exchange rate. Please try again.' },
+        { status: 503 }
+      )
+    }
+
+    const data = await res.json()
+    const usdToNgn = data.rates?.NGN
+
+    if (typeof usdToNgn !== 'number' || isNaN(usdToNgn)) {
+      return NextResponse.json(
+        { error: 'Unable to fetch exchange rate. Please try again.' },
+        { status: 503 }
+      )
+    }
+
+    return NextResponse.json({
+      rate: {
+        from: 'USDC',
+        to: 'NGN',
+        value: usdToNgn,
+        source: 'open.er-api.com',
+        fetchedAt: new Date().toISOString(),
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching exchange rate:', error)
+    return NextResponse.json(
+      { error: 'Unable to fetch exchange rate. Please try again.' },
+      { status: 503 }
+    )
+  }
+}

--- a/app/api/routes-b/profile/route.ts
+++ b/app/api/routes-b/profile/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+// GET /api/routes-b/profile — get current user's profile
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      include: {
+        wallet: { select: { stellarAddress: true } },
+        _count: { select: { bankAccounts: true } },
+      },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({
+      profile: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        wallet: user.wallet ? { stellarAddress: user.wallet.stellarAddress } : null,
+        bankAccountCount: user._count.bankAccounts,
+        createdAt: user.createdAt,
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching profile:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// PATCH /api/routes-b/profile — update user's display name
+export async function PATCH(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const body = await request.json()
+    const { displayName } = body
+
+    if (!displayName || typeof displayName !== 'string' || displayName.trim().length === 0) {
+      return NextResponse.json({ error: 'displayName must be a non-empty string' }, { status: 400 })
+    }
+
+    if (displayName.length > 100) {
+      return NextResponse.json({ error: 'displayName must be 100 characters or less' }, { status: 400 })
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: { name: displayName.trim() },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        createdAt: true,
+      }
+    })
+
+    return NextResponse.json({
+      profile: {
+        id: updatedUser.id,
+        email: updatedUser.email,
+        name: updatedUser.name,
+        role: updatedUser.role,
+        createdAt: updatedUser.createdAt,
+      }
+    })
+  } catch (error) {
+    console.error('Error updating profile:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements all routes-b API endpoints for the Stellar Wave bounty.

## Endpoints Added

### Bank Accounts
- **GET /api/routes-b/bank-accounts** - List user's bank accounts
- **POST /api/routes-b/bank-accounts** - Add new bank account
  - Validates bankName (non-empty, max 100 chars)
  - Validates bankCode (3-10 digits)
  - Validates accountNumber (exactly 10 digits - Nigerian NUBAN)
  - First account auto-set as default
- **DELETE /api/routes-b/bank-accounts/[id]** - Remove bank account
  - Promotes next oldest account to default if needed

### Profile
- **GET /api/routes-b/profile** - Get current user profile
  - Returns wallet address and bank account count
  - Does NOT return privyId
- **PATCH /api/routes-b/profile** - Update display name

### Exchange Rate
- **GET /api/routes-b/exchange-rate** - Get USDC to NGN rate
  - Uses open.er-api.com
  - No auth required (public data)

## Acceptance Criteria Met

✅ All routes return correct status codes
✅ Proper authentication validation
✅ Input validation and error handling
✅ Auto-default logic for first bank account
✅ Default account promotion on deletion
✅ Response formats match specifications

## Related Issues

Fixes: #362
Fixes: #363
Fixes: #364
Fixes: #365
Fixes: #366
Fixes: #367