### PR TITLE
feat(routes-b): PATCH /api/routes-b/notifications/[id]/read

### DIFF
--- a/app/api/routes-b/notifications/[id]/read/route.ts
+++ b/app/api/routes-b/notifications/[id]/read/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const notification = await prisma.notification.findUnique({ where: { id } })
+
+  if (!notification) {
+    return NextResponse.json({ error: 'Notification not found' }, { status: 404 })
+  }
+
+  if (notification.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Idempotent: already-read notifications return 200 without re-writing
+  if (notification.isRead) {
+    return NextResponse.json({ id: notification.id, isRead: true })
+  }
+
+  const updated = await prisma.notification.update({
+    where: { id },
+    data: { isRead: true },
+    select: { id: true, isRead: true },
+  })
+
+  return NextResponse.json(updated)
+}


### PR DESCRIPTION
## Summary

- Implements `PATCH /api/routes-b/notifications/[id]/read` scoped exclusively to `app/api/routes-b/notifications/[id]/read/route.ts` — no other files touched
- Auth: 401 if no/invalid Bearer token
- 404 if notification does not exist; 403 if `notification.userId !== user.id`
- Idempotent: already-read notification returns `200 { id, isRead: true }` without writing to the DB
- Notification model already present in Prisma schema — no migration needed

## Test plan

- [ ] Valid auth + own unread notification → `200 { id, isRead: true }`
- [ ] Same request again (already read) → `200 { id, isRead: true }` (idempotent)
- [ ] Another user's notification → `403`
- [ ] Non-existent ID → `404`
- [ ] No/invalid token → `401`

Closes #416