### PR TITLE
fix: add IBAN validation, LTV calculation, duplicate detection, and tag sweep

### DIFF
--- a/app/api/routes-b/_lib/iban.ts
+++ b/app/api/routes-b/_lib/iban.ts
@@ -1,0 +1,40 @@
+const IBAN_LENGTHS: Record<string, number> = {
+  AD: 24, AE: 23, AL: 28, AT: 20, AZ: 28, BA: 20, BE: 16, BG: 22, BH: 22, BR: 29,
+  BY: 28, CH: 21, CR: 22, CY: 28, CZ: 24, DE: 22, DK: 18, DO: 28, EE: 20, EG: 29,
+  ES: 24, FI: 18, FO: 18, FR: 27, GB: 22, GE: 22, GI: 23, GL: 18, GR: 27, GT: 28,
+  HR: 21, HU: 28, IE: 22, IL: 23, IS: 26, IT: 27, JO: 30, KW: 30, KZ: 20, LB: 28,
+  LC: 32, LI: 21, LT: 20, LU: 20, LV: 21, MC: 27, MD: 24, ME: 22, MK: 19, MR: 27,
+  MT: 31, MU: 30, NL: 18, NO: 15, PK: 24, PL: 28, PS: 29, PT: 25, QA: 29, RO: 24,
+  RS: 22, SA: 24, SE: 24, SI: 19, SK: 24, SM: 27, TN: 24, TR: 26, UA: 29, VA: 22,
+  VG: 24, XK: 20,
+};
+
+export function validateIBAN(iban: string): boolean {
+  const normalized = iban.replace(/\s/g, '').toUpperCase();
+
+  const countryCode = normalized.substring(0, 2);
+  const expectedLength = IBAN_LENGTHS[countryCode];
+
+  if (!expectedLength || normalized.length !== expectedLength) {
+    return false;
+  }
+
+  const rearranged = normalized.substring(4) + normalized.substring(0, 4);
+  let numeric = '';
+
+  for (let i = 0; i < rearranged.length; i++) {
+    const char = rearranged[i];
+    if (/\d/.test(char)) {
+      numeric += char;
+    } else {
+      numeric += (char.charCodeAt(0) - 55).toString();
+    }
+  }
+
+  let remainder = 0;
+  for (let i = 0; i < numeric.length; i++) {
+    remainder = (remainder * 10 + parseInt(numeric[i])) % 97;
+  }
+
+  return remainder === 1;
+}

--- a/app/api/routes-b/_lib/swift.ts
+++ b/app/api/routes-b/_lib/swift.ts
@@ -1,0 +1,13 @@
+export function validateSWIFT(swift: string): boolean {
+  const normalized = swift.replace(/\s/g, '').toUpperCase();
+
+  if (normalized.length !== 8 && normalized.length !== 11) {
+    return false;
+  }
+
+  if (!/^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$/.test(normalized)) {
+    return false;
+  }
+
+  return true;
+}

--- a/app/api/routes-b/analytics/clients/route.ts
+++ b/app/api/routes-b/analytics/clients/route.ts
@@ -27,19 +27,41 @@ export async function GET(request: NextRequest) {
 
   const grouped = await prisma.invoice.groupBy({
     by: ["clientEmail", "clientName"],
-    where: { userId: user.id },
+    where: { userId: user.id, paidAt: { not: null } },
     _count: { id: true },
     _sum: { amount: true },
+    _max: { paidAt: true },
+    _min: { createdAt: true },
     orderBy: { _sum: { amount: "desc" } },
     take: limit,
   });
 
-  const clients = grouped.map((c: any) => ({
-    clientEmail: c.clientEmail,
-    clientName: c.clientName,
-    totalInvoiced: Number(c._sum.amount ?? 0),
-    invoiceCount: c._count.id,
-  }));
+  const clients = grouped.map((c: any) => {
+    const totalPaid = Number(c._sum.amount ?? 0);
+    const invoiceCount = c._count.id;
+    const firstInvoiceDate = c._min.createdAt ? new Date(c._min.createdAt) : null;
+    const lastPaymentAt = c._max.paidAt ? new Date(c._max.paidAt) : null;
+
+    let activeMonths = 0;
+    if (firstInvoiceDate && lastPaymentAt) {
+      const diffTime = Math.abs(lastPaymentAt.getTime() - firstInvoiceDate.getTime());
+      activeMonths = Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 30));
+    }
+
+    const avgMonthlyPaid = activeMonths > 0 ? totalPaid / activeMonths : 0;
+    const projectedAnnual = activeMonths >= 3 ? avgMonthlyPaid * 12 : undefined;
+
+    return {
+      clientEmail: c.clientEmail,
+      clientName: c.clientName,
+      totalPaid,
+      activeMonths,
+      avgMonthlyPaid,
+      lastPaymentAt,
+      projectedAnnual,
+      invoiceCount,
+    };
+  });
 
   return NextResponse.json({ clients });
 }

--- a/app/api/routes-b/bank-accounts/route.ts
+++ b/app/api/routes-b/bank-accounts/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { validateIBAN } from '../_lib/iban'
+import { validateSWIFT } from '../_lib/swift'
 
 function isValidDigits(value: string, min: number, max: number) {
   const pattern = new RegExp(`^\\d{${min},${max}}$`)
@@ -50,7 +52,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { bankName, bankCode, accountNumber, accountName } = body ?? {}
+  const { bankName, bankCode, accountNumber, accountName, iban, swift } = body ?? {}
 
   if (
     typeof bankName !== 'string' ||
@@ -71,6 +73,14 @@ export async function POST(request: NextRequest) {
       },
       { status: 400 },
     )
+  }
+
+  if (iban !== undefined && (typeof iban !== 'string' || !validateIBAN(iban))) {
+    return NextResponse.json({ error: 'Invalid IBAN format' }, { status: 400 })
+  }
+
+  if (swift !== undefined && (typeof swift !== 'string' || !validateSWIFT(swift))) {
+    return NextResponse.json({ error: 'Invalid SWIFT/BIC format' }, { status: 400 })
   }
 
   const existingCount = await prisma.bankAccount.count({ where: { userId: user.id } })

--- a/app/api/routes-b/bank-accounts/route.ts
+++ b/app/api/routes-b/bank-accounts/route.ts
@@ -83,6 +83,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid SWIFT/BIC format' }, { status: 400 })
   }
 
+  const existing = await prisma.bankAccount.findFirst({
+    where: {
+      userId: user.id,
+      accountNumber: { equals: accountNumber, mode: 'insensitive' },
+      bankCode: { equals: bankCode, mode: 'insensitive' },
+    },
+  })
+
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Bank account already exists', existingId: existing.id },
+      { status: 409 },
+    )
+  }
+
   const existingCount = await prisma.bankAccount.count({ where: { userId: user.id } })
   const isDefault = existingCount === 0
 

--- a/app/api/routes-b/tags/sweep/route.ts
+++ b/app/api/routes-b/tags/sweep/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { checkRateLimit } from '../../_lib/rate-limit'
+
+export async function POST(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const rateLimitKey = `tag-sweep:${user.id}`
+  const rateLimitResult = checkRateLimit(rateLimitKey, { limit: 1, windowMs: 60 * 1000 })
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { error: 'Rate limited. Maximum 1 sweep per minute.' },
+      { status: 429 },
+    )
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const allUserTags = await tx.tag.findMany({
+      where: { userId: user.id },
+      select: { id: true },
+    })
+
+    const referencedTagIds = await tx.invoiceTag.findMany({
+      where: {
+        invoice: {
+          userId: user.id,
+        },
+      },
+      distinct: ['tagId'],
+      select: { tagId: true },
+    })
+
+    const referencedIdSet = new Set(referencedTagIds.map((t) => t.tagId))
+    const unusedIds = allUserTags.filter((t) => !referencedIdSet.has(t.id)).map((t) => t.id)
+
+    if (unusedIds.length === 0) {
+      return { deletedCount: 0, deletedIds: [] }
+    }
+
+    await tx.tag.deleteMany({
+      where: {
+        id: { in: unusedIds },
+        userId: user.id,
+      },
+    })
+
+    return {
+      deletedCount: unusedIds.length,
+      deletedIds: unusedIds,
+    }
+  })
+
+  return NextResponse.json(result)
+}


### PR DESCRIPTION
## Summary

Implement four critical enhancements to routes-b: IBAN/SWIFT validation for bank accounts, client lifetime value calculation in analytics, bulk-delete unused tags endpoint, and duplicate bank account detection.

## Changes

- Add IBAN validation with mod-97 check and country-specific length tables
- Add SWIFT/BIC validation for 8 or 11 character format
- Detect and prevent duplicate bank accounts (same accountNumber + bankCode)
- Extend client analytics with LTV metrics: totalPaid, activeMonths, avgMonthlyPaid, lastPaymentAt, projectedAnnual (hidden for < 3 active months)
- Add POST /tags/sweep endpoint for bulk-deleting unused tags with rate limiting

## Testing

- IBAN validation handles multiple countries and mod-97 checksum verification
- SWIFT validation enforces correct format and length
- Duplicate detection returns 409 Conflict with existing account ID
- LTV calculation uses single grouped query for efficiency
- Tag sweep uses transaction for atomicity and enforces rate limit

Closes #574
Closes #575
Closes #578
Closes #522