### PR TITLE
feat(routes-b): implement invoice PDF, preview, paid list, and audit event endpoints

### DIFF
--- a/app/api/routes-b/audit-log/[id]/route.ts
+++ b/app/api/routes-b/audit-log/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const event = await prisma.auditEvent.findUnique({ where: { id } })
+
+  if (!event) {
+    return NextResponse.json({ error: 'Audit event not found' }, { status: 404 })
+  }
+
+  if (event.actorId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return NextResponse.json({
+    event: {
+      id: event.id,
+      action: event.eventType,
+      resourceType: 'invoice',
+      resourceId: event.invoiceId,
+      ipAddress: null,
+      userAgent: null,
+      createdAt: event.createdAt,
+    },
+  })
+}

--- a/app/api/routes-b/invoices/[id]/pdf/route.ts
+++ b/app/api/routes-b/invoices/[id]/pdf/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { renderToStream } from '@react-pdf/renderer'
+import { InvoicePDF } from '@/lib/pdf'
+import React from 'react'
+
+export const runtime = 'nodejs'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      invoiceNumber: true,
+      clientEmail: true,
+      clientName: true,
+      description: true,
+      amount: true,
+      currency: true,
+      status: true,
+      paymentLink: true,
+      dueDate: true,
+      paidAt: true,
+      createdAt: true,
+    },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const branding = await prisma.brandingSettings.findUnique({ where: { userId: user.id } })
+
+  const stream = await renderToStream(
+    React.createElement(InvoicePDF, {
+      invoice: {
+        invoiceNumber: invoice.invoiceNumber,
+        freelancerName: user.name || user.email,
+        freelancerEmail: user.email,
+        clientName: invoice.clientName || 'Client',
+        clientEmail: invoice.clientEmail,
+        description: invoice.description,
+        amount: Number(invoice.amount),
+        currency: invoice.currency,
+        status: invoice.status,
+        dueDate: invoice.dueDate ? invoice.dueDate.toISOString() : null,
+        createdAt: invoice.createdAt.toISOString(),
+        paidAt: invoice.paidAt ? invoice.paidAt.toISOString() : null,
+        paymentLink: invoice.paymentLink,
+      },
+      branding: branding ?? undefined,
+    }),
+  )
+
+  return new NextResponse(stream as unknown as ReadableStream, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="invoice-${invoice.invoiceNumber}.pdf"`,
+    },
+  })
+}

--- a/app/api/routes-b/invoices/[id]/preview/route.ts
+++ b/app/api/routes-b/invoices/[id]/preview/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      invoiceNumber: true,
+      clientName: true,
+      clientEmail: true,
+      description: true,
+      amount: true,
+      currency: true,
+      status: true,
+      dueDate: true,
+      paymentLink: true,
+      createdAt: true,
+    },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const branding = await prisma.brandingSettings.findUnique({ where: { userId: user.id } })
+
+  return NextResponse.json({
+    preview: {
+      invoice: {
+        id: invoice.id,
+        invoiceNumber: invoice.invoiceNumber,
+        clientName: invoice.clientName,
+        clientEmail: invoice.clientEmail,
+        description: invoice.description,
+        amount: Number(invoice.amount),
+        currency: invoice.currency,
+        status: invoice.status,
+        dueDate: invoice.dueDate,
+        paymentLink: invoice.paymentLink,
+        createdAt: invoice.createdAt,
+      },
+      branding: branding
+        ? {
+            logoUrl: branding.logoUrl,
+            primaryColor: branding.primaryColor,
+            footerText: branding.footerText,
+          }
+        : null,
+    },
+  })
+}

--- a/app/api/routes-b/invoices/paid/route.ts
+++ b/app/api/routes-b/invoices/paid/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const { searchParams } = new URL(request.url)
+
+  const parsedPage = parseInt(searchParams.get('page') || '1', 10)
+  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage
+
+  const parsedLimit = parseInt(searchParams.get('limit') || '20', 10)
+  const limit = Math.min(50, Math.max(1, Number.isNaN(parsedLimit) ? 20 : parsedLimit))
+
+  const [invoices, total] = await Promise.all([
+    prisma.invoice.findMany({
+      where: { userId: user.id, status: 'paid' },
+      orderBy: { paidAt: 'desc' },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        amount: true,
+        currency: true,
+        paidAt: true,
+        createdAt: true,
+      },
+    }),
+    prisma.invoice.count({ where: { userId: user.id, status: 'paid' } }),
+  ])
+
+  return NextResponse.json({
+    invoices: invoices.map(invoice => ({
+      ...invoice,
+      amount: Number(invoice.amount),
+    })),
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  })
+}


### PR DESCRIPTION
## Overview

This PR implements four new `GET` endpoints under the `routes-b` namespace, covering invoice PDF generation, invoice preview, paid invoice listing, and single audit event retrieval. All handlers follow the established auth pattern (Privy bearer token verification) and return consistent error shapes.

---

## Changes

### `GET /api/routes-b/invoices/[id]/pdf` — closes #402
Streams a downloadable PDF of the invoice using the existing `InvoicePDF` React component from `lib/pdf.tsx` and `@react-pdf/renderer`. No new packages were added.

- Verifies auth and invoice ownership before rendering
- Fetches the user's `BrandingSettings` and passes them to the PDF component (gracefully handles `null`)
- Returns `Content-Type: application/pdf` with `Content-Disposition: attachment; filename="invoice-{invoiceNumber}.pdf"`
- Runs on the Node.js runtime (`export const runtime = 'nodejs'`) since PDF rendering requires it

### `GET /api/routes-b/invoices/[id]/preview` — closes #458
Returns the invoice's data alongside the user's branding settings in a single JSON response, intended for rendering a live invoice preview in the UI without generating a PDF.

- Returns a `preview` object containing `invoice` (full invoice fields) and `branding` (logo, primary color, footer text)
- `branding` is `null` when the user has no `BrandingSettings` record
- `amount` is serialized as a number, not a Prisma `Decimal` string

### `GET /api/routes-b/invoices/paid` — closes #451
Returns a paginated list of the authenticated user's invoices with `status: 'paid'`, ordered by most recently paid first.

- Supports `page` (default: 1) and `limit` (default: 20, max: 50) query params
- Returns an empty `invoices` array (not a 404) when no paid invoices exist
- Includes a `pagination` object with `page`, `limit`, `total`, and `totalPages`
- `amount` is serialized as a number

### `GET /api/routes-b/audit-log/[id]` — closes #457
Returns a single audit event by its ID, scoped to the authenticated user.

- Returns `403` (not `404`) when the event exists but belongs to a different user — prevents user enumeration
- Maps `eventType` → `action`, `invoiceId` → `resourceId`, and sets `resourceType` to `"invoice"` consistent with the existing list endpoint

---

## Auth & Error Handling (all endpoints)

| Scenario | Status |
|---|---|
| Missing / invalid token | `401 Unauthorized` |
| Invoice / event not found | `404 Not Found` |
| Resource belongs to a different user | `403 Forbidden` |
| Success | `200 OK` |

---

## Test plan
- [ ] **PDF**: response has `Content-Type: application/pdf` and correct `Content-Disposition` filename; renders without branding when user has no `BrandingSettings`; returns 401 with no token, 404 for unknown invoice, 403 for another user's invoice
- [ ] **Preview**: `branding` is `null` when not configured; `amount` is a number; returns 401/403/404 correctly
- [ ] **Paid list**: only returns invoices with `status: paid`; ordered by `paidAt desc`; pagination math is correct; returns empty array (not 404) when user has no paid invoices; respects `limit` cap of 50
- [ ] **Audit event**: returns correct event shape; returns 403 for another user's event; returns 404 for non-existent ID; returns 401 with no token

Closes #402, #451, #457, #458