### PR TITLE
feat: add routes-b invoice status, notifications, and webhooks

### DIFF
--- a/app/api/routes-b/invoices/[id]/payment-status/route.ts
+++ b/app/api/routes-b/invoices/[id]/payment-status/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const invoice = await prisma.invoice.findFirst({
+    where: {
+      OR: [
+        { id },
+        { invoiceNumber: id },
+      ],
+    },
+    select: {
+      invoiceNumber: true,
+      status: true,
+      amount: true,
+      currency: true,
+      paidAt: true,
+      dueDate: true,
+    },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    invoiceNumber: invoice.invoiceNumber,
+    status: invoice.status,
+    amount: Number(invoice.amount),
+    currency: invoice.currency,
+    paidAt: invoice.paidAt,
+    dueDate: invoice.dueDate,
+  })
+}

--- a/app/api/routes-b/notifications/route.ts
+++ b/app/api/routes-b/notifications/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const unreadOnly = searchParams.get('unread') === 'true'
+
+    const notifications = await prisma.notification.findMany({
+      where: {
+        userId: user.id,
+        ...(unreadOnly ? { isRead: false } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        message: true,
+        isRead: true,
+        createdAt: true,
+      },
+    })
+
+    const unreadCount = await prisma.notification.count({
+      where: { userId: user.id, isRead: false },
+    })
+
+    return NextResponse.json({
+      notifications,
+      unreadCount,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes B notifications GET error')
+    return NextResponse.json({ error: 'Failed to get notifications' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/webhooks/[id]/route.ts
+++ b/app/api/routes-b/webhooks/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const webhook = await prisma.userWebhook.findUnique({ where: { id } })
+  if (!webhook) {
+    return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
+  }
+
+  if (webhook.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  await prisma.userWebhook.delete({ where: { id } })
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/routes-b/webhooks/route.ts
+++ b/app/api/routes-b/webhooks/route.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+const MAX_WEBHOOKS_PER_USER = 10
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return null
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return null
+  }
+
+  return prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+}
+
+function isValidHttpsUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthenticatedUser(request)
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+
+    if (!body.targetUrl || typeof body.targetUrl !== 'string') {
+      return NextResponse.json({ error: 'targetUrl is required' }, { status: 400 })
+    }
+
+    if (body.targetUrl.length > 512 || !isValidHttpsUrl(body.targetUrl)) {
+      return NextResponse.json({ error: 'targetUrl must be a valid https:// URL (max 512 chars)' }, { status: 400 })
+    }
+
+    if (body.description !== undefined && body.description !== null) {
+      if (typeof body.description !== 'string' || body.description.length > 100) {
+        return NextResponse.json({ error: 'description must be a string of at most 100 characters' }, { status: 400 })
+      }
+    }
+
+    const existingCount = await prisma.userWebhook.count({
+      where: { userId: user.id },
+    })
+
+    if (existingCount >= MAX_WEBHOOKS_PER_USER) {
+      return NextResponse.json(
+        { error: 'Maximum of 10 webhooks per user reached' },
+        { status: 429 },
+      )
+    }
+
+    const signingSecret = crypto.randomBytes(32).toString('hex')
+
+    const webhook = await prisma.userWebhook.create({
+      data: {
+        userId: user.id,
+        targetUrl: body.targetUrl,
+        description: body.description ?? null,
+        signingSecret,
+      },
+      select: {
+        id: true,
+        targetUrl: true,
+        description: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json(
+      {
+        id: webhook.id,
+        targetUrl: webhook.targetUrl,
+        description: webhook.description ?? null,
+        signingSecret,
+        createdAt: webhook.createdAt,
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    logger.error({ err: error }, 'Routes B webhooks POST error')
+    return NextResponse.json({ error: 'Failed to register webhook' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
Closes #407
Closes #415
Closes #420
Closes #434

## Changes
- add a public invoice payment-status endpoint that looks up by invoice id or invoice number and returns public-safe payment fields only
- add an authenticated notifications endpoint with `?unread=true` filtering and `unreadCount`
- add webhook registration with HTTPS validation, description validation, generated signing secrets, and per-user limits
- add webhook deletion with ownership checks and `204 No Content` responses

## Testing
- npm run lint
- npm run build
- npm test

## Notes
- `npm run lint` passes with pre-existing warnings only
- `npm run build` passes locally
- `npm test` currently fails on pre-existing repo issues unrelated to this change: missing `DATABASE_URL` in authorization tests and broken KYC limiter exports in `tests/lib/rate-limit.test.ts`