### PR TITLE
feat: add GET and POST handlers for invoice messages

### DIFF
--- a/app/api/routes-d/invoices/[id]/messages/route.ts
+++ b/app/api/routes-d/invoices/[id]/messages/route.ts
@@ -19,15 +19,16 @@ async function getAuthenticatedUser(request: NextRequest) {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   const user = await getAuthenticatedUser(request)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const invoice = await prisma.invoice.findUnique({
-    where: { id: params.id },
+    where: { id },
     select: { id: true, userId: true },
   })
 
@@ -40,7 +41,7 @@ export async function GET(
   }
 
   const messages = await prisma.invoiceMessage.findMany({
-    where: { invoiceId: params.id },
+    where: { invoiceId: id },
     select: {
       id: true,
       invoiceId: true,
@@ -59,15 +60,16 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   const user = await getAuthenticatedUser(request)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const invoice = await prisma.invoice.findUnique({
-    where: { id: params.id },
+    where: { id },
     select: { id: true, userId: true },
   })
 


### PR DESCRIPTION
## Summary

- `GET /api/routes-d/invoices/[id]/messages` — returns all messages for an invoice ordered by `createdAt asc`
- `POST /api/routes-d/invoices/[id]/messages` — creates a new message with `senderType: 'freelancer'` and `senderName: user.name ?? user.email`

Both handlers share auth + ownership validation (401 / 403 / 404).

## Changes

- ✅ `GET` handler — list invoice messages
- ✅ `POST` handler — add message to invoice
- ✅ Auth validation (401)
- ✅ Invoice ownership check (403)
- ✅ Invoice not found (404)
- ✅ `content` required, non-empty, max 1000 chars (400)
- ✅ Returns `201` with created message

## Acceptance criteria

- [x] Returns `201` with the created message
- [x] `content` longer than 1000 chars returns `400`
- [x] Missing `content` returns `400`
- [x] Returns `403` if invoice belongs to a different user
- [x] Returns `404` if invoice does not exist
- [x] Returns `401` for unauthenticated requests

## Closes #333 