### PR TITLE
feat(routes-d): DELETE webhook endpoint

### DIFF
--- a/app/api/routes-d/webhooks/[id]/route.ts
+++ b/app/api/routes-d/webhooks/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  // 1. Auth
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // 2. Fetch Webhook
+  const webhook = await prisma.userWebhook.findUnique({ where: { id: params.id } })
+  if (!webhook) {
+    return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
+  }
+
+  // 3. Ownership Check
+  if (webhook.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // 4. Delete
+  await prisma.userWebhook.delete({ where: { id: params.id } })
+
+  // 5. Response
+  return new NextResponse(null, { status: 204 })
+}


### PR DESCRIPTION
## Summary
Implement a secure DELETE endpoint at `/api/routes-d/webhooks/[id]` to remove a webhook.

## Changes
- Added `app/api/routes-d/webhooks/[id]/route.ts`

## Endpoint Behavior
- **204** on successful deletion (no content)
- **401** if unauthenticated
- **403** if user is not the webhook owner
- **404** if webhook not found

Closes #343