### PR TITLE
feat(routes-b): implement notifications/avatar/trust-score/tags endpoints

### DIFF
--- a/app/api/routes-b/notifications/mark-all-read/route.ts
+++ b/app/api/routes-b/notifications/mark-all-read/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function POST(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const result = await prisma.notification.updateMany({
+    where: { userId: user.id, isRead: false },
+    data: { isRead: true },
+  })
+
+  return NextResponse.json({ updated: result.count })
+}

--- a/app/api/routes-b/profile/avatar/route.ts
+++ b/app/api/routes-b/profile/avatar/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+function isValidHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const { avatarUrl } = body ?? {}
+
+  if (avatarUrl !== null && typeof avatarUrl !== 'string') {
+    return NextResponse.json({ error: 'avatarUrl must be a string or null' }, { status: 400 })
+  }
+
+  if (typeof avatarUrl === 'string') {
+    if (avatarUrl.length > 512) {
+      return NextResponse.json({ error: 'avatarUrl must not exceed 512 characters' }, { status: 400 })
+    }
+
+    if (!isValidHttpsUrl(avatarUrl)) {
+      return NextResponse.json({ error: 'avatarUrl must be a valid HTTPS URL' }, { status: 400 })
+    }
+  }
+
+  const updatedUser = await prisma.user.update({
+    where: { privyId: claims.userId },
+    data: { avatarUrl: avatarUrl ?? null },
+    select: { avatarUrl: true },
+  })
+
+  return NextResponse.json({ avatarUrl: updatedUser.avatarUrl })
+}

--- a/app/api/routes-b/tags/route.ts
+++ b/app/api/routes-b/tags/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const tags = await prisma.tag.findMany({
+    where: { userId: user.id },
+    orderBy: { name: 'asc' },
+    include: { _count: { select: { invoiceTags: true } } },
+  })
+
+  return NextResponse.json({
+    tags: tags.map(tag => ({
+      id: tag.id,
+      name: tag.name,
+      color: tag.color,
+      invoiceCount: tag._count.invoiceTags,
+      createdAt: tag.createdAt,
+    })),
+  })
+}

--- a/app/api/routes-b/trust-score/route.ts
+++ b/app/api/routes-b/trust-score/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const trustScore = await prisma.userTrustScore.findUnique({
+    where: { userId: user.id },
+    select: {
+      score: true,
+      totalVolumeUsdc: true,
+      disputeCount: true,
+      lastUpdatedAt: true,
+    },
+  })
+
+  if (!trustScore) {
+    return NextResponse.json({
+      trustScore: {
+        score: 50,
+        totalVolumeUsdc: 0,
+        disputeCount: 0,
+        updatedAt: null,
+      },
+    })
+  }
+
+  return NextResponse.json({
+    trustScore: {
+      score: trustScore.score,
+      totalVolumeUsdc: Number(trustScore.totalVolumeUsdc),
+      disputeCount: trustScore.disputeCount,
+      updatedAt: trustScore.lastUpdatedAt,
+    },
+  })
+}


### PR DESCRIPTION
## Description
Implements four new `routes-b` endpoints for notifications bulk-read, profile avatar updates, trust score retrieval, and tag listing for authenticated users.

Closes #418
Closes #421
Closes #436
Closes #440

## Changes proposed

### What were you told to do?
Implement the following routes under `app/api/routes-b` with strict auth checks, expected response shapes, and validation behavior:
- `POST /api/routes-b/notifications/mark-all-read`
- `PATCH /api/routes-b/profile/avatar`
- `GET /api/routes-b/trust-score`
- `GET /api/routes-b/tags`

### What did I do?
#### Notifications Bulk Read (`#436`)
- Added `POST` handler in `app/api/routes-b/notifications/mark-all-read/route.ts`.
- Authenticates request, resolves current user, and bulk-updates unread notifications.
- Returns `{ updated: N }` including `{ updated: 0 }` when none were unread.

#### Profile Avatar Update (`#421`)
- Added `PATCH` handler in `app/api/routes-b/profile/avatar/route.ts`.
- Supports `{ "avatarUrl": "https://..." }` and `{ "avatarUrl": null }` to clear.
- Enforces HTTPS-only URLs and max length 512.
- Returns `{ avatarUrl: <value|null> }`.

#### Trust Score Endpoint (`#418`)
- Added `GET` handler in `app/api/routes-b/trust-score/route.ts`.
- Returns existing trust score record for authenticated user.
- Returns defaults when record is missing: score `50`, volume `0`, disputes `0`, `updatedAt: null`.
- Ensures `totalVolumeUsdc` is returned as a number.

#### Tags Listing (`#440`)
- Added `GET` handler in `app/api/routes-b/tags/route.ts`.
- Returns all current-user tags sorted by name ascending.
- Includes computed `invoiceCount` from `invoiceTags` relation count.
- Returns empty `tags` array when none exist.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Formatted touched files with:
  - `npx eslint --fix app/api/routes-b/notifications/mark-all-read/route.ts app/api/routes-b/profile/avatar/route.ts app/api/routes-b/trust-score/route.ts app/api/routes-b/tags/route.ts`
- Ran project checks:
  - `npm test` (currently fails on pre-existing unrelated suite issues: DB connectivity in `tests/lib/authorization.test.ts` and KYC limiter export expectations in `tests/lib/rate-limit.test.ts`)
  - `npm run build` (currently fails due pre-existing unrelated import error in `app/api/webhooks/offramp/route.ts` referencing `@/lib/prisma`)
