### PR TITLE
feat: implement routes-b analytics, dashboard, audit log, and invoice messages

### DIFF
--- a/app/api/routes-b/analytics/invoices/route.ts
+++ b/app/api/routes-b/analytics/invoices/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
+type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const [grouped, totals] = await Promise.all([
+    prisma.invoice.groupBy({
+      by: ['status'],
+      where: { userId: user.id },
+      _count: { id: true },
+    }),
+    prisma.invoice.aggregate({
+      where: { userId: user.id },
+      _count: { id: true },
+      _sum: { amount: true },
+    }),
+  ])
+
+  const counts = INVOICE_STATUSES.reduce<Record<InvoiceStatus, number>>(
+    (acc, status) => {
+      acc[status] = 0
+      return acc
+    },
+    {} as Record<InvoiceStatus, number>,
+  )
+
+  for (const row of grouped) {
+    if (INVOICE_STATUSES.includes(row.status as InvoiceStatus)) {
+      counts[row.status as InvoiceStatus] = row._count.id
+    }
+  }
+
+  const total = counts.pending + counts.paid + counts.overdue + counts.cancelled
+
+  return NextResponse.json({
+    invoices: {
+      total,
+      pending: counts.pending,
+      paid: counts.paid,
+      overdue: counts.overdue,
+      cancelled: counts.cancelled,
+      totalInvoiced: Number(totals._sum.amount ?? 0),
+    },
+  })
+}

--- a/app/api/routes-b/audit-log/route.ts
+++ b/app/api/routes-b/audit-log/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const { searchParams } = new URL(request.url)
+
+  const parsedPage = parseInt(searchParams.get('page') || '1', 10)
+  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage
+
+  const parsedLimit = parseInt(searchParams.get('limit') || '20', 10)
+  const limit = Math.min(50, Math.max(1, Number.isNaN(parsedLimit) ? 20 : parsedLimit))
+
+  const action = searchParams.get('action')
+
+  const where = {
+    actorId: user.id,
+    ...(action ? { eventType: action } : {}),
+  }
+
+  const [total, events] = await Promise.all([
+    prisma.auditEvent.count({ where }),
+    prisma.auditEvent.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+  ])
+
+  const totalPages = Math.ceil(total / limit)
+
+  return NextResponse.json({
+    events: events.map(event => ({
+      id: event.id,
+      action: event.eventType,
+      resourceType: 'invoice',
+      resourceId: event.invoiceId,
+      ipAddress: null,
+      createdAt: event.createdAt,
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages,
+    },
+  })
+}

--- a/app/api/routes-b/dashboard/route.ts
+++ b/app/api/routes-b/dashboard/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
+type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const now = new Date()
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+
+  const [invoiceStats, totalEarned, thisMonthEarned, recentTxns] = await Promise.all([
+    prisma.invoice.groupBy({ by: ['status'], where: { userId: user.id }, _count: { id: true } }),
+    prisma.transaction.aggregate({
+      where: { userId: user.id, type: 'payment', status: 'completed' },
+      _sum: { amount: true },
+    }),
+    prisma.transaction.aggregate({
+      where: {
+        userId: user.id,
+        type: 'payment',
+        status: 'completed',
+        createdAt: { gte: startOfMonth },
+      },
+      _sum: { amount: true },
+    }),
+    prisma.transaction.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'desc' },
+      take: 5,
+      select: { id: true, type: true, amount: true, currency: true, createdAt: true },
+    }),
+  ])
+
+  const counts = INVOICE_STATUSES.reduce<Record<InvoiceStatus, number>>(
+    (acc, status) => {
+      acc[status] = 0
+      return acc
+    },
+    {} as Record<InvoiceStatus, number>,
+  )
+
+  for (const row of invoiceStats) {
+    if (INVOICE_STATUSES.includes(row.status as InvoiceStatus)) {
+      counts[row.status as InvoiceStatus] = row._count.id
+    }
+  }
+
+  return NextResponse.json({
+    summary: {
+      invoices: {
+        total: counts.pending + counts.paid + counts.overdue + counts.cancelled,
+        pending: counts.pending,
+        paid: counts.paid,
+        overdue: counts.overdue,
+        cancelled: counts.cancelled,
+      },
+      earnings: {
+        totalEarned: Number(totalEarned._sum.amount ?? 0),
+        thisMonth: Number(thisMonthEarned._sum.amount ?? 0),
+        currency: 'USDC',
+      },
+      recentTransactions: recentTxns.map(txn => ({
+        id: txn.id,
+        type: txn.type,
+        amount: Number(txn.amount),
+        currency: txn.currency,
+        createdAt: txn.createdAt,
+      })),
+    },
+  })
+}

--- a/app/api/routes-b/invoices/[id]/messages/route.ts
+++ b/app/api/routes-b/invoices/[id]/messages/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return null
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return null
+
+  return prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true, name: true, email: true },
+  })
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: { id: true, userId: true },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: { content?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { content } = body
+
+  if (!content || typeof content !== 'string' || content.trim() === '') {
+    return NextResponse.json({ error: 'content is required and must be a non-empty string' }, { status: 400 })
+  }
+
+  if (content.length > 1000) {
+    return NextResponse.json({ error: 'content must be 1000 characters or fewer' }, { status: 400 })
+  }
+
+  const message = await prisma.invoiceMessage.create({
+    data: {
+      invoiceId: invoice.id,
+      senderType: 'freelancer',
+      senderName: user.name ?? user.email,
+      content: content.trim(),
+    },
+    select: {
+      id: true,
+      invoiceId: true,
+      senderType: true,
+      senderName: true,
+      content: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json(message, { status: 201 })
+}


### PR DESCRIPTION
## Summary
- add `GET /api/routes-b/analytics/invoices` with parallel grouped counts + totals and zero-default status buckets
- add `GET /api/routes-b/dashboard` with parallel invoice, earnings, and recent transaction summary
- add `GET /api/routes-b/audit-log` with page/limit/action filters and pagination metadata
- add `POST /api/routes-b/invoices/[id]/messages` with auth, ownership checks, and content validation

Closes #369
Closes #370
Closes #378
Closes #379