### PR TITLE
feat: POST /api/routes-b/webhooks/[id]/ping — send test ping to webhook

### DIFF
--- a/app/api/routes-b/webhooks/[id]/ping/route.ts
+++ b/app/api/routes-b/webhooks/[id]/ping/route.ts
@@ -1,0 +1,73 @@
+import crypto from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const webhook = await prisma.userWebhook.findUnique({ where: { id } })
+  if (!webhook) {
+    return NextResponse.json({ error: 'Webhook not found' }, { status: 404 })
+  }
+
+  if (webhook.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const payload = {
+    event: 'ping',
+    timestamp: new Date().toISOString(),
+    webhookId: id,
+  }
+
+  const signature = crypto
+    .createHmac('sha256', webhook.signingSecret)
+    .update(JSON.stringify(payload))
+    .digest('hex')
+
+  try {
+    const response = await fetch(webhook.targetUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-LancePay-Signature': `sha256=${signature}`,
+      },
+      body: JSON.stringify(payload),
+    })
+
+    const success = response.status >= 200 && response.status < 300
+
+    return NextResponse.json({
+      success,
+      statusCode: response.status,
+      targetUrl: webhook.targetUrl,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes B webhook ping network error')
+    return NextResponse.json({
+      success: false,
+      statusCode: 0,
+      targetUrl: webhook.targetUrl,
+    })
+  }
+}


### PR DESCRIPTION
Closes #478

## What changed

Adds `app/api/routes-b/webhooks/[id]/ping/route.ts` with a `POST` handler that sends a signed test ping to a registered webhook's target URL.

## How it works

- Authenticates the request via Bearer token (Privy)
- Looks up the `UserWebhook` by `id` and verifies ownership
- Builds a `{ event: 'ping', timestamp, webhookId }` payload
- Signs it with HMAC-SHA256 using the webhook's `signingSecret`
- POSTs to `webhook.targetUrl` with `X-LancePay-Signature: sha256=<sig>`
- Returns `{ success, statusCode, targetUrl }` — non-2xx responses set `success: false`, network errors set `statusCode: 0`

## Acceptance criteria covered

- 200 with `{ success, statusCode, targetUrl }` on success
- Payload is HMAC-signed and sent with the signature header
- Non-2xx from target returns `success: false`, not a server error
- Network failure returns `{ success: false, statusCode: 0 }`
- 403 if webhook belongs to another user
- 404 if webhook does not exist
- 401 for unauthenticated requests