### PR TITLE
feat(routes-d): GET /api/routes-d/exchange-rate — USDC→NGN

### DIFF
--- a/app/api/routes-d/exchange-rate/route.ts
+++ b/app/api/routes-d/exchange-rate/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getUsdToNgnRate } from '@/lib/exchange-rate'
+
+export async function GET() {
+  const result = await getUsdToNgnRate()
+
+  if ('fallback' in result && result.fallback) {
+    return NextResponse.json(
+      { error: 'Unable to fetch exchange rate' },
+      { status: 503 }
+    )
+  }
+
+  return NextResponse.json({
+    rate: {
+      from: 'USDC',
+      to: 'NGN',
+      value: result.rate as number,
+      fetchedAt: result.lastUpdated,
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Implements `GET /api/routes-d/exchange-rate` scoped exclusively to `app/api/routes-d/exchange-rate/route.ts` — no auth required (public endpoint), no other files touched
- Reuses `getUsdToNgnRate()` from `lib/exchange-rate` exactly as used by `app/api/exchange-rate/route.ts` — same fetch/cache logic, no duplication
- On upstream failure (when the library sets `fallback: true`): returns `503 { error: "Unable to fetch exchange rate" }`
- On success: returns `{ rate: { from: "USDC", to: "NGN", value: <number>, fetchedAt: <ISO string> } }` — `value` is a number, not a string

## Test plan

- [ ] `GET /api/routes-d/exchange-rate` with valid `EXCHANGE_RATE_API_KEY` → `200 { rate: { from: "USDC", to: "NGN", value: <number>, fetchedAt: "..." } }`
- [ ] `value` field is a number (not a string)
- [ ] `EXCHANGE_RATE_API_KEY` unset or upstream fails → `503 { error: "Unable to fetch exchange rate" }`
- [ ] No auth header needed — endpoint is public

Closes #346