### PR TITLE
fix: add routes-b health probe and duplicate invoice guard

### DIFF
--- a/app/api/routes-b/_health/__tests__/health-route.test.ts
+++ b/app/api/routes-b/_health/__tests__/health-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '../route'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}))
+
+import { prisma } from '@/lib/db'
+
+const mockedQueryRaw = vi.mocked(prisma.$queryRaw)
+
+describe('GET /api/routes-b/_health', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 200 when db check is healthy', async () => {
+    mockedQueryRaw.mockResolvedValue([{ '?column?': 1 }] as never)
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.checks.db).toBe('ok')
+    expect(typeof body.checks.time).toBe('string')
+    expect(typeof body.checks.version).toBe('string')
+  })
+
+  it('returns 503 when db check is slow', async () => {
+    mockedQueryRaw.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve([{ '?column?': 1 }]), 300)
+        }) as never,
+    )
+
+    const started = Date.now()
+    const res = await GET()
+    const elapsed = Date.now() - started
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body.ok).toBe(false)
+    expect(body.checks.db).toBe('degraded')
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('returns 503 when db check throws', async () => {
+    mockedQueryRaw.mockRejectedValue(new Error('db offline'))
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body).toEqual({
+      ok: false,
+      checks: {
+        db: 'degraded',
+        time: expect.any(String),
+        version: expect.any(String),
+      },
+    })
+  })
+})
+

--- a/app/api/routes-b/_health/route.ts
+++ b/app/api/routes-b/_health/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+const DB_TIMEOUT_MS = 250
+const HARD_TIMEOUT_MS = 450
+const APP_VERSION = process.env.npm_package_version || 'unknown'
+
+async function checkDbWithTimeout() {
+  const dbCheck = prisma.$queryRaw`SELECT 1`
+  const timeout = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error('DB_TIMEOUT')), DB_TIMEOUT_MS)
+  })
+  await Promise.race([dbCheck, timeout])
+}
+
+export async function GET() {
+  const startedAt = Date.now()
+  const responseTimeout = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error('HEALTH_TIMEOUT')), HARD_TIMEOUT_MS)
+  })
+
+  try {
+    await Promise.race([checkDbWithTimeout(), responseTimeout])
+    return NextResponse.json(
+      {
+        ok: true,
+        checks: {
+          db: 'ok',
+          time: new Date(startedAt).toISOString(),
+          version: APP_VERSION,
+        },
+      },
+      { status: 200 },
+    )
+  } catch {
+    return NextResponse.json(
+      {
+        ok: false,
+        checks: {
+          db: 'degraded',
+          time: new Date(startedAt).toISOString(),
+          version: APP_VERSION,
+        },
+      },
+      { status: 503 },
+    )
+  }
+}
+

--- a/app/api/routes-b/_lib/duplicate-detection.ts
+++ b/app/api/routes-b/_lib/duplicate-detection.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@/lib/db'
+
+const DUPLICATE_WINDOW_MS = 5 * 60 * 1000
+
+type DuplicateLookupInput = {
+  userId: string
+  clientEmail: string
+  amount: number
+  currency: string
+}
+
+export async function findRecentDuplicateInvoice(input: DuplicateLookupInput) {
+  const duplicate = await prisma.invoice.findFirst({
+    where: {
+      userId: input.userId,
+      clientEmail: input.clientEmail,
+      amount: input.amount,
+      currency: input.currency,
+      createdAt: {
+        gte: new Date(Date.now() - DUPLICATE_WINDOW_MS),
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true },
+  })
+
+  return duplicate?.id ?? null
+}
+

--- a/app/api/routes-b/invoices/__tests__/post-invoice-duplicate.test.ts
+++ b/app/api/routes-b/invoices/__tests__/post-invoice-duplicate.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '../route'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  generateInvoiceNumber: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    invoice: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { generateInvoiceNumber } from '@/lib/utils'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedGenerateInvoiceNumber = vi.mocked(generateInvoiceNumber)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindUnique = vi.mocked(prisma.invoice.findUnique)
+const mockedInvoiceFindFirst = vi.mocked(prisma.invoice.findFirst)
+const mockedInvoiceCreate = vi.mocked(prisma.invoice.create)
+
+const fakeUser = { id: 'user-1', privyId: 'privy-1' }
+const fakeInvoice = {
+  id: 'invoice-123',
+  invoiceNumber: 'INV-123',
+  paymentLink: 'https://example.com/pay/INV-123',
+  status: 'pending',
+  amount: 100,
+  currency: 'USD',
+}
+
+function makeRequest(url: string, body: unknown): NextRequest {
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/routes-b/invoices duplicate detection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(null as never)
+    mockedGenerateInvoiceNumber.mockReturnValue('INV-123')
+    mockedInvoiceCreate.mockResolvedValue(fakeInvoice as never)
+  })
+
+  it('creates invoice when there is no duplicate', async () => {
+    mockedInvoiceFindFirst.mockResolvedValue(null as never)
+    const req = makeRequest('http://localhost/api/routes-b/invoices', {
+      clientEmail: 'client@example.com',
+      description: 'Website redesign',
+      amount: 100,
+      currency: 'usd',
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(201)
+    expect(mockedInvoiceFindFirst).toHaveBeenCalled()
+    expect(mockedInvoiceCreate).toHaveBeenCalled()
+  })
+
+  it('blocks near-duplicate with 409', async () => {
+    mockedInvoiceFindFirst.mockResolvedValue({ id: 'existing-invoice' } as never)
+    const req = makeRequest('http://localhost/api/routes-b/invoices', {
+      clientEmail: 'client@example.com',
+      description: 'Website redesign',
+      amount: 100,
+      currency: 'USD',
+    })
+
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(409)
+    expect(body).toEqual({ duplicateOfId: 'existing-invoice' })
+    expect(mockedInvoiceCreate).not.toHaveBeenCalled()
+  })
+
+  it('bypasses duplicate check when force=true', async () => {
+    const req = makeRequest('http://localhost/api/routes-b/invoices?force=true', {
+      clientEmail: 'client@example.com',
+      description: 'Website redesign',
+      amount: 100,
+      currency: 'USD',
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(201)
+    expect(mockedInvoiceFindFirst).not.toHaveBeenCalled()
+    expect(mockedInvoiceCreate).toHaveBeenCalled()
+  })
+
+  it('allows create when similar invoice is outside duplicate window', async () => {
+    mockedInvoiceFindFirst.mockResolvedValue(null as never)
+    const req = makeRequest('http://localhost/api/routes-b/invoices', {
+      clientEmail: 'client@example.com',
+      description: 'Website redesign',
+      amount: 100,
+      currency: 'USD',
+    })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(201)
+    expect(mockedInvoiceFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: expect.objectContaining({ gte: expect.any(Date) }),
+        }),
+      }),
+    )
+  })
+})
+

--- a/app/api/routes-b/invoices/route.ts
+++ b/app/api/routes-b/invoices/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { generateInvoiceNumber } from '@/lib/utils'
+import { findRecentDuplicateInvoice } from '../_lib/duplicate-detection'
 
 async function getAuthenticatedUser(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -112,6 +113,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'amount must be greater than 0' }, { status: 400 })
   }
 
+  const { searchParams } = new URL(request.url)
+  const forceCreate = searchParams.get('force') === 'true'
+  const normalizedClientEmail = String(clientEmail).toLowerCase()
+  const normalizedCurrency = String(currency).toUpperCase()
+
+  if (!forceCreate) {
+    const duplicateInvoiceId = await findRecentDuplicateInvoice({
+      userId: auth.user.id,
+      clientEmail: normalizedClientEmail,
+      amount: parsedAmount,
+      currency: normalizedCurrency,
+    })
+
+    if (duplicateInvoiceId) {
+      return NextResponse.json({ duplicateOfId: duplicateInvoiceId }, { status: 409 })
+    }
+  }
+
   let parsedDueDate: Date | null = null
   if (dueDate) {
     parsedDueDate = new Date(dueDate)
@@ -128,11 +147,11 @@ export async function POST(request: NextRequest) {
     data: {
       userId: auth.user.id,
       invoiceNumber,
-      clientEmail: String(clientEmail).toLowerCase(),
+      clientEmail: normalizedClientEmail,
       clientName: clientName || null,
       description,
       amount: parsedAmount,
-      currency,
+      currency: normalizedCurrency,
       paymentLink,
       dueDate: parsedDueDate,
     },


### PR DESCRIPTION
Closes #562
Closes #562
CLoses #573
Closes #579
Closes #581

## Changes
- add an unauthenticated routes-b health-check endpoint with fail-fast DB probe behavior
- add duplicate invoice detection for routes-b invoice creation with a force bypass
- add focused tests for both routes

## Testing
- local test files added for health-check success, timeout, and failure cases
- local test files added for duplicate invoice create, block, bypass, and window behavior
- full test execution was blocked in this environment by the local npm/vitest lock issue encountered earlier