### PR TITLE
feat(routes-b): add bank account, profile, and pending invoice update endpoints

### DIFF
--- a/app/api/routes-b/bank-accounts/[id]/route.ts
+++ b/app/api/routes-b/bank-accounts/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const account = await prisma.bankAccount.findUnique({ where: { id } })
+  if (!account) {
+    return NextResponse.json({ error: 'Bank account not found' }, { status: 404 })
+  }
+
+  if (account.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (account.isDefault) {
+    const next = await prisma.bankAccount.findFirst({
+      where: { userId: user.id, id: { not: id } },
+      orderBy: { createdAt: 'asc' },
+    })
+
+    if (next) {
+      await prisma.bankAccount.update({
+        where: { id: next.id },
+        data: { isDefault: true },
+      })
+    }
+  }
+
+  await prisma.bankAccount.delete({ where: { id } })
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/routes-b/bank-accounts/route.ts
+++ b/app/api/routes-b/bank-accounts/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+function isValidDigits(value: string, min: number, max: number) {
+  const pattern = new RegExp(`^\\d{${min},${max}}$`)
+  return pattern.test(value)
+}
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const bankAccounts = await prisma.bankAccount.findMany({
+    where: { userId: user.id },
+    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+    select: {
+      id: true,
+      bankName: true,
+      bankCode: true,
+      accountNumber: true,
+      accountName: true,
+      isDefault: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({ bankAccounts })
+}
+
+export async function POST(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const body = await request.json()
+  const { bankName, bankCode, accountNumber, accountName } = body ?? {}
+
+  if (
+    typeof bankName !== 'string' ||
+    bankName.trim() === '' ||
+    bankName.trim().length > 100 ||
+    typeof bankCode !== 'string' ||
+    !isValidDigits(bankCode, 3, 10) ||
+    typeof accountNumber !== 'string' ||
+    !/^\d{10}$/.test(accountNumber) ||
+    typeof accountName !== 'string' ||
+    accountName.trim() === '' ||
+    accountName.trim().length > 100
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'Invalid input. bankName/accountName must be non-empty <= 100 chars, bankCode must be 3-10 digits, and accountNumber must be exactly 10 digits.',
+      },
+      { status: 400 },
+    )
+  }
+
+  const existingCount = await prisma.bankAccount.count({ where: { userId: user.id } })
+  const isDefault = existingCount === 0
+
+  const bankAccount = await prisma.bankAccount.create({
+    data: {
+      userId: user.id,
+      bankName: bankName.trim(),
+      bankCode,
+      accountNumber,
+      accountName: accountName.trim(),
+      isDefault,
+    },
+    select: {
+      id: true,
+      bankName: true,
+      bankCode: true,
+      accountNumber: true,
+      accountName: true,
+      isDefault: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json(bankAccount, { status: 201 })
+}

--- a/app/api/routes-b/invoices/[id]/route.ts
+++ b/app/api/routes-b/invoices/[id]/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+function isValidIsoDate(value: string) {
+  const date = new Date(value)
+  return !Number.isNaN(date.getTime())
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findFirst({
+    where: { id, userId: user.id },
+    select: {
+      id: true,
+      invoiceNumber: true,
+      clientEmail: true,
+      clientName: true,
+      description: true,
+      amount: true,
+      currency: true,
+      status: true,
+      paymentLink: true,
+      dueDate: true,
+      paidAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ ...invoice, amount: Number(invoice.amount) })
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const requester = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!requester) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const ownedInvoice = await prisma.invoice.findFirst({
+    where: { id, userId: requester.id },
+    select: { id: true, status: true },
+  })
+
+  if (!ownedInvoice) {
+    const existingInvoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: { id: true },
+    })
+
+    if (existingInvoice) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (ownedInvoice.status !== 'pending') {
+    return NextResponse.json({ error: 'Only pending invoices can be edited' }, { status: 422 })
+  }
+
+  const body = await request.json()
+
+  const updateData: {
+    description?: string
+    amount?: number
+    dueDate?: Date | null
+    clientName?: string
+  } = {}
+
+  if (body.description !== undefined) {
+    if (typeof body.description !== 'string' || body.description.trim() === '') {
+      return NextResponse.json({ error: 'description must be a non-empty string' }, { status: 400 })
+    }
+    if (body.description.length > 500) {
+      return NextResponse.json({ error: 'description must be 500 characters or fewer' }, { status: 400 })
+    }
+    updateData.description = body.description.trim()
+  }
+
+  if (body.amount !== undefined) {
+    if (typeof body.amount !== 'number' || Number.isNaN(body.amount) || body.amount <= 0) {
+      return NextResponse.json({ error: 'amount must be a positive number' }, { status: 400 })
+    }
+    updateData.amount = body.amount
+  }
+
+  if (body.dueDate !== undefined) {
+    if (body.dueDate === null) {
+      updateData.dueDate = null
+    } else if (typeof body.dueDate === 'string' && isValidIsoDate(body.dueDate)) {
+      updateData.dueDate = new Date(body.dueDate)
+    } else {
+      return NextResponse.json(
+        { error: 'dueDate must be a valid ISO date string or null' },
+        { status: 400 },
+      )
+    }
+  }
+
+  if (body.clientName !== undefined) {
+    if (typeof body.clientName !== 'string') {
+      return NextResponse.json({ error: 'clientName must be a string' }, { status: 400 })
+    }
+    if (body.clientName.length > 100) {
+      return NextResponse.json({ error: 'clientName must be 100 characters or fewer' }, { status: 400 })
+    }
+    updateData.clientName = body.clientName
+  }
+
+  const updatedInvoice = await prisma.invoice.update({
+    where: { id: ownedInvoice.id },
+    data: updateData,
+    select: {
+      id: true,
+      invoiceNumber: true,
+      description: true,
+      amount: true,
+      status: true,
+      updatedAt: true,
+      dueDate: true,
+      clientName: true,
+      clientEmail: true,
+      currency: true,
+      paymentLink: true,
+      paidAt: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({ ...updatedInvoice, amount: Number(updatedInvoice.amount) })
+}

--- a/app/api/routes-b/profile/route.ts
+++ b/app/api/routes-b/profile/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    include: {
+      wallet: { select: { address: true } },
+      _count: { select: { bankAccounts: true } },
+    },
+  })
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    profile: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      wallet: user.wallet ? { stellarAddress: user.wallet.address } : null,
+      bankAccountCount: user._count.bankAccounts,
+      createdAt: user.createdAt,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add `POST /api/routes-b/bank-accounts` with full input validation and first-account auto-default behavior
- add `DELETE /api/routes-b/bank-accounts/[id]` with ownership checks and default-account promotion on deletion
- add `GET /api/routes-b/profile` and `PATCH /api/routes-b/invoices/[id]` for authenticated profile retrieval and pending-invoice field updates

Closes #401
Closes #363
Closes #364
Closes #365