### PR TITLE
feat: implement GET /api/routes-b/audit-log endpoint (Issue #379)

### DIFF
--- a/app/api/routes-b/audit-log/route.ts
+++ b/app/api/routes-b/audit-log/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    // Verify auth
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(request.url)
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10))
+    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)))
+    const action = searchParams.get('action')
+
+    // Build where clause
+    const where: any = {
+      actorId: user.id,
+    }
+
+    if (action) {
+      where.eventType = action
+    }
+
+    // Get total count
+    const total = await prisma.auditEvent.count({ where })
+
+    // Fetch events, newest first
+    const events = await prisma.auditEvent.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+    })
+
+    // Format response
+    const formattedEvents = events.map((event) => {
+      const metadata = event.metadata as any
+      return {
+        id: event.id,
+        action: event.eventType,
+        resourceType: 'invoice',
+        resourceId: event.invoiceId,
+        ipAddress: metadata?.ip || '',
+        createdAt: event.createdAt,
+      }
+    })
+
+    return NextResponse.json({
+      events: formattedEvents,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Audit log list error')
+    return NextResponse.json({ error: 'Failed to list audit events' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

Implements Issue #379 - GET /api/routes-b/audit-log endpoint

### Features
- Paginated list of user's audit events
- Query parameters: page, limit, action
- Default limit 20, max 50
- Newest events first
- Returns empty array when no events

### Acceptance Criteria
- [x] Returns 200 with events + pagination, newest first
- [x] ?action=invoice_created filters correctly
- [x] Default limit is 20; max 50
- [x] Returns empty array (not 404) when user has no audit events
- [x] Returns 401 for unauthenticated requests

Closes #379