### PR TITLE
feat: add routes-b detail GET handlers

### DIFF
--- a/app/api/routes-b/invoices/[id]/preview/route.ts
+++ b/app/api/routes-b/invoices/[id]/preview/route.ts
@@ -19,23 +19,32 @@ export async function GET(
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
-  const invoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      userId: true,
-      invoiceNumber: true,
-      clientName: true,
-      clientEmail: true,
-      description: true,
-      amount: true,
-      currency: true,
-      status: true,
-      dueDate: true,
-      paymentLink: true,
-      createdAt: true,
-    },
-  })
+  const [invoice, branding] = await Promise.all([
+    prisma.invoice.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        description: true,
+        amount: true,
+        currency: true,
+        status: true,
+        dueDate: true,
+        paymentLink: true,
+      },
+    }),
+    prisma.brandingSettings.findUnique({
+      where: { userId: user.id },
+      select: {
+        logoUrl: true,
+        primaryColor: true,
+        footerText: true,
+      },
+    }),
+  ])
 
   if (!invoice) {
     return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
@@ -44,24 +53,19 @@ export async function GET(
   if (invoice.userId !== user.id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
-
-  const branding = await prisma.brandingSettings.findUnique({ where: { userId: user.id } })
-
   return NextResponse.json({
     preview: {
-      invoice: {
-        id: invoice.id,
-        invoiceNumber: invoice.invoiceNumber,
-        clientName: invoice.clientName,
-        clientEmail: invoice.clientEmail,
-        description: invoice.description,
-        amount: Number(invoice.amount),
-        currency: invoice.currency,
-        status: invoice.status,
-        dueDate: invoice.dueDate,
-        paymentLink: invoice.paymentLink,
-        createdAt: invoice.createdAt,
-      },
+      invoiceNumber: invoice.invoiceNumber,
+      freelancerName: user.name,
+      freelancerEmail: user.email,
+      clientName: invoice.clientName,
+      clientEmail: invoice.clientEmail,
+      description: invoice.description,
+      amount: Number(invoice.amount),
+      currency: invoice.currency,
+      status: invoice.status,
+      dueDate: invoice.dueDate,
+      paymentLink: invoice.paymentLink,
       branding: branding
         ? {
             logoUrl: branding.logoUrl,

--- a/app/api/routes-b/reminder-settings/route.ts
+++ b/app/api/routes-b/reminder-settings/route.ts
@@ -24,16 +24,22 @@ export async function GET(request: NextRequest) {
       where: { userId: user.id },
       select: {
         id: true,
-        enabled: true,
         beforeDueDays: true,
         onDueEnabled: true,
         afterDueDays: true,
-        customMessage: true,
-        createdAt: true,
       },
     })
 
-    return NextResponse.json({ settings: settings ?? null })
+    return NextResponse.json({
+      settings: settings
+        ? {
+            id: settings.id,
+            sendOnDueDate: settings.onDueEnabled,
+            sendDaysBefore: settings.beforeDueDays[0] ?? null,
+            sendDaysAfter: settings.afterDueDays[0] ?? null,
+          }
+        : null,
+    })
   } catch (error) {
     logger.error({ err: error }, 'Routes B reminder-settings GET error')
     return NextResponse.json({ error: 'Failed to get reminder settings' }, { status: 500 })

--- a/app/api/routes-b/tags/[id]/route.ts
+++ b/app/api/routes-b/tags/[id]/route.ts
@@ -2,7 +2,37 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-// ── DELETE /api/routes-b/tags/[id] — remove a tag and all its invoice associations ──
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { id } = await params
+
+    const tag = await prisma.tag.findUnique({
+        where: { id },
+        include: { _count: { select: { invoiceTags: true } } },
+    })
+
+    if (!tag) return NextResponse.json({ error: 'Tag not found' }, { status: 404 })
+    if (tag.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+    return NextResponse.json({
+        id: tag.id,
+        name: tag.name,
+        color: tag.color,
+        invoiceCount: tag._count.invoiceTags,
+        createdAt: tag.createdAt,
+    })
+}
+
+// DELETE /api/routes-b/tags/[id] - remove a tag and all its invoice associations
 export async function DELETE(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }

--- a/app/api/routes-b/webhooks/[id]/route.ts
+++ b/app/api/routes-b/webhooks/[id]/route.ts
@@ -2,6 +2,52 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const webhook = await prisma.userWebhook.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      userId: true,
+      targetUrl: true,
+      description: true,
+      createdAt: true,
+    },
+  })
+
+  if (!webhook) {
+    return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
+  }
+
+  if (webhook.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return NextResponse.json({
+    webhook: {
+      id: webhook.id,
+      targetUrl: webhook.targetUrl,
+      description: webhook.description,
+      createdAt: webhook.createdAt,
+    },
+  })
+}
+
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },


### PR DESCRIPTION
## Description
Implement the missing Routes B GET detail endpoints for tags, webhooks, reminder settings, and invoice preview responses.
Closes #477
Closes #485
Closes #488
Closes #489

## Changes proposed
### What were you told to do?
Implement the Routes B GET handlers for a single tag with invoice count, a single webhook without exposing its signing secret, reminder settings for the authenticated user, and invoice preview data formatted for template rendering. Keep the work scoped to the specified route files.

### What did I do?
#### Tag And Webhook Detail Handlers
- Added `GET /api/routes-b/tags/[id]` to return a single tag with `invoiceCount`, plus `401`/`403`/`404` handling.
- Added `GET /api/routes-b/webhooks/[id]` to return a single webhook by ID while excluding `signingSecret` from the response.

#### Reminder Settings Response Shape
- Updated `GET /api/routes-b/reminder-settings` to return the simplified `settings` object expected by the issue.
- Preserved the required `200` response with `{ "settings": null }` when the user has not configured reminders.

#### Invoice Preview Payload
- Updated `GET /api/routes-b/invoices/[id]/preview` to fetch invoice and branding data in parallel with `Promise.all`.
- Reshaped the response into a single `preview` object with freelancer, client, invoice, amount, and branding fields.
- Ensured `amount` is returned as a number and `branding` is `null` when unset.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npx eslint --fix --ext .ts --no-error-on-unmatched-pattern --ignore-pattern '.next/**' -- 'app/api/routes-b/tags/[id]/route.ts' 'app/api/routes-b/webhooks/[id]/route.ts' 'app/api/routes-b/reminder-settings/route.ts' 'app/api/routes-b/invoices/[id]/preview/route.ts'`
- `npm run build` ?
- `npm test` still fails due existing repo-level issues unrelated to these route files: missing `DATABASE_URL` for `tests/lib/authorization.test.ts` and failing KYC rate-limit exports in `tests/lib/rate-limit.test.ts`.
