### PR TITLE
Implement GET /api/routes-b/invoices for listing authenticated user's…

### DIFF
--- a/app/api/routes-b/invoices/route.ts
+++ b/app/api/routes-b/invoices/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const { searchParams } = new URL(request.url)
+  const status = searchParams.get('status')
+  const page = parseInt(searchParams.get('page') || '1')
+  const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50)
+
+  const validStatuses = ['pending', 'paid', 'overdue', 'cancelled']
+  if (status && !validStatuses.includes(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
+  }
+
+  const where: any = { userId: user.id }
+  if (status) where.status = status
+
+  const total = await prisma.invoice.count({ where })
+  const invoices = await prisma.invoice.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    skip: (page - 1) * limit,
+    take: limit,
+    select: {
+      id: true,
+      invoiceNumber: true,
+      clientName: true,
+      clientEmail: true,
+      amount: true,
+      currency: true,
+      status: true,
+      dueDate: true,
+      createdAt: true,
+    }
+  })
+
+  const totalPages = Math.ceil(total / limit)
+
+  const response = {
+    invoices: invoices.map(inv => ({
+      ...inv,
+      amount: parseFloat(inv.amount.toString())
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages
+    }
+  }
+
+  return NextResponse.json(response)
+}


### PR DESCRIPTION
## Description
This PR implements the `GET /api/routes-b/invoices` endpoint to list authenticated user's invoices, as specified in issue #358.

### Changes Made
- Created `app/api/routes-b/invoices/route.ts` with the GET handler
- Implemented authentication using the provided auth pattern
- Added query parameter support for `status` (pending, paid, overdue, cancelled), `page`, and `limit`
- Included pagination metadata in the response
- Ensured `amount` is returned as a number, not string
- Handled edge cases: empty array for no invoices, 401 for unauth, 400 for invalid status

### Acceptance Criteria Met
- Returns 200 with invoices + pagination metadata
- `?status=paid` filters correctly; unknown status returns 400
- `amount` is a number
- Returns empty array when user has no invoices
- Returns 401 for unauthenticated requests

### Testing
- Code follows existing patterns from similar routes
- No other files modified outside the specified scope

Closes #358