### PR TITLE
Add multi-field search on routes-b invoices

### DIFF
--- a/app/api/routes-b/_lib/ageing.ts
+++ b/app/api/routes-b/_lib/ageing.ts
@@ -1,0 +1,25 @@
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export type AgeingBucketKey = '1_30' | '31_60' | '61_90' | '90_plus'
+
+export type AgeingBuckets<T> = Record<AgeingBucketKey, T[]>
+
+export function emptyAgeingBuckets<T>(): AgeingBuckets<T> {
+  return {
+    '1_30': [],
+    '31_60': [],
+    '61_90': [],
+    '90_plus': [],
+  }
+}
+
+export function getDaysOverdueUtc(dueDate: Date, now: Date = new Date()): number {
+  return Math.max(0, Math.floor((now.getTime() - dueDate.getTime()) / DAY_MS))
+}
+
+export function getAgeingBucket(daysOverdue: number): AgeingBucketKey {
+  if (daysOverdue <= 30) return '1_30'
+  if (daysOverdue <= 60) return '31_60'
+  if (daysOverdue <= 90) return '61_90'
+  return '90_plus'
+}

--- a/app/api/routes-b/_lib/invoice-archive.ts
+++ b/app/api/routes-b/_lib/invoice-archive.ts
@@ -1,0 +1,7 @@
+export function parseIncludeArchivedParam(value: string | null): boolean {
+  return value === 'true'
+}
+
+export function getArchiveFilter(includeArchived: boolean) {
+  return includeArchived ? {} : { isConfidential: false }
+}

--- a/app/api/routes-b/_lib/invoice-filters.ts
+++ b/app/api/routes-b/_lib/invoice-filters.ts
@@ -1,0 +1,52 @@
+import { Prisma } from '@prisma/client'
+
+export type InvoiceListFilters = {
+  number: string | null
+  client: string | null
+  minAmount: string | null
+  maxAmount: string | null
+  currency: string | null
+}
+
+export function parsePositiveAmount(value: string | null): number | null {
+  if (value === null) return null
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Amount filters must be positive numbers')
+  }
+
+  return parsed
+}
+
+export function buildInvoiceWhereFilters(filters: InvoiceListFilters): Prisma.InvoiceWhereInput {
+  const where: Prisma.InvoiceWhereInput = {}
+
+  if (filters.number) {
+    where.invoiceNumber = { contains: filters.number, mode: 'insensitive' }
+  }
+
+  if (filters.client) {
+    where.clientName = { contains: filters.client, mode: 'insensitive' }
+  }
+
+  const minAmount = parsePositiveAmount(filters.minAmount)
+  const maxAmount = parsePositiveAmount(filters.maxAmount)
+
+  if (minAmount !== null || maxAmount !== null) {
+    if (minAmount !== null && maxAmount !== null && minAmount > maxAmount) {
+      throw new Error('minAmount must be less than or equal to maxAmount')
+    }
+
+    where.amount = {
+      ...(minAmount !== null ? { gte: minAmount } : {}),
+      ...(maxAmount !== null ? { lte: maxAmount } : {}),
+    }
+  }
+
+  if (filters.currency) {
+    where.currency = filters.currency.toUpperCase()
+  }
+
+  return where
+}

--- a/app/api/routes-b/_lib/with-body-limit.ts
+++ b/app/api/routes-b/_lib/with-body-limit.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const ONE_MEBIBYTE = 1024 * 1024
+
+type HandlerArgs = [NextRequest, ...unknown[]]
+type Handler = (...args: HandlerArgs) => Promise<Response>
+
+export type BodyLimitOptions = {
+  limitBytes?: number
+}
+
+async function exceedsBodyLimit(request: NextRequest, limitBytes: number): Promise<boolean> {
+  const contentLengthHeader = request.headers.get('content-length')
+
+  if (contentLengthHeader) {
+    const parsed = Number.parseInt(contentLengthHeader, 10)
+    if (!Number.isNaN(parsed)) {
+      return parsed > limitBytes
+    }
+  }
+
+  if (!request.body) {
+    return false
+  }
+
+  const clone = request.clone()
+  const reader = clone.body?.getReader()
+  if (!reader) {
+    return false
+  }
+
+  let total = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+
+    total += value.byteLength
+    if (total > limitBytes) {
+      await reader.cancel()
+      return true
+    }
+  }
+
+  return false
+}
+
+export function withBodyLimit(handler: Handler, options?: BodyLimitOptions): Handler {
+  const limitBytes = options?.limitBytes ?? ONE_MEBIBYTE
+
+  return async (...args: HandlerArgs) => {
+    const [request] = args
+
+    const tooLarge = await exceedsBodyLimit(request, limitBytes)
+    if (tooLarge) {
+      return NextResponse.json(
+        { error: `Payload too large. Maximum allowed is ${limitBytes} bytes` },
+        { status: 413 },
+      )
+    }
+
+    return handler(...args)
+  }
+}

--- a/app/api/routes-b/branding/route.ts
+++ b/app/api/routes-b/branding/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
+import { withBodyLimit } from '../_lib/with-body-limit'
 
 function isValidHexColor(color: string): boolean {
   return /^#[0-9A-Fa-f]{6}$/.test(color);
@@ -10,7 +11,7 @@ function isValidHttpsUrl(url: string): boolean {
   return url.startsWith("https://");
 }
 
-export async function PATCH(request: NextRequest) {
+async function patchBranding(request: NextRequest) {
   const authToken = request.headers
     .get("authorization")
     ?.replace("Bearer ", "");
@@ -83,3 +84,5 @@ export async function PATCH(request: NextRequest) {
 
   return NextResponse.json({ branding });
 }
+
+export const PATCH = withBodyLimit(patchBranding, { limitBytes: 1024 * 1024 })

--- a/app/api/routes-b/contacts/[id]/route.ts
+++ b/app/api/routes-b/contacts/[id]/route.ts
@@ -2,86 +2,48 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { withBodyLimit } from '../../_lib/with-body-limit'
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   let contactId: string | undefined
 
   try {
-    // check auth header
-    const authToken = request.headers
-      .get('authorization')
-      ?.replace('Bearer ', '')
-
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    //  verify token
     const claims = await verifyAuthToken(authToken)
     if (!claims) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // get user
-    const user = await prisma.user.findUnique({
-      where: { privyId: claims.userId },
-    })
-
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // get contact ID
     const { id } = params
     contactId = id
 
-    // find contact
-    const contact = await prisma.contact.findUnique({
-      where: { id },
-    })
+    const contact = await prisma.contact.findUnique({ where: { id } })
 
-    // not found - 404
     if (!contact) {
-      return NextResponse.json(
-        { error: 'Contact not found' },
-        { status: 404 }
-      )
+      return NextResponse.json({ error: 'Contact not found' }, { status: 404 })
     }
 
-    // ownership check - 403
     if (contact.userId !== user.id) {
-      return NextResponse.json(
-        { error: 'Forbidden' },
-        { status: 403 }
-      )
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    // return contact - 200
-    return NextResponse.json(
-      { contact },
-      { status: 200 }
-    )
+    return NextResponse.json({ contact }, { status: 200 })
   } catch (error) {
-    logger.error(
-      { err: error, contactId },
-      'Routes B contact GET error'
-    )
-
-    return NextResponse.json(
-      { error: 'Failed to fetch contact' },
-      { status: 500 }
-    )
+    logger.error({ err: error, contactId }, 'Routes B contact GET error')
+    return NextResponse.json({ error: 'Failed to fetch contact' }, { status: 500 })
   }
 }
-}
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+async function patchContact(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -100,9 +62,7 @@ export async function PATCH(
 
     const { id } = await params
 
-    const contact = await prisma.contact.findUnique({
-      where: { id },
-    })
+    const contact = await prisma.contact.findUnique({ where: { id } })
 
     if (!contact) {
       return NextResponse.json({ error: 'Contact not found' }, { status: 404 })
@@ -112,12 +72,7 @@ export async function PATCH(
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    let body: {
-      name?: unknown
-      email?: unknown
-      company?: unknown
-      notes?: unknown
-    }
+    let body: { name?: unknown; email?: unknown; company?: unknown; notes?: unknown }
 
     try {
       body = await request.json()
@@ -125,12 +80,7 @@ export async function PATCH(
       return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    const updateData: {
-      name?: string
-      email?: string
-      company?: string | null
-      notes?: string | null
-    } = {}
+    const updateData: { name?: string; email?: string; company?: string | null; notes?: string | null } = {}
 
     if (body.name !== undefined) {
       if (typeof body.name !== 'string' || body.name.trim() === '') {
@@ -154,12 +104,7 @@ export async function PATCH(
       }
 
       const existingContact = await prisma.contact.findUnique({
-        where: {
-          userId_email: {
-            userId: user.id,
-            email: normalizedEmail,
-          },
-        },
+        where: { userId_email: { userId: user.id, email: normalizedEmail } },
         select: { id: true },
       })
 
@@ -175,10 +120,7 @@ export async function PATCH(
         return NextResponse.json({ error: 'company must be a string' }, { status: 400 })
       }
       if (typeof body.company === 'string' && body.company.trim().length > 100) {
-        return NextResponse.json(
-          { error: 'company must be 100 characters or fewer' },
-          { status: 400 }
-        )
+        return NextResponse.json({ error: 'company must be 100 characters or fewer' }, { status: 400 })
       }
       updateData.company = typeof body.company === 'string' ? body.company.trim() : null
     }
@@ -197,22 +139,12 @@ export async function PATCH(
       Object.keys(updateData).length === 0
         ? await prisma.contact.findUnique({
             where: { id },
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              updatedAt: true,
-            },
+            select: { id: true, name: true, email: true, updatedAt: true },
           })
         : await prisma.contact.update({
             where: { id },
             data: updateData,
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              updatedAt: true,
-            },
+            select: { id: true, name: true, email: true, updatedAt: true },
           })
 
     return NextResponse.json({ contact: updatedContact }, { status: 200 })
@@ -222,3 +154,5 @@ export async function PATCH(
     return NextResponse.json({ error: 'Failed to update contact' }, { status: 500 })
   }
 }
+
+export const PATCH = withBodyLimit(patchContact)

--- a/app/api/routes-b/invoices/[id]/archive/route.ts
+++ b/app/api/routes-b/invoices/[id]/archive/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const invoice = await prisma.invoice.findUnique({ where: { id }, select: { id: true, userId: true, isConfidential: true } })
+  if (!invoice) return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  if (invoice.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const updated = await prisma.invoice.update({
+    where: { id },
+    data: { isConfidential: true },
+    select: { id: true, status: true, isConfidential: true },
+  })
+
+  return NextResponse.json({ invoice: { id: updated.id, status: updated.status, archived: updated.isConfidential } })
+}

--- a/app/api/routes-b/invoices/[id]/unarchive/route.ts
+++ b/app/api/routes-b/invoices/[id]/unarchive/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const invoice = await prisma.invoice.findUnique({ where: { id }, select: { id: true, userId: true, isConfidential: true } })
+  if (!invoice) return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  if (invoice.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const updated = await prisma.invoice.update({
+    where: { id },
+    data: { isConfidential: false },
+    select: { id: true, status: true, isConfidential: true },
+  })
+
+  return NextResponse.json({ invoice: { id: updated.id, status: updated.status, archived: updated.isConfidential } })
+}

--- a/app/api/routes-b/invoices/archived/route.ts
+++ b/app/api/routes-b/invoices/archived/route.ts
@@ -1,32 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
 
   const { searchParams } = new URL(request.url)
-  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
   const page = Math.max(1, Number.parseInt(searchParams.get('page') || '1', 10) || 1)
-  const limit = Math.min(
-    50,
-    Math.max(1, Number.parseInt(searchParams.get('limit') || '20', 10) || 20),
-  )
+  const limit = Math.min(50, Math.max(1, Number.parseInt(searchParams.get('limit') || '20', 10) || 20))
 
   const [invoices, total] = await Promise.all([
     prisma.invoice.findMany({
-      where: { userId: user.id, status: 'pending', ...getArchiveFilter(includeArchived) },
-      orderBy: { createdAt: 'desc' },
+      where: {
+        userId: user.id,
+        isConfidential: true,
+      },
+      orderBy: { updatedAt: 'desc' },
       skip: (page - 1) * limit,
       take: limit,
       select: {
@@ -34,18 +28,16 @@ export async function GET(request: NextRequest) {
         invoiceNumber: true,
         clientName: true,
         amount: true,
-        dueDate: true,
+        currency: true,
+        status: true,
         createdAt: true,
       },
     }),
-    prisma.invoice.count({ where: { userId: user.id, status: 'pending', ...getArchiveFilter(includeArchived) } }),
+    prisma.invoice.count({ where: { userId: user.id, isConfidential: true } }),
   ])
 
   return NextResponse.json({
-    invoices: invoices.map((invoice) => ({
-      ...invoice,
-      amount: Number(invoice.amount),
-    })),
+    invoices: invoices.map((invoice) => ({ ...invoice, amount: Number(invoice.amount) })),
     pagination: {
       page,
       limit,

--- a/app/api/routes-b/invoices/cancelled/route.ts
+++ b/app/api/routes-b/invoices/cancelled/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 
 export async function GET(request: NextRequest) {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -11,6 +12,7 @@ export async function GET(request: NextRequest) {
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
 
     const { searchParams } = new URL(request.url)
+  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
     const page = Math.max(1, Number.parseInt(searchParams.get('page') || '1', 10) || 1)
     const limit = Math.min(
         50,
@@ -22,6 +24,7 @@ export async function GET(request: NextRequest) {
             where: {
                 userId: user.id,
                 status: 'cancelled',
+                ...getArchiveFilter(includeArchived),
             },
             orderBy: { createdAt: 'desc' },
             skip: (page - 1) * limit,
@@ -39,6 +42,7 @@ export async function GET(request: NextRequest) {
             where: {
                 userId: user.id,
                 status: 'cancelled',
+                ...getArchiveFilter(includeArchived),
             },
         }),
     ])

--- a/app/api/routes-b/invoices/overdue/route.ts
+++ b/app/api/routes-b/invoices/overdue/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { Invoice } from '@prisma/client'
 import { verifyAuthToken } from '@/lib/auth'
+import { emptyAgeingBuckets, getAgeingBucket, getDaysOverdueUtc } from '../../_lib/ageing'
+import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 
 export async function GET(request: NextRequest) {
-  // 1. Verify auth
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -16,28 +17,26 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
+  const { searchParams } = new URL(request.url)
+  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
+  const bucketed = searchParams.get('bucketed') === 'true'
   const now = new Date()
 
-  // 2. Fetch overdue invoices
-  // An invoice is overdue when status is 'pending' and dueDate < now
   const overdueInvoices = await prisma.invoice.findMany({
     where: {
       userId: user.id,
       status: 'pending',
+      ...getArchiveFilter(includeArchived),
       dueDate: {
         not: null,
         lt: now,
       },
     },
-    orderBy: { dueDate: 'asc' }, // most overdue first
+    orderBy: { dueDate: 'asc' },
   })
 
-  // 3. Format response and compute daysOverdue
   const invoices = overdueInvoices.map((inv: Invoice) => {
-    // Math.floor((now - dueDate) / ms_per_day)
-    const daysOverdue = Math.floor(
-      (now.getTime() - inv.dueDate!.getTime()) / (1000 * 60 * 60 * 24)
-    )
+    const daysOverdue = getDaysOverdueUtc(inv.dueDate!, now)
 
     return {
       id: inv.id,
@@ -46,13 +45,31 @@ export async function GET(request: NextRequest) {
       clientEmail: inv.clientEmail,
       amount: Number(inv.amount),
       dueDate: inv.dueDate,
-      daysOverdue: Math.max(0, daysOverdue), // Ensure non-negative
+      daysOverdue,
     }
   })
 
-  // 4. Return results
-  return NextResponse.json({
-    invoices,
-    total: invoices.length,
-  })
+  if (!bucketed) {
+    return NextResponse.json({
+      invoices,
+      total: invoices.length,
+    })
+  }
+
+  const buckets = emptyAgeingBuckets<typeof invoices[number]>()
+  const totals = {
+    '1_30': { count: 0, amount: 0 },
+    '31_60': { count: 0, amount: 0 },
+    '61_90': { count: 0, amount: 0 },
+    '90_plus': { count: 0, amount: 0 },
+  }
+
+  for (const invoice of invoices) {
+    const key = getAgeingBucket(invoice.daysOverdue)
+    buckets[key].push(invoice)
+    totals[key].count += 1
+    totals[key].amount += invoice.amount
+  }
+
+  return NextResponse.json({ buckets, totals })
 }

--- a/app/api/routes-b/invoices/paid/route.ts
+++ b/app/api/routes-b/invoices/paid/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -15,6 +16,7 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
+  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
 
   const parsedPage = parseInt(searchParams.get('page') || '1', 10)
   const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage
@@ -24,7 +26,7 @@ export async function GET(request: NextRequest) {
 
   const [invoices, total] = await Promise.all([
     prisma.invoice.findMany({
-      where: { userId: user.id, status: 'paid' },
+      where: { userId: user.id, status: 'paid', ...getArchiveFilter(includeArchived) },
       orderBy: { paidAt: 'desc' },
       skip: (page - 1) * limit,
       take: limit,
@@ -39,7 +41,7 @@ export async function GET(request: NextRequest) {
         createdAt: true,
       },
     }),
-    prisma.invoice.count({ where: { userId: user.id, status: 'paid' } }),
+    prisma.invoice.count({ where: { userId: user.id, status: 'paid', ...getArchiveFilter(includeArchived) } }),
   ])
 
   return NextResponse.json({

--- a/app/api/routes-b/invoices/route.ts
+++ b/app/api/routes-b/invoices/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { generateInvoiceNumber } from '@/lib/utils'
+import { buildInvoiceWhereFilters } from '../_lib/invoice-filters'
+import { getArchiveFilter, parseIncludeArchivedParam } from '../_lib/invoice-archive'
 
 async function getAuthenticatedUser(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -42,6 +44,7 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url)
   const status = searchParams.get('status')
+  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
   const page = Math.max(1, Number.parseInt(searchParams.get('page') || '1', 10) || 1)
   const limit = Math.min(
     50,
@@ -53,9 +56,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid status' }, { status: 400 })
   }
 
+  let searchFilters = {}
+  try {
+    searchFilters = buildInvoiceWhereFilters({
+      number: searchParams.get('number'),
+      client: searchParams.get('client'),
+      minAmount: searchParams.get('minAmount'),
+      maxAmount: searchParams.get('maxAmount'),
+      currency: searchParams.get('currency'),
+    })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 400 })
+  }
+
   const where = {
     userId: auth.user.id,
     ...(status ? { status } : {}),
+    ...getArchiveFilter(includeArchived),
+    ...searchFilters,
   }
 
   const total = await prisma.invoice.count({ where })

--- a/app/api/routes-b/profile/avatar/route.ts
+++ b/app/api/routes-b/profile/avatar/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { withBodyLimit } from '../../_lib/with-body-limit'
 
 function isValidHttpsUrl(url: string): boolean {
   try {
@@ -10,7 +11,7 @@ function isValidHttpsUrl(url: string): boolean {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function patchAvatar(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -42,3 +43,5 @@ export async function PATCH(request: NextRequest) {
 
   return NextResponse.json({ avatarUrl: updatedUser.avatarUrl })
 }
+
+export const PATCH = withBodyLimit(patchAvatar, { limitBytes: 2 * 1024 * 1024 })

--- a/app/api/routes-b/reminder-settings/route.ts
+++ b/app/api/routes-b/reminder-settings/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { withBodyLimit } from '../_lib/with-body-limit'
 
 export async function GET(request: NextRequest) {
   try {
@@ -46,7 +47,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function patchReminderSettings(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -149,3 +150,5 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to update reminder settings' }, { status: 500 })
   }
 }
+
+export const PATCH = withBodyLimit(patchReminderSettings, { limitBytes: 1024 * 1024 })

--- a/app/api/routes-b/tags/route.ts
+++ b/app/api/routes-b/tags/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { withBodyLimit } from '../_lib/with-body-limit'
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -31,7 +32,7 @@ export async function GET(request: NextRequest) {
   })
 }
 
-export async function POST(request: NextRequest) {
+async function postTag(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -87,3 +88,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
+
+export const POST = withBodyLimit(postTag, { limitBytes: 1024 * 1024 })

--- a/app/api/routes-b/tests/ageing.test.ts
+++ b/app/api/routes-b/tests/ageing.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { getAgeingBucket } from '../_lib/ageing'
+import { GET as getOverdue } from '../invoices/overdue/route'
+
+describe('ageing bucket helper', () => {
+  it('handles bucket boundaries', () => {
+    expect(getAgeingBucket(1)).toBe('1_30')
+    expect(getAgeingBucket(30)).toBe('1_30')
+    expect(getAgeingBucket(31)).toBe('31_60')
+    expect(getAgeingBucket(60)).toBe('31_60')
+    expect(getAgeingBucket(61)).toBe('61_90')
+    expect(getAgeingBucket(90)).toBe('61_90')
+    expect(getAgeingBucket(91)).toBe('90_plus')
+  })
+})
+
+describe('GET /invoices/overdue?bucketed=true', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('returns empty buckets and totals for each bucket', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'u1' } as any)
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([] as any)
+
+    const req = new NextRequest('http://localhost/api/routes-b/invoices/overdue?bucketed=true', {
+      headers: { authorization: 'Bearer token' },
+    })
+
+    const res = await getOverdue(req)
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(Object.keys(json.buckets)).toEqual(['1_30', '31_60', '61_90', '90_plus'])
+    expect(json.buckets['1_30']).toEqual([])
+    expect(json.buckets['31_60']).toEqual([])
+    expect(json.buckets['61_90']).toEqual([])
+    expect(json.buckets['90_plus']).toEqual([])
+    expect(json.totals['90_plus']).toEqual({ count: 0, amount: 0 })
+  })
+})

--- a/app/api/routes-b/tests/archive-invoices.test.ts
+++ b/app/api/routes-b/tests/archive-invoices.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { POST as archivePost } from '../invoices/[id]/archive/route'
+import { POST as unarchivePost } from '../invoices/[id]/unarchive/route'
+import { GET as listInvoices } from '../invoices/route'
+
+const authd = () => {
+  vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as any)
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'u1' } as any)
+}
+
+describe('archive/unarchive invoices', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('archives and unarchives', async () => {
+    authd()
+    vi.mocked(prisma.invoice.findUnique).mockResolvedValue({ id: 'inv-1', userId: 'u1' } as any)
+    vi.mocked(prisma.invoice.update)
+      .mockResolvedValueOnce({ id: 'inv-1', status: 'paid', isConfidential: true } as any)
+      .mockResolvedValueOnce({ id: 'inv-1', status: 'paid', isConfidential: false } as any)
+
+    const headers = { authorization: 'Bearer token' }
+    const archived = await archivePost(new NextRequest('http://localhost/a', { method: 'POST', headers }), { params: Promise.resolve({ id: 'inv-1' }) })
+    const unarchived = await unarchivePost(new NextRequest('http://localhost/b', { method: 'POST', headers }), { params: Promise.resolve({ id: 'inv-1' }) })
+
+    expect((await archived.json()).invoice.archived).toBe(true)
+    expect((await unarchived.json()).invoice.archived).toBe(false)
+  })
+
+  it('excludes archived by default and includes with flag', async () => {
+    authd()
+    vi.mocked(prisma.invoice.count).mockResolvedValue(0)
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([] as any)
+
+    await listInvoices(new NextRequest('http://localhost/api/routes-b/invoices', { headers: { authorization: 'Bearer token' } }))
+    expect(vi.mocked(prisma.invoice.findMany).mock.calls[0][0].where.isConfidential).toBe(false)
+
+    await listInvoices(new NextRequest('http://localhost/api/routes-b/invoices?includeArchived=true', { headers: { authorization: 'Bearer token' } }))
+    expect(vi.mocked(prisma.invoice.findMany).mock.calls[1][0].where.isConfidential).toBeUndefined()
+  })
+})

--- a/app/api/routes-b/tests/invoice-filters.test.ts
+++ b/app/api/routes-b/tests/invoice-filters.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { count: vi.fn(), findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn() },
+  },
+}))
+vi.mock('@/lib/utils', () => ({ generateInvoiceNumber: vi.fn(() => 'INV-1001') }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET as listInvoices } from '../invoices/route'
+
+describe('GET /invoices multi-field filters', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'u1' } as any)
+    vi.mocked(prisma.invoice.count).mockResolvedValue(0)
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([] as any)
+  })
+
+  it('applies single filter', async () => {
+    await listInvoices(new NextRequest('http://localhost/api/routes-b/invoices?number=INV-1', { headers: { authorization: 'Bearer token' } }))
+    expect(vi.mocked(prisma.invoice.findMany).mock.calls[0][0].where.invoiceNumber).toEqual({ contains: 'INV-1', mode: 'insensitive' })
+  })
+
+  it('applies combined filters with AND semantics', async () => {
+    await listInvoices(new NextRequest('http://localhost/api/routes-b/invoices?number=INV&client=acme&minAmount=10&maxAmount=99&currency=usd', { headers: { authorization: 'Bearer token' } }))
+    const where = vi.mocked(prisma.invoice.findMany).mock.calls[0][0].where
+    expect(where.invoiceNumber).toBeTruthy()
+    expect(where.clientName).toBeTruthy()
+    expect(where.amount).toEqual({ gte: 10, lte: 99 })
+    expect(where.currency).toBe('USD')
+  })
+
+  it('rejects invalid amount', async () => {
+    const res = await listInvoices(new NextRequest('http://localhost/api/routes-b/invoices?minAmount=-1', { headers: { authorization: 'Bearer token' } }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/routes-b/tests/with-body-limit.test.ts
+++ b/app/api/routes-b/tests/with-body-limit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import { withBodyLimit } from '../_lib/with-body-limit'
+
+const okHandler = async () => NextResponse.json({ ok: true })
+
+describe('withBodyLimit', () => {
+  it('allows under and at limit', async () => {
+    const wrapped = withBodyLimit(okHandler, { limitBytes: 4 })
+
+    const under = await wrapped(new NextRequest('http://localhost/x', { method: 'POST', headers: { 'content-length': '3' }, body: 'abc' }))
+    const at = await wrapped(new NextRequest('http://localhost/x', { method: 'POST', headers: { 'content-length': '4' }, body: 'abcd' }))
+
+    expect(under.status).toBe(200)
+    expect(at.status).toBe(200)
+  })
+
+  it('rejects over limit and missing content-length stream over cap', async () => {
+    const wrapped = withBodyLimit(okHandler, { limitBytes: 4 })
+
+    const over = await wrapped(new NextRequest('http://localhost/x', { method: 'POST', headers: { 'content-length': '5' }, body: 'abcde' }))
+    const missingLength = await wrapped(new NextRequest('http://localhost/x', { method: 'POST', body: 'abcde' }))
+
+    expect(over.status).toBe(413)
+    expect(missingLength.status).toBe(413)
+  })
+
+  it('supports per-route override', async () => {
+    const wrapped = withBodyLimit(okHandler, { limitBytes: 2 })
+    const res = await wrapped(new NextRequest('http://localhost/x', { method: 'POST', headers: { 'content-length': '3' }, body: 'abc' }))
+    expect(res.status).toBe(413)
+  })
+})

--- a/app/api/routes-b/webhooks/route.ts
+++ b/app/api/routes-b/webhooks/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { withBodyLimit } from '../_lib/with-body-limit'
 
 const MAX_WEBHOOKS_PER_USER = 10
 
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: NextRequest) {
+async function postWebhook(request: NextRequest) {
   try {
     const user = await getAuthenticatedUser(request)
     if (!user) {
@@ -126,3 +127,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to register webhook' }, { status: 500 })
   }
 }
+
+export const POST = withBodyLimit(postWebhook, { limitBytes: 1024 * 1024 })


### PR DESCRIPTION
close #566 

Description
Added helper libraries under app/api/routes-b/_lib: ageing.ts (UTC day calc + bucket logic), invoice-archive.ts (include flag + filter), invoice-filters.ts (filter parsing/validation), and with-body-limit.ts (1 MiB default body-size wrapper with streaming fallback).
Extended GET /api/routes-b/invoices/overdue with ?bucketed=true to return { buckets: { 1_30, 31_60, 61_90, 90_plus }, totals } while preserving the original flat response when bucketed is absent, using UTC-based days-overdue computation.
Added archive endpoints POST /api/routes-b/invoices/[id]/archive and POST /api/routes-b/invoices/[id]/unarchive, an GET /api/routes-b/invoices/archived list, and wired ?includeArchived=true (default lists exclude archived) into invoices listing routes, implemented via the new archive helper.
Implemented multi-field filters in GET /api/routes-b/invoices (number, client, minAmount, maxAmount, currency) with validation and AND semantics using the new filter builder.
Introduced withBodyLimit and applied it to starter routes inside routes-b (branding, contacts PATCH, tags POST, webhooks POST, reminder-settings PATCH) and provided a per-route override example for avatar PATCH (2 MiB).
Added unit tests under app/api/routes-b/tests for ageing bucket boundaries and response shape, archive/unarchive behavior and default exclusion, invoice filter behavior and invalid amounts, and body-size limit scenarios.

Testing
Unit tests were added covering ageing boundaries and bucket shape, archive/unarchive and list include/exclude, invoice filter application and invalid amounts, and body-size wrapper behavior (files: app/api/routes-b/tests/*.test.ts).
Attempted to run the test suite via npx vitest run app/api/routes-b/tests/*.test.ts, but test execution failed in this environment due to npm registry access being blocked (403 Forbidden) so tests were not executed here.
Ran git diff --check and file/format checks completed without reported issues in this environment.