### PR TITLE
Add GET /api/routes-b/transactions/[id] endpoint

### DIFF
--- a/app/api/routes-b/transactions/[id]/route.ts
+++ b/app/api/routes-b/transactions/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { verifyAuthToken } from "@/lib/auth";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const authToken = request.headers
+    .get("authorization")
+    ?.replace("Bearer ", "");
+  if (!authToken)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const claims = await verifyAuthToken(authToken);
+  if (!claims)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+  });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const transaction = await prisma.transaction.findUnique({
+    where: { id: params.id },
+  });
+
+  if (!transaction)
+    return NextResponse.json(
+      { error: "Transaction not found" },
+      { status: 404 },
+    );
+
+  if (transaction.userId !== user.id)
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  return NextResponse.json({
+    transaction: {
+      id: transaction.id,
+      type: transaction.type,
+      status: transaction.status,
+      amount: Number(transaction.amount),
+      currency: transaction.currency,
+      description: transaction.error ?? null,
+      stellarTxHash: transaction.txHash ?? null,
+      createdAt: transaction.createdAt,
+    },
+  });
+}


### PR DESCRIPTION
Implements the GET handler for retrieving a single transaction by ID.

- Returns 200 with full transaction details for the authenticated owner
- Returns 401 for unauthenticated or invalid token requests
- Returns 403 when the transaction exists but belongs to a different user
- Returns 404 when no transaction matches the given ID
- Maps `txHash` → `stellarTxHash` and serializes `amount` as a number (not a Decimal string)

File added: app/api/routes-b/transactions/[id]/route.ts

this pr Closes #408 