### PR TITLE
feat: add routes-b earnings, search, and invoice summary endpoints

### DIFF
--- a/app/api/routes-b/analytics/earnings/route.ts
+++ b/app/api/routes-b/analytics/earnings/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const now = new Date()
+    const startOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const startOfLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    const endOfLastMonth = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999)
+
+    const [total, thisMonth, lastMonth] = await Promise.all([
+      prisma.transaction.aggregate({
+        where: { userId: user.id, type: 'payment', status: 'completed' },
+        _sum: { amount: true },
+      }),
+      prisma.transaction.aggregate({
+        where: {
+          userId: user.id,
+          type: 'payment',
+          status: 'completed',
+          createdAt: { gte: startOfThisMonth },
+        },
+        _sum: { amount: true },
+      }),
+      prisma.transaction.aggregate({
+        where: {
+          userId: user.id,
+          type: 'payment',
+          status: 'completed',
+          createdAt: { gte: startOfLastMonth, lte: endOfLastMonth },
+        },
+        _sum: { amount: true },
+      }),
+    ])
+
+    return NextResponse.json({
+      earnings: {
+        totalEarned: Number(total._sum.amount ?? 0),
+        thisMonth: Number(thisMonth._sum.amount ?? 0),
+        lastMonth: Number(lastMonth._sum.amount ?? 0),
+        currency: 'USDC',
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B earnings GET error')
+    return NextResponse.json({ error: 'Failed to get earnings' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/invoices/summary/route.ts
+++ b/app/api/routes-b/invoices/summary/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const parsedMonths = parseInt(url.searchParams.get('months') || '6', 10)
+    const months = Math.min(12, Math.max(1, Number.isNaN(parsedMonths) ? 6 : parsedMonths))
+
+    const summary = []
+
+    for (let i = months - 1; i >= 0; i--) {
+      const date = new Date()
+      const start = new Date(date.getFullYear(), date.getMonth() - i, 1)
+      const end = new Date(date.getFullYear(), date.getMonth() - i + 1, 0, 23, 59, 59, 999)
+
+      const agg = await prisma.invoice.aggregate({
+        where: {
+          userId: user.id,
+          status: 'paid',
+          paidAt: { gte: start, lte: end },
+        },
+        _count: { id: true },
+        _sum: { amount: true },
+      })
+
+      summary.push({
+        month: start.toISOString().slice(0, 7),
+        invoicesPaid: agg._count.id,
+        earned: Number(agg._sum.amount ?? 0),
+      })
+    }
+
+    return NextResponse.json({ summary })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B invoice summary GET error')
+    return NextResponse.json({ error: 'Failed to get invoice summary' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/search/route.ts
+++ b/app/api/routes-b/search/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const q = url.searchParams.get('q')?.trim() ?? ''
+    const type = url.searchParams.get('type')
+
+    if (q.length < 2) {
+      return NextResponse.json(
+        { error: 'Query parameter "q" is required and must be at least 2 characters' },
+        { status: 400 }
+      )
+    }
+
+    const isInvoicesOnly = type === 'invoices'
+    const isBankAccountsOnly = type === 'bank-accounts'
+    const isBoth = !type
+
+    if (!isBoth && !isInvoicesOnly && !isBankAccountsOnly) {
+      return NextResponse.json(
+        { error: 'Invalid "type". Expected "invoices" or "bank-accounts"' },
+        { status: 400 }
+      )
+    }
+
+    const [invoices, bankAccounts] = await Promise.all([
+      isBankAccountsOnly
+        ? Promise.resolve([])
+        : prisma.invoice.findMany({
+            where: {
+              userId: user.id,
+              OR: [
+                { invoiceNumber: { contains: q, mode: 'insensitive' } },
+                { clientName: { contains: q, mode: 'insensitive' } },
+                { clientEmail: { contains: q, mode: 'insensitive' } },
+                { description: { contains: q, mode: 'insensitive' } },
+              ],
+            },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+            select: {
+              id: true,
+              invoiceNumber: true,
+              clientName: true,
+              amount: true,
+              status: true,
+            },
+          }),
+      isInvoicesOnly
+        ? Promise.resolve([])
+        : prisma.bankAccount.findMany({
+            where: {
+              userId: user.id,
+              OR: [
+                { bankName: { contains: q, mode: 'insensitive' } },
+                { accountName: { contains: q, mode: 'insensitive' } },
+                { accountNumber: { contains: q } },
+              ],
+            },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+          }),
+    ])
+
+    return NextResponse.json({
+      query: q,
+      results: {
+        invoices,
+        bankAccounts,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B search GET error')
+    return NextResponse.json({ error: 'Failed to search records' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add GET /api/routes-b/analytics/earnings to return total, this month, and last month payment aggregates for authenticated users
- add GET /api/routes-b/search with q/type validation and parallel invoice + bank account search results
- add GET /api/routes-b/invoices/summary to return month-by-month paid invoice counts and earnings with months clamped to 12

Closes #368
Closes #374
Closes #380