### PR TITLE
feat(routes-b): PATCH /api/routes-b/bank-accounts/[id]/default

### DIFF
--- a/app/api/routes-b/bank-accounts/[id]/default/route.ts
+++ b/app/api/routes-b/bank-accounts/[id]/default/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+interface RouteParams {
+  params: Promise<{ id: string }>
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { id } = await params
+
+  const account = await prisma.bankAccount.findUnique({ where: { id } })
+
+  if (!account) {
+    return NextResponse.json({ error: 'Bank account not found' }, { status: 404 })
+  }
+
+  if (account.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Idempotent: already default — return current state without re-writing
+  if (account.isDefault) {
+    return NextResponse.json({
+      id: account.id,
+      bankName: account.bankName,
+      accountNumber: account.accountNumber,
+      isDefault: true,
+    })
+  }
+
+  const updated = await prisma.$transaction(async (tx) => {
+    // Unset any existing default for this user
+    await tx.bankAccount.updateMany({
+      where: { userId: user.id, isDefault: true },
+      data: { isDefault: false },
+    })
+
+    // Set the requested account as default
+    return tx.bankAccount.update({
+      where: { id },
+      data: { isDefault: true },
+      select: {
+        id: true,
+        bankName: true,
+        accountNumber: true,
+        isDefault: true,
+      },
+    })
+  })
+
+  return NextResponse.json(updated)
+}


### PR DESCRIPTION
## Summary

- Implements `PATCH /api/routes-b/bank-accounts/[id]/default` scoped exclusively to `app/api/routes-b/bank-accounts/[id]/default/route.ts` — no other files touched
- Auth: 401 if no/invalid token; 404 if account not found; 403 if account belongs to another user
- Uses `prisma.$transaction` to atomically unset all previous defaults then set the new one — no window where two accounts are simultaneously default
- Idempotent: if account is already default, returns `200` with current state without a DB write
- Response shape: `{ id, bankName, accountNumber, isDefault: true }`

## Test plan

- [ ] Valid auth + own account → `200 { id, bankName, accountNumber, isDefault: true }`
- [ ] Previous default is atomically unset in same transaction
- [ ] Same request again → `200` (idempotent, no extra write)
- [ ] Another user's account → `403`
- [ ] Non-existent ID → `404`
- [ ] No/invalid token → `401`

Closes #411