### PR TITLE
feat(routes-b): add typeahead suggest endpoint with cache

### DIFF
--- a/app/api/routes-b/search/suggest/__tests__/route.test.ts
+++ b/app/api/routes-b/search/suggest/__tests__/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+import { resetSuggestCache } from '../_lib/cache'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+    contact: { findMany: vi.fn() },
+    tag: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindMany = vi.mocked(prisma.invoice.findMany)
+const mockedContactFindMany = vi.mocked(prisma.contact.findMany)
+const mockedTagFindMany = vi.mocked(prisma.tag.findMany)
+
+function makeRequest(q: string) {
+  return new NextRequest(`http://localhost/api/routes-b/search/suggest?q=${encodeURIComponent(q)}`, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/routes-b/search/suggest', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    resetSuggestCache()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user-1' } as never)
+    mockedInvoiceFindMany.mockResolvedValue([] as never)
+    mockedContactFindMany.mockResolvedValue([] as never)
+    mockedTagFindMany.mockResolvedValue([] as never)
+  })
+
+  it('rejects short query', async () => {
+    const res = await GET(makeRequest('a'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns cross-type suggestions ordered by recency', async () => {
+    mockedInvoiceFindMany.mockResolvedValue([
+      { id: 'inv-1', invoiceNumber: 'INV-100', clientName: 'Acme', createdAt: new Date('2026-01-02') },
+    ] as never)
+    mockedContactFindMany.mockResolvedValue([
+      { id: 'con-1', name: 'Acme Corp', createdAt: new Date('2026-01-03') },
+    ] as never)
+    mockedTagFindMany.mockResolvedValue([
+      { id: 'tag-1', name: 'acme', createdAt: new Date('2026-01-01') },
+    ] as never)
+
+    const res = await GET(makeRequest('acme'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+
+    expect(json.cache).toBe('miss')
+    expect(json.suggestions.map((s: { type: string }) => s.type)).toEqual(['contact', 'invoice', 'tag'])
+    expect(json.suggestions).toHaveLength(3)
+  })
+
+  it('returns cached value on repeated query', async () => {
+    mockedInvoiceFindMany.mockResolvedValue([
+      { id: 'inv-1', invoiceNumber: 'INV-100', clientName: 'Acme', createdAt: new Date('2026-01-02') },
+    ] as never)
+
+    const first = await GET(makeRequest('acme'))
+    expect(first.status).toBe(200)
+    expect((await first.json()).cache).toBe('miss')
+
+    const second = await GET(makeRequest('acme'))
+    expect(second.status).toBe(200)
+    expect((await second.json()).cache).toBe('hit')
+    expect(mockedInvoiceFindMany).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/api/routes-b/search/suggest/_lib/cache.ts
+++ b/app/api/routes-b/search/suggest/_lib/cache.ts
@@ -1,0 +1,35 @@
+type Suggestion = {
+  type: 'invoice' | 'contact' | 'tag'
+  id: string
+  label: string
+  matchedField: 'invoiceNumber' | 'clientName' | 'name'
+}
+
+type CacheEntry = {
+  value: Suggestion[]
+  expiresAt: number
+}
+
+const CACHE_TTL_MS = 30_000
+const cache = new Map<string, CacheEntry>()
+
+export function getSuggestCache(key: string, now = Date.now()): Suggestion[] | null {
+  const hit = cache.get(key)
+  if (!hit) return null
+  if (now >= hit.expiresAt) {
+    cache.delete(key)
+    return null
+  }
+  return hit.value
+}
+
+export function setSuggestCache(key: string, value: Suggestion[], now = Date.now()) {
+  cache.set(key, {
+    value,
+    expiresAt: now + CACHE_TTL_MS,
+  })
+}
+
+export function resetSuggestCache() {
+  cache.clear()
+}

--- a/app/api/routes-b/search/suggest/route.ts
+++ b/app/api/routes-b/search/suggest/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { sanitizeSearchQuery } from '../../_lib/validation'
+import { getSuggestCache, setSuggestCache } from './_lib/cache'
+
+type Suggestion = {
+  type: 'invoice' | 'contact' | 'tag'
+  id: string
+  label: string
+  matchedField: 'invoiceNumber' | 'clientName' | 'name'
+  createdAt: Date
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const url = new URL(request.url)
+    const qRaw = url.searchParams.get('q') ?? ''
+    const q = sanitizeSearchQuery(qRaw)
+
+    if (q.length < 2 || q.length > 32) {
+      return NextResponse.json({ error: 'q must be between 2 and 32 characters' }, { status: 400 })
+    }
+
+    const cacheKey = `${user.id}:${q.toLowerCase()}`
+    const cached = getSuggestCache(cacheKey)
+    if (cached) {
+      return NextResponse.json({ suggestions: cached, cache: 'hit' })
+    }
+
+    const [invoices, contacts, tags] = await Promise.all([
+      prisma.invoice.findMany({
+        where: {
+          userId: user.id,
+          OR: [
+            { invoiceNumber: { contains: q, mode: 'insensitive' } },
+            { clientName: { contains: q, mode: 'insensitive' } },
+          ],
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: { id: true, invoiceNumber: true, clientName: true, createdAt: true },
+      }),
+      prisma.contact.findMany({
+        where: {
+          userId: user.id,
+          OR: [{ name: { contains: q, mode: 'insensitive' } }],
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: { id: true, name: true, createdAt: true },
+      }),
+      prisma.tag.findMany({
+        where: {
+          userId: user.id,
+          name: { contains: q, mode: 'insensitive' },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 8,
+        select: { id: true, name: true, createdAt: true },
+      }),
+    ])
+
+    const merged: Suggestion[] = [
+      ...invoices.map((row) => ({
+        type: 'invoice' as const,
+        id: row.id,
+        label: row.invoiceNumber,
+        matchedField: 'invoiceNumber' as const,
+        createdAt: row.createdAt,
+      })),
+      ...contacts.map((row) => ({
+        type: 'contact' as const,
+        id: row.id,
+        label: row.name,
+        matchedField: 'name' as const,
+        createdAt: row.createdAt,
+      })),
+      ...tags.map((row) => ({
+        type: 'tag' as const,
+        id: row.id,
+        label: row.name,
+        matchedField: 'name' as const,
+        createdAt: row.createdAt,
+      })),
+    ]
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(0, 8)
+      .map(({ createdAt, ...rest }) => rest)
+
+    setSuggestCache(cacheKey, merged)
+    return NextResponse.json({ suggestions: merged, cache: 'miss' })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B search suggest GET error')
+    return NextResponse.json({ error: 'Failed to fetch suggestions' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add `GET /api/routes-b/search/suggest?q=<prefix>` to return lightweight typeahead suggestions
- enforce query validation (`q` min 2, max 32) using existing routes-b sanitization
- return unified suggestion items across invoices, contacts, and tags: `{ type, id, label, matchedField }`
- limit output to 8 items and order merged results by recency (`createdAt desc`)
- add 30s in-memory cache keyed by `userId + query` with explicit cache hit/miss behavior
- add tests for short-query rejection, cross-type results, recency ordering, and cache hit/miss

## Validation
- `npm test -- app/api/routes-b/search/suggest/__tests__/route.test.ts` *(fails locally: missing `vitest/config` dependency in this clone environment)*

Closes #534
Closes #553
Closes #576
Closes #577
