### PR TITLE
feat: add routes-b request ids and endpoints

### DIFF
--- a/app/api/routes-b/_health/route.ts
+++ b/app/api/routes-b/_health/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 
@@ -13,7 +14,7 @@ async function checkDbWithTimeout() {
   await Promise.race([dbCheck, timeout])
 }
 
-export async function GET() {
+async function GETHandler() {
   const startedAt = Date.now()
   const responseTimeout = new Promise<never>((_, reject) => {
     setTimeout(() => reject(new Error('HEALTH_TIMEOUT')), HARD_TIMEOUT_MS)
@@ -47,3 +48,4 @@ export async function GET() {
   }
 }
 
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/_lib/amounts.ts
+++ b/app/api/routes-b/_lib/amounts.ts
@@ -1,0 +1,3 @@
+export function normalizeCurrencyAmount(value: unknown): number {
+  return Number(value ?? 0)
+}

--- a/app/api/routes-b/_lib/flags.ts
+++ b/app/api/routes-b/_lib/flags.ts
@@ -24,6 +24,9 @@ const defaultFlags: Record<string, FlagValue> = {
   'webhook-event-filtering': 'off',
 };
 
+export const ENABLE_CONTACTS_SOFT_DELETE = process.env.ENABLE_CONTACTS_SOFT_DELETE === 'true' ||
+  process.env.FLAG_CONTACTS_SOFT_DELETE === 'on'
+
 function parseFlagValue(envValue: string | undefined): FlagValue {
   if (!envValue) return 'off';
   
@@ -58,9 +61,9 @@ export function isEnabled(flagName: string, context: FlagContext = {}): boolean 
   // Check cache first
   const cacheKey = `${flagName}:${context.userId || 'no-user'}`;
   if (flagCache.has(cacheKey)) {
-    return flagCache.get(cacheKey) === 'on' || 
-           (Array.isArray(flagCache.get(cacheKey)) && context.userId && 
-            (flagCache.get(cacheKey) as string[]).includes(context.userId));
+    const cached = flagCache.get(cacheKey)
+    return cached === 'on' ||
+      Boolean(Array.isArray(cached) && context.userId && cached.includes(context.userId))
   }
   
   // Get flag value from env or defaults

--- a/app/api/routes-b/_lib/notification-cache.ts
+++ b/app/api/routes-b/_lib/notification-cache.ts
@@ -1,0 +1,19 @@
+import { deleteCacheValue, getCacheValue, setCacheValue } from './cache'
+
+const UNREAD_COUNT_TTL_MS = 10_000
+
+function unreadCountCacheKey(userId: string) {
+  return `notifications:unread-count:${userId}`
+}
+
+export function getCachedUnreadCount(userId: string): number | null {
+  return getCacheValue<number>(unreadCountCacheKey(userId))
+}
+
+export function setCachedUnreadCount(userId: string, count: number) {
+  setCacheValue(unreadCountCacheKey(userId), count, UNREAD_COUNT_TTL_MS)
+}
+
+export function bustUnreadCountCache(userId: string) {
+  deleteCacheValue(unreadCountCacheKey(userId))
+}

--- a/app/api/routes-b/_lib/presigned-upload.ts
+++ b/app/api/routes-b/_lib/presigned-upload.ts
@@ -19,11 +19,20 @@ const CLOUDINARY_CLOUD_NAME = process.env.CLOUDINARY_CLOUD_NAME
 const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY
 const CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET
 
-if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_API_KEY || !CLOUDINARY_API_SECRET) {
-  throw new Error('Missing Cloudinary configuration')
+function requireCloudinaryConfig() {
+  if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_API_KEY || !CLOUDINARY_API_SECRET) {
+    throw new Error('Missing Cloudinary configuration')
+  }
+
+  return {
+    cloudName: CLOUDINARY_CLOUD_NAME,
+    apiKey: CLOUDINARY_API_KEY,
+    apiSecret: CLOUDINARY_API_SECRET,
+  }
 }
 
 export function generatePresignedUpload(userId: string): PresignedUploadResponse {
+  const config = requireCloudinaryConfig()
   const timestamp = Math.round(Date.now() / 1000)
   const publicId = `avatars/${userId}/${timestamp}`
   const folder = 'avatars'
@@ -45,15 +54,15 @@ export function generatePresignedUpload(userId: string): PresignedUploadResponse
     .join('&')
   
   const signature = createHash('sha1')
-    .update(signatureString + CLOUDINARY_API_SECRET)
+    .update(signatureString + config.apiSecret)
     .digest('hex')
   
   const expiresAt = new Date(Date.now() + 60 * 1000) // 60 seconds from now
   
   return {
-    url: `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/auto/upload`,
+    url: `https://api.cloudinary.com/v1_1/${config.cloudName}/auto/upload`,
     fields: {
-      api_key: CLOUDINARY_API_KEY,
+      api_key: config.apiKey,
       timestamp: timestamp.toString(),
       public_id: publicId,
       folder,
@@ -105,7 +114,7 @@ export async function validateUploadedFile(key: string, buffer: ArrayBuffer): Pr
 }
 
 export function generateCloudinaryUrl(key: string): string {
-  return `https://res.cloudinary.com/${CLOUDINARY_CLOUD_NAME}/image/upload/${key}.jpg`
+  return `https://res.cloudinary.com/${CLOUDINARY_CLOUD_NAME || 'demo'}/image/upload/${key}.jpg`
 }
 
 export function isExpiredKey(expiresAt: string): boolean {

--- a/app/api/routes-b/_lib/rate-limit.ts
+++ b/app/api/routes-b/_lib/rate-limit.ts
@@ -38,3 +38,14 @@ export function checkRateLimit(
 export function resetRateLimitBuckets() {
   buckets.clear()
 }
+
+export async function rateLimit(key: string, limit: number, windowMs: number) {
+  const result = checkRateLimit(key, { limit, windowMs })
+
+  return result.allowed
+    ? { allowed: true as const }
+    : {
+        allowed: false as const,
+        resetTime: new Date(Date.now() + result.retryAfter * 1000).toISOString(),
+      }
+}

--- a/app/api/routes-b/_lib/with-request-id.ts
+++ b/app/api/routes-b/_lib/with-request-id.ts
@@ -1,0 +1,104 @@
+import { AsyncLocalStorage } from 'async_hooks'
+import { randomBytes } from 'crypto'
+import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
+
+type RequestContext = {
+  requestId: string
+}
+
+type RouteHandler = (...args: any[]) => unknown | Promise<unknown>
+
+const requestContext = new AsyncLocalStorage<RequestContext>()
+const LOGGER_PATCHED = Symbol.for('routes-b.logger.request-id-patched')
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function generateUuidV7(): string {
+  const bytes = randomBytes(16)
+  const timestamp = Date.now()
+
+  bytes[0] = Math.floor(timestamp / 0x10000000000) & 0xff
+  bytes[1] = Math.floor(timestamp / 0x100000000) & 0xff
+  bytes[2] = Math.floor(timestamp / 0x1000000) & 0xff
+  bytes[3] = Math.floor(timestamp / 0x10000) & 0xff
+  bytes[4] = Math.floor(timestamp / 0x100) & 0xff
+  bytes[5] = timestamp & 0xff
+  bytes[6] = (bytes[6] & 0x0f) | 0x70
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+function isUuid(value: string | null): value is string {
+  return Boolean(value && UUID_PATTERN.test(value))
+}
+
+function getRequestHeader(args: any[], name: string): string | null {
+  const request = args[0]
+  return typeof request?.headers?.get === 'function' ? request.headers.get(name) : null
+}
+
+function resolveRequestId(args: any[]) {
+  const clientRequestId = getRequestHeader(args, 'x-request-id')
+  return isUuid(clientRequestId) ? clientRequestId : generateUuidV7()
+}
+
+export function getRequestId(): string | null {
+  return requestContext.getStore()?.requestId ?? null
+}
+
+function patchLogger() {
+  const target = logger as any
+  if (target[LOGGER_PATCHED]) return
+
+  for (const method of ['trace', 'debug', 'info', 'warn', 'error', 'fatal'] as const) {
+    const original = target[method]
+    if (typeof original !== 'function') continue
+
+    target[method] = function requestIdLoggerMethod(this: unknown, ...args: any[]) {
+      const requestId = getRequestId()
+      if (requestId) {
+        const first = args[0]
+        if (first && typeof first === 'object' && !Array.isArray(first) && !(first instanceof Error)) {
+          args[0] = { requestId, ...first }
+        } else {
+          args.unshift({ requestId })
+        }
+      }
+
+      return original.apply(this, args)
+    }
+  }
+
+  target[LOGGER_PATCHED] = true
+}
+
+function responseWithRequestId(response: unknown, requestId: string): Response {
+  const routeResponse = response instanceof Response
+    ? response
+    : new Response(null, { status: 204 })
+
+  routeResponse.headers.set('X-Request-Id', requestId)
+  return routeResponse
+}
+
+patchLogger()
+
+export function withRequestId<T extends RouteHandler>(handler: T): (...args: any[]) => Promise<Response> {
+  return (async (...args: any[]) => {
+    const requestId = resolveRequestId(args)
+
+    try {
+      const response = await requestContext.run({ requestId }, () => handler(...args))
+      return responseWithRequestId(response, requestId)
+    } catch (error) {
+      logger.error({ err: error }, 'Routes B unhandled route error')
+      return responseWithRequestId(
+        NextResponse.json({ error: 'Internal server error' }, { status: 500 }),
+        requestId,
+      )
+    }
+  })
+}

--- a/app/api/routes-b/_openapi/route.ts
+++ b/app/api/routes-b/_openapi/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { generateOpenAPIDocument } from '../_lib/openapi'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 
                   `https://${request.headers.get('host')}` ||
                   'http://localhost:3000'
@@ -15,3 +16,5 @@ export async function GET(request: NextRequest) {
     }
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/clients/route.ts
+++ b/app/api/routes-b/analytics/clients/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers
     .get("authorization")
     ?.replace("Bearer ", "");
@@ -65,3 +66,5 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({ clients });
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/earnings/route.ts
+++ b/app/api/routes-b/analytics/earnings/route.ts
@@ -1,10 +1,11 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { parseUtcDateRange } from '../../_lib/date-range'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -60,3 +61,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to get earnings' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/invoices/route.ts
+++ b/app/api/routes-b/analytics/invoices/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -5,7 +6,7 @@ import { verifyAuthToken } from '@/lib/auth'
 const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
 type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -57,3 +58,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/top-months/route.ts
+++ b/app/api/routes-b/analytics/top-months/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -6,7 +7,7 @@ import { verifyAuthToken } from '@/lib/auth'
  * GET /api/routes-b/analytics/top-months
  * Returns the three calendar months with the highest paid invoice totals for the authenticated user.
  */
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     const claims = await verifyAuthToken(authToken || '')
@@ -48,3 +49,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/withdrawals/route.ts
+++ b/app/api/routes-b/analytics/withdrawals/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -53,3 +54,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to get withdrawal stats' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/audit-log/[id]/export.csv/route.ts
+++ b/app/api/routes-b/audit-log/[id]/export.csv/route.ts
@@ -1,0 +1,102 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import type { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { parseAuditFilters } from '../../../_lib/audit-filters'
+import { createCsvStream } from '../../../_lib/csv-stream'
+
+const EXPORT_ROW_LIMIT = 50_000
+
+async function GETHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const filters = parseAuditFilters(new URL(request.url).searchParams)
+
+  if (!filters.ok) {
+    return NextResponse.json({ error: filters.error }, { status: 400 })
+  }
+
+  const where: Prisma.AuditEventWhereInput = {
+    invoiceId: id,
+    createdAt: {
+      gte: filters.value.from,
+      lte: filters.value.to,
+    },
+    ...(filters.value.actor ? { actorId: filters.value.actor } : {}),
+    invoice: {
+      userId: user.id,
+    },
+  }
+
+  const rowCount = await prisma.auditEvent.count({ where })
+  if (rowCount > EXPORT_ROW_LIMIT) {
+    return NextResponse.json(
+      {
+        error: 'Audit export is too large',
+        hint: 'request-narrower-range',
+      },
+      { status: 413 },
+    )
+  }
+
+  type AuditEventRow = {
+    id: string
+    eventType: string
+    invoiceId: string
+    actorId: string | null
+    metadata: unknown
+    createdAt: Date
+  }
+
+  const stream = createCsvStream<AuditEventRow>(
+    [
+      { header: 'id', value: row => row.id },
+      { header: 'action', value: row => row.eventType },
+      { header: 'resourceType', value: () => 'invoice' },
+      { header: 'resourceId', value: row => row.invoiceId },
+      { header: 'actorId', value: row => row.actorId },
+      { header: 'metadata', value: row => JSON.stringify(row.metadata ?? {}) },
+      { header: 'createdAt', value: row => row.createdAt },
+    ],
+    (cursor, batchSize) =>
+      prisma.auditEvent.findMany({
+        where,
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: batchSize,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+        select: {
+          id: true,
+          eventType: true,
+          invoiceId: true,
+          actorId: true,
+          metadata: true,
+          createdAt: true,
+        },
+      }),
+  )
+
+  return new NextResponse(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="audit-log-${id}.csv"`,
+    },
+  })
+}
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/audit-log/[id]/route.ts
+++ b/app/api/routes-b/audit-log/[id]/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { parseAuditFilters } from '../../_lib/audit-filters'
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -53,3 +54,5 @@ export async function GET(
     })),
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/audit-log/route.ts
+++ b/app/api/routes-b/audit-log/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -54,3 +55,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/bank-accounts/[id]/default/route.ts
+++ b/app/api/routes-b/bank-accounts/[id]/default/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -6,7 +7,7 @@ interface RouteParams {
   params: Promise<{ id: string }>
 }
 
-export async function PATCH(request: NextRequest, { params }: RouteParams) {
+async function PATCHHandler(request: NextRequest, { params }: RouteParams) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -66,3 +67,5 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
   return NextResponse.json(updated)
 }
+
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/bank-accounts/[id]/route.ts
+++ b/app/api/routes-b/bank-accounts/[id]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -48,3 +49,5 @@ export async function GET(
     },
   });
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/bank-accounts/route.ts
+++ b/app/api/routes-b/bank-accounts/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -10,7 +11,7 @@ function isValidDigits(value: string, min: number, max: number) {
 }
 
 /** Lists the authenticated user's saved bank accounts (default account first). */
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -39,7 +40,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ bankAccounts })
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -123,3 +124,6 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json(bankAccount, { status: 201 })
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/branding/route.ts
+++ b/app/api/routes-b/branding/route.ts
@@ -1,7 +1,11 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
+import { logger } from '@/lib/logger'
 import { registerRoute } from '../_lib/openapi'
+import { hasTableColumn } from '../_lib/table-columns'
+import { brandingSchema, type BrandingPayload } from './schema'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -170,9 +174,8 @@ async function writeBranding(request: NextRequest) {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
   return writeBranding(request)
 }
 
-  return NextResponse.json({ branding });
-}
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/contacts/[id]/route.ts
+++ b/app/api/routes-b/contacts/[id]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -20,7 +21,7 @@ async function getAuthenticatedUser(request: NextRequest) {
   })
 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -57,7 +58,7 @@ export async function GET(
   }
 }
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -192,7 +193,7 @@ export async function PATCH(
   }
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -232,3 +233,7 @@ export async function DELETE(
     return NextResponse.json({ error: 'Failed to delete contact' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/contacts/export.csv/route.ts
+++ b/app/api/routes-b/contacts/export.csv/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -16,7 +17,7 @@ type ContactCsvRow = {
   updatedAt: Date
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -92,3 +93,4 @@ export async function GET(request: NextRequest) {
   })
 }
 
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/contacts/import/route.ts
+++ b/app/api/routes-b/contacts/import/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -30,7 +31,7 @@ registerRoute({
   tags: ['contacts']
 })
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   // Check authentication
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
@@ -233,3 +234,5 @@ export async function POST(request: NextRequest) {
     )
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/contacts/route.ts
+++ b/app/api/routes-b/contacts/route.ts
@@ -1,10 +1,11 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { listContacts } from '../_lib/contacts'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -41,3 +42,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to get contacts' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/credit-notes/[id]/pdf/route.ts
+++ b/app/api/routes-b/credit-notes/[id]/pdf/route.ts
@@ -1,14 +1,15 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { renderToStream } from '@react-pdf/renderer'
-import { getCreditNoteById } from '../../_lib/credit-notes'
-import { CreditNotePDF } from '../../_lib/CreditNotePDF'
+import { getCreditNoteById } from '../../../_lib/credit-notes'
+import { CreditNotePDF } from '../../../_lib/CreditNotePDF'
 import React from 'react'
 
 export const runtime = 'nodejs'
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -38,3 +39,5 @@ export async function GET(
     return NextResponse.json({ error: 'Failed to generate PDF' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/credit-notes/[id]/route.ts
+++ b/app/api/routes-b/credit-notes/[id]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -29,7 +30,7 @@ registerRoute({
   tags: ['credit-notes']
 })
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -52,7 +53,7 @@ export async function GET(
   }
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -74,3 +75,6 @@ export async function DELETE(
     return NextResponse.json({ error: 'Failed to delete credit note' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/credit-notes/route.ts
+++ b/app/api/routes-b/credit-notes/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -41,7 +42,7 @@ registerRoute({
   tags: ['credit-notes']
 })
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -59,7 +60,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -93,3 +94,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to create credit note' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/dashboard/route.ts
+++ b/app/api/routes-b/dashboard/route.ts
@@ -1,11 +1,14 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { normalizeCurrencyAmount } from '../_lib/amounts'
 
 const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
 type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -20,7 +23,11 @@ export async function GET(request: NextRequest) {
   const now = new Date()
   const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
 
-  const [invoiceStats, totalEarned, thisMonthEarned, recentTxns] = await Promise.all([
+  const sparklineEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1))
+  const sparklineStart = new Date(sparklineEnd)
+  sparklineStart.setUTCDate(sparklineStart.getUTCDate() - 14)
+
+  const [invoiceStats, totalEarned, thisMonthEarned, recentTxns, sparklineRows] = await Promise.all([
     prisma.invoice.groupBy({ by: ['status'], where: { userId: user.id }, _count: { id: true } }),
     prisma.transaction.aggregate({
       where: { userId: user.id, type: 'payment', status: 'completed' },
@@ -41,6 +48,17 @@ export async function GET(request: NextRequest) {
       take: 5,
       select: { id: true, type: true, amount: true, currency: true, createdAt: true },
     }),
+    prisma.$queryRaw<Array<{ day: Date; amount: unknown }>>(Prisma.sql`
+      SELECT DATE_TRUNC('day', "createdAt") AS day, COALESCE(SUM(amount), 0) AS amount
+      FROM "Transaction"
+      WHERE "userId" = ${user.id}
+        AND type = 'payment'
+        AND status = 'completed'
+        AND "createdAt" >= ${sparklineStart}
+        AND "createdAt" < ${sparklineEnd}
+      GROUP BY day
+      ORDER BY day ASC
+    `),
   ])
 
   const counts = INVOICE_STATUSES.reduce<Record<InvoiceStatus, number>>(
@@ -56,6 +74,24 @@ export async function GET(request: NextRequest) {
       counts[row.status as InvoiceStatus] = row._count.id
     }
   }
+
+  const sparklineByDate = new Map(
+    sparklineRows.map(row => [
+      row.day.toISOString().slice(0, 10),
+      normalizeCurrencyAmount(row.amount),
+    ]),
+  )
+
+  const sparklinePoints = Array.from({ length: 14 }, (_, index) => {
+    const date = new Date(sparklineStart)
+    date.setUTCDate(sparklineStart.getUTCDate() + index)
+    const key = date.toISOString().slice(0, 10)
+
+    return {
+      date: key,
+      amount: sparklineByDate.get(key) ?? 0,
+    }
+  })
 
   return NextResponse.json({
     summary: {
@@ -79,5 +115,11 @@ export async function GET(request: NextRequest) {
         createdAt: txn.createdAt,
       })),
     },
+    sparkline: {
+      days: 14,
+      points: sparklinePoints,
+    },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/exchange-rate/route.ts
+++ b/app/api/routes-b/exchange-rate/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { getCachedValue, setCachedValue } from '../_lib/cache'
 
@@ -24,7 +25,7 @@ function canBypassCache(request: NextRequest) {
   return providedToken === configuredToken
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const searchParams = new URL(request.url).searchParams
   const from = (searchParams.get('from') || 'USD').toUpperCase()
   const to = (searchParams.get('to') || 'NGN').toUpperCase()
@@ -121,3 +122,5 @@ export async function GET(request: NextRequest) {
     )
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/amount/route.ts
+++ b/app/api/routes-b/invoices/[id]/amount/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -54,3 +55,5 @@ export async function PATCH(
 
   return NextResponse.json({ ...updated, amount: Number(updated.amount) })
 }
+
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/invoices/[id]/client/route.ts
+++ b/app/api/routes-b/invoices/[id]/client/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -39,7 +40,7 @@ export async function GET(
   })
 }
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -105,3 +106,6 @@ export async function PATCH(
 
   return NextResponse.json(updated)
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/invoices/[id]/discount/route.ts
+++ b/app/api/routes-b/invoices/[id]/discount/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -40,7 +41,7 @@ registerRoute({
   tags: ['invoices']
 })
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -82,7 +83,7 @@ export async function POST(
   }
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -119,3 +120,6 @@ export async function DELETE(
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Failed to remove discount' }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/invoices/[id]/due-date/route.ts
+++ b/app/api/routes-b/invoices/[id]/due-date/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -91,3 +92,5 @@ export async function PATCH(
 
   return NextResponse.json(updatedInvoice, { status: 200 })
 }
+
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/invoices/[id]/duplicate/route.ts
+++ b/app/api/routes-b/invoices/[id]/duplicate/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { generateInvoiceNumber } from '@/lib/utils'
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -66,3 +67,5 @@ export async function POST(
     { status: 201 },
   )
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/[id]/messages/route.ts
+++ b/app/api/routes-b/invoices/[id]/messages/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -15,7 +16,7 @@ async function getAuthenticatedUser(request: NextRequest) {
   })
 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -53,7 +54,7 @@ export async function GET(
   return NextResponse.json({ messages })
 }
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -112,3 +113,6 @@ export async function POST(
 
   return NextResponse.json(message, { status: 201 })
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/[id]/payment-status/route.ts
+++ b/app/api/routes-b/invoices/[id]/payment-status/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 
-export async function GET(
+async function GETHandler(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -37,3 +38,5 @@ export async function GET(
     dueDate: invoice.dueDate,
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/pdf/route.ts
+++ b/app/api/routes-b/invoices/[id]/pdf/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -8,7 +9,7 @@ import React from 'react'
 
 export const runtime = 'nodejs'
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -82,3 +83,5 @@ export async function GET(
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/preview/route.ts
+++ b/app/api/routes-b/invoices/[id]/preview/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -76,3 +77,5 @@ export async function GET(
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/remind/route.ts
+++ b/app/api/routes-b/invoices/[id]/remind/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { sendEmail } from '@/lib/email'
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -82,3 +83,5 @@ export async function POST(
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/[id]/route.ts
+++ b/app/api/routes-b/invoices/[id]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -8,7 +9,7 @@ function isValidIsoDate(value: string) {
   return !Number.isNaN(date.getTime())
 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -74,7 +75,7 @@ export async function GET(
   return response
 }
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -200,3 +201,6 @@ export async function PATCH(
 
   return NextResponse.json({ ...updatedInvoice, amount: Number(updatedInvoice.amount) })
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/invoices/[id]/schedule/route.ts
+++ b/app/api/routes-b/invoices/[id]/schedule/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 /**
  * POST /api/routes-b/invoices/[id]/schedule
  * Schedule an invoice to be sent at a future date.
@@ -21,7 +22,7 @@ async function resolveUser(request: NextRequest) {
   return prisma.user.findUnique({ where: { privyId: claims.userId } })
 }
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -90,7 +91,7 @@ export async function POST(
   )
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -116,3 +117,6 @@ export async function DELETE(
 
   return NextResponse.json({ invoiceId: invoice.id, status: 'cancelled' })
 }
+
+export const POST = withRequestId(POSTHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/invoices/[id]/share-link/route.ts
+++ b/app/api/routes-b/invoices/[id]/share-link/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 /**
  * POST /api/routes-b/invoices/[id]/share-link
  * Mint a read-only share token for an invoice.
@@ -7,7 +8,7 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { mintShareToken } from '../../../_lib/share-tokens'
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -45,3 +46,5 @@ export async function POST(
     { status: 201 },
   )
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/[id]/tags/[tagId]/route.ts
+++ b/app/api/routes-b/invoices/[id]/tags/[tagId]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; tagId: string }> }
 ) {
@@ -41,3 +42,5 @@ export async function DELETE(
 
   return new NextResponse(null, { status: 204 })
 }
+
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/invoices/[id]/tags/route.ts
+++ b/app/api/routes-b/invoices/[id]/tags/route.ts
@@ -1,10 +1,11 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 
 // ── GET /api/routes-b/invoices/[id]/tags — get all tags for an invoice ──
-export async function GET(
+async function GETHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -50,7 +51,7 @@ export async function GET(
 }
 
 // ── POST /api/routes-b/invoices/[id]/tags — apply a tag to an invoice ──
-export async function POST(
+async function POSTHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -115,3 +116,6 @@ export async function POST(
         return NextResponse.json({ error: 'Failed to apply tag' }, { status: 500 })
     }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/cancelled/route.ts
+++ b/app/api/routes-b/invoices/cancelled/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     const claims = await verifyAuthToken(authToken || '')
     if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -62,3 +63,5 @@ export async function GET(request: NextRequest) {
         },
     })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/overdue/route.ts
+++ b/app/api/routes-b/invoices/overdue/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { Invoice } from '@prisma/client'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   // 1. Verify auth
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
@@ -56,3 +57,5 @@ export async function GET(request: NextRequest) {
     total: invoices.length,
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/paid/route.ts
+++ b/app/api/routes-b/invoices/paid/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -55,3 +56,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/pending/route.ts
+++ b/app/api/routes-b/invoices/pending/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -52,3 +53,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/public/[token]/route.ts
+++ b/app/api/routes-b/invoices/public/[token]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 /**
  * GET /api/routes-b/invoices/public/[token]
  * Read-only public view of an invoice via share token.
@@ -11,7 +12,7 @@ import { checkRateLimit } from '../../../_lib/rate-limit'
 
 const RATE_LIMIT = { limit: 60, windowMs: 60 * 60 * 1000 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ token: string }> },
 ) {
@@ -73,3 +74,5 @@ export async function GET(
     createdAt: invoice.createdAt,
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/route.ts
+++ b/app/api/routes-b/invoices/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -90,7 +91,7 @@ async function getUniqueInvoiceNumber() {
   throw new Error('Failed to generate a unique invoice number')
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const auth = await getAuthenticatedUser(request)
   if ('error' in auth) {
     return auth.error
@@ -166,7 +167,7 @@ export async function GET(request: NextRequest) {
   })
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const auth = await getAuthenticatedUser(request)
   if ('error' in auth) {
     return auth.error
@@ -243,3 +244,6 @@ export async function POST(request: NextRequest) {
     { status: 201 },
   )
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/summary/route.ts
+++ b/app/api/routes-b/invoices/summary/route.ts
@@ -1,10 +1,11 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { getInvoiceStatusSummary } from '../../_lib/aggregations'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -22,3 +23,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to get invoice summary' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/templates/[id]/instantiate/route.ts
+++ b/app/api/routes-b/invoices/templates/[id]/instantiate/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../../_lib/with-request-id'
 /**
  * POST /api/routes-b/invoices/templates/[id]/instantiate
  * Create a real invoice from a template and advance nextRunAt.
@@ -33,7 +34,7 @@ function cadenceWindowMs(cadence: string): number {
 // idempotency: track last instantiation per template
 const lastInstantiated = new Map<string, { invoiceId: string; at: Date }>()
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -108,3 +109,5 @@ export async function POST(
     { status: 201 },
   )
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/templates/[id]/route.ts
+++ b/app/api/routes-b/invoices/templates/[id]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 /**
  * GET    /api/routes-b/invoices/templates/[id]  - get a template
  * PATCH  /api/routes-b/invoices/templates/[id]  - update a template
@@ -21,7 +22,7 @@ function serialize(t: ReturnType<typeof getTemplateStore>['values'] extends Iter
   return { ...t, nextRunAt: t.nextRunAt.toISOString(), createdAt: t.createdAt.toISOString(), updatedAt: t.updatedAt.toISOString() }
 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -37,7 +38,7 @@ export async function GET(
   return NextResponse.json({ template: serialize(tpl) })
 }
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -89,7 +90,7 @@ export async function PATCH(
   return NextResponse.json({ template: serialize(tpl) })
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -105,3 +106,7 @@ export async function DELETE(
   getTemplateStore().delete(id)
   return new NextResponse(null, { status: 204 })
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/invoices/templates/route.ts
+++ b/app/api/routes-b/invoices/templates/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 /**
  * GET  /api/routes-b/invoices/templates  - list templates for user
  * POST /api/routes-b/invoices/templates  - create a template
@@ -39,7 +40,7 @@ export function clearTemplateStore() { templates.clear(); seq = 0 }
 
 function newId() { return `tpl_${++seq}_${Date.now()}` }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const user = await resolveUser(request)
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ templates: userTemplates.map(serialize) })
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const user = await resolveUser(request)
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
@@ -103,3 +104,6 @@ export async function POST(request: NextRequest) {
 function serialize(t: InvoiceTemplate) {
   return { ...t, nextRunAt: t.nextRunAt.toISOString(), createdAt: t.createdAt.toISOString(), updatedAt: t.updatedAt.toISOString() }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/notifications/[id]/read/route.ts
+++ b/app/api/routes-b/notifications/[id]/read/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -6,7 +7,7 @@ interface RouteParams {
   params: Promise<{ id: string }>
 }
 
-export async function PATCH(request: NextRequest, { params }: RouteParams) {
+async function PATCHHandler(request: NextRequest, { params }: RouteParams) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -47,3 +48,5 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
   return NextResponse.json(updated)
 }
+
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/notifications/mark-all-read/route.ts
+++ b/app/api/routes-b/notifications/mark-all-read/route.ts
@@ -1,9 +1,11 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { checkRateLimit } from '../../_lib/rate-limit'
+import { bustUnreadCountCache } from '../../_lib/notification-cache'
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -35,5 +37,9 @@ export async function POST(request: NextRequest) {
     data: { isRead: true },
   })
 
+  bustUnreadCountCache(user.id)
+
   return NextResponse.json({ updated: result.count })
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/notifications/preferences/route.ts
+++ b/app/api/routes-b/notifications/preferences/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../../_lib/authz'
@@ -14,7 +15,7 @@ function parsePrefs(raw?: string | null) {
   }
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const settings = await prisma.reminderSettings.findUnique({ where: { userId: auth.userId }, select: { customMessage: true } })
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const body = await request.json()
@@ -48,3 +49,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/notifications/route.ts
+++ b/app/api/routes-b/notifications/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -52,3 +53,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to get notifications' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/notifications/unread-count/route.ts
+++ b/app/api/routes-b/notifications/unread-count/route.ts
@@ -1,12 +1,15 @@
-import { withRequestId } from '../_lib/with-request-id'
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import {
+  getCachedUnreadCount,
+  setCachedUnreadCount,
+} from '../../_lib/notification-cache'
 
 async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
-
   if (!claims) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -16,18 +19,18 @@ async function GETHandler(request: NextRequest) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
-  const wallet = await prisma.wallet.findUnique({ where: { userId: user.id } })
-  if (!wallet) {
-    return NextResponse.json({ wallet: null }, { status: 200 })
+  const cached = getCachedUnreadCount(user.id)
+  if (cached !== null) {
+    return NextResponse.json({ count: cached })
   }
 
-  return NextResponse.json({
-    wallet: {
-      id: wallet.id,
-      stellarAddress: wallet.address,
-      createdAt: wallet.createdAt,
-    },
+  const count = await prisma.notification.count({
+    where: { userId: user.id, isRead: false },
   })
+
+  setCachedUnreadCount(user.id, count)
+
+  return NextResponse.json({ count })
 }
 
 export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/profile/avatar/finalize/route.ts
+++ b/app/api/routes-b/profile/avatar/finalize/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { generateCloudinaryUrl, isExpiredKey } from '../../_lib/presigned-upload'
+import { generateCloudinaryUrl, isExpiredKey } from '../../../_lib/presigned-upload'
 import { getMaxFileSize, isAllowedMimeType, sniffMimeType, stripExifMetadata } from '../../../_lib/file-signature'
 import { registerRoute } from '../../../_lib/openapi'
 import { z } from 'zod'
@@ -21,7 +22,7 @@ registerRoute({
   tags: ['profile']
 })
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -88,3 +89,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to finalize avatar upload' }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/profile/avatar/presign/route.ts
+++ b/app/api/routes-b/profile/avatar/presign/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { generatePresignedUpload } from '../../_lib/presigned-upload'
+import { generatePresignedUpload } from '../../../_lib/presigned-upload'
 import { registerRoute } from '../../../_lib/openapi'
 import { z } from 'zod'
 
@@ -20,7 +21,7 @@ registerRoute({
   tags: ['profile']
 })
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -49,3 +50,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to generate presigned upload URL' }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/profile/avatar/route.ts
+++ b/app/api/routes-b/profile/avatar/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -10,7 +11,7 @@ function isValidHttpsUrl(url: string): boolean {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -42,3 +43,5 @@ export async function PATCH(request: NextRequest) {
 
   return NextResponse.json({ avatarUrl: updatedUser.avatarUrl })
 }
+
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/profile/route.ts
+++ b/app/api/routes-b/profile/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -6,7 +7,7 @@ import { redactProfile, parseRevealQuery, isAdminRequest } from '../_lib/redact'
 
 // ── GET /api/routes-b/profile — get current user's profile ──────────
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -57,7 +58,7 @@ export async function GET(request: NextRequest) {
 
 // ── PATCH /api/routes-b/profile — update user's display name ────────
 
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -93,3 +94,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/reminder-settings/route.ts
+++ b/app/api/routes-b/reminder-settings/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -57,7 +58,7 @@ async function persistReminderChannel(userId: string, payload: ReminderSettingsP
   return payload.channel
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -104,7 +105,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -243,3 +244,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to update reminder settings' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)

--- a/app/api/routes-b/search/route.ts
+++ b/app/api/routes-b/search/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAuthToken } from '@/lib/auth'
 import { prisma } from '@/lib/db'
@@ -48,7 +49,7 @@ type Facets = {
   statuses: Record<string, number>
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -218,3 +219,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to search records' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/search/suggest/route.ts
+++ b/app/api/routes-b/search/suggest/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAuthToken } from '@/lib/auth'
 import { prisma } from '@/lib/db'
@@ -13,7 +14,7 @@ type Suggestion = {
   createdAt: Date
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -105,3 +106,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to fetch suggestions' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/stats/route.ts
+++ b/app/api/routes-b/stats/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../_lib/authz'
@@ -25,7 +26,7 @@ registerRoute({
   tags: ['stats']
 })
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const cacheKey = `routes-b:stats:${auth.userId}`
@@ -81,3 +82,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/tags/[id]/route.ts
+++ b/app/api/routes-b/tags/[id]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(
+async function GETHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -32,7 +33,7 @@ export async function GET(
     })
 }
 
-export async function PATCH(
+async function PATCHHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -123,7 +124,7 @@ export async function PATCH(
 }
 
 // DELETE /api/routes-b/tags/[id] - remove a tag and all its invoice associations
-export async function DELETE(
+async function DELETEHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -157,3 +158,7 @@ export async function DELETE(
         return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
     }
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/tags/route.ts
+++ b/app/api/routes-b/tags/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -40,7 +41,7 @@ registerRoute({
   tags: ['tags']
 })
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -69,7 +70,7 @@ export async function GET(request: NextRequest) {
   })
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -125,3 +126,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/tags/sweep/route.ts
+++ b/app/api/routes-b/tags/sweep/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { checkRateLimit } from '../../_lib/rate-limit'
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -62,3 +63,5 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json(result)
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/tokens/[id]/route.ts
+++ b/app/api/routes-b/tokens/[id]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../../_lib/authz'
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+async function DELETEHandler(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const token = await prisma.apiKey.findFirst({ where: { id: params.id, userId: auth.userId, name: { startsWith: 'routes-b-pat:' } } })
@@ -14,3 +15,5 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 }
+
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/tokens/route.ts
+++ b/app/api/routes-b/tokens/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import crypto from 'crypto'
 import { prisma } from '@/lib/db'
@@ -7,7 +8,7 @@ const CAP = 10
 
 function mask(token: string) { return `${token.slice(0, 6)}...${token.slice(-4)}` }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const count = await prisma.apiKey.count({ where: { userId: auth.userId, name: { startsWith: 'routes-b-pat:' }, isActive: true } })
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   }
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const tokens = await prisma.apiKey.findMany({ where: { userId: auth.userId, name: { startsWith: 'routes-b-pat:' } }, orderBy: { createdAt: 'desc' } })
@@ -35,3 +36,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/transactions/[id]/refund/route.ts
+++ b/app/api/routes-b/transactions/[id]/refund/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -23,7 +24,7 @@ registerRoute({
   tags: ['transactions']
 })
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -88,3 +89,5 @@ export async function POST(
     return NextResponse.json({ error: 'Failed to process refund' }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/transactions/[id]/route.ts
+++ b/app/api/routes-b/transactions/[id]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -49,3 +50,5 @@ export async function GET(
     },
   });
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/transactions/export/route.ts
+++ b/app/api/routes-b/transactions/export/route.ts
@@ -1,10 +1,11 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { createCsvStream } from '../../_lib/csv-stream'
 import type { Prisma } from '@prisma/client'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -90,3 +91,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/transactions/route.ts
+++ b/app/api/routes-b/transactions/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -17,7 +18,7 @@ function parseDateParam(value: string | null, fieldName: 'from' | 'to') {
   return { date }
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -107,3 +108,5 @@ export async function GET(request: NextRequest) {
     },
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/trust-score/route.ts
+++ b/app/api/routes-b/trust-score/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../_lib/authz'
@@ -70,7 +71,7 @@ async function recomputeTrustScore(userId: string): Promise<TrustScorePayload> {
   }
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const force = request.nextUrl.searchParams.get('force') === 'true'
@@ -98,3 +99,5 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/webhooks/[id]/dead-letters/[eventId]/replay/route.ts
+++ b/app/api/routes-b/webhooks/[id]/dead-letters/[eventId]/replay/route.ts
@@ -1,9 +1,10 @@
+import { withRequestId } from '../../../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { deadLetterQueue } from '../../../_lib/dead-letter'
-import { dispatchWebhookDelivery } from '../../../_lib/webhook-delivery'
-import { registerRoute } from '../../../../_lib/openapi'
+import { deadLetterQueue } from '../../../../../_lib/dead-letter'
+import { dispatchWebhookDelivery } from '../../../../../_lib/webhook-delivery'
+import { registerRoute } from '../../../../../_lib/openapi'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -24,7 +25,7 @@ registerRoute({
   tags: ['webhooks']
 })
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; eventId: string }> },
 ) {
@@ -94,3 +95,5 @@ export async function POST(
     }, { status: 500 })
   }
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/webhooks/[id]/dead-letters/route.ts
+++ b/app/api/routes-b/webhooks/[id]/dead-letters/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { deadLetterQueue } from '../../_lib/dead-letter'
+import { deadLetterQueue } from '../../../_lib/dead-letter'
 import { registerRoute } from '../../../_lib/openapi'
 import { z } from 'zod'
 
@@ -25,7 +26,7 @@ registerRoute({
   tags: ['webhooks']
 })
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -69,3 +70,5 @@ export async function GET(
     })),
   })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/webhooks/[id]/history/route.ts
+++ b/app/api/routes-b/webhooks/[id]/history/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { getWebhookHistory } from '../../_lib/webhook-history'
-import { registerRoute } from '../../_lib/openapi'
+import { getWebhookHistory } from '../../../_lib/webhook-history'
+import { registerRoute } from '../../../_lib/openapi'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -26,7 +27,7 @@ registerRoute({
   tags: ['webhooks']
 })
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
@@ -63,3 +64,5 @@ export async function GET(
     return NextResponse.json({ error: 'Failed to fetch webhook history' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/webhooks/[id]/reveal/route.ts
+++ b/app/api/routes-b/webhooks/[id]/reveal/route.ts
@@ -1,7 +1,8 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { rateLimit } from '../../_lib/rate-limit'
+import { rateLimit } from '../../../_lib/rate-limit'
 import { registerRoute } from '../../../_lib/openapi'
 import { z } from 'zod'
 
@@ -17,7 +18,7 @@ registerRoute({
   tags: ['webhooks']
 })
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -83,3 +84,5 @@ export async function POST(
     signingSecret: webhook.signingSecret,
   })
 }
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/webhooks/[id]/route.ts
+++ b/app/api/routes-b/webhooks/[id]/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -68,7 +69,7 @@ function isValidHttpsUrl(url: string) {
   }
 }
 
-export async function GET(
+async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -120,7 +121,7 @@ export async function GET(
   })
 }
 
-export async function PATCH(
+async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -212,7 +213,7 @@ export async function PATCH(
   })
 }
 
-export async function DELETE(
+async function DELETEHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -242,3 +243,7 @@ export async function DELETE(
 
   return new NextResponse(null, { status: 204 })
 }
+
+export const GET = withRequestId(GETHandler)
+export const PATCH = withRequestId(PATCHHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/webhooks/[id]/test/route.ts
+++ b/app/api/routes-b/webhooks/[id]/test/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -7,7 +8,7 @@ import { dispatchWebhookDelivery } from '../../../_lib/webhook-delivery'
 const TEST_DELIVERY_LIMIT = 10
 const TEST_DELIVERY_WINDOW_MS = 60 * 60 * 1000
 
-export async function POST(
+async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
@@ -74,3 +75,4 @@ export async function POST(
   return NextResponse.json({ outcome: result })
 }
 
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/webhooks/route.ts
+++ b/app/api/routes-b/webhooks/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -79,7 +80,7 @@ function isValidHttpsUrl(url: string) {
   }
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const user = await getAuthenticatedUser(request)
     if (!user) {
@@ -114,7 +115,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   try {
     const user = await getAuthenticatedUser(request)
     if (!user) {
@@ -229,3 +230,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Failed to register webhook' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/withdrawals/[id]/route.ts
+++ b/app/api/routes-b/withdrawals/[id]/route.ts
@@ -1,8 +1,9 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 
-export async function GET(
+async function GETHandler(
     request: NextRequest,
     { params }: { params: Promise<{ id: string }> }
 ) {
@@ -36,3 +37,5 @@ export async function GET(
         },
     })
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/withdrawals/estimate/route.ts
+++ b/app/api/routes-b/withdrawals/estimate/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 /**
  * GET /api/routes-b/withdrawals/estimate
  * Returns a fee estimate for a withdrawal without creating any records.
@@ -12,7 +13,7 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { calculateWithdrawalFee, isSupportedCurrency } from '../../_lib/withdrawal-fees'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -66,3 +67,5 @@ export async function GET(request: NextRequest) {
   const estimate = calculateWithdrawalFee(amount, currency)
   return NextResponse.json(estimate)
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/withdrawals/route.ts
+++ b/app/api/routes-b/withdrawals/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -7,7 +8,7 @@ import { calculateWithdrawalFee } from '../_lib/withdrawal-fees'
  * GET /api/routes-b/withdrawals
  * List withdrawal history for the authenticated user.
  */
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest) {
  * POST /api/routes-b/withdrawals
  * Record a new withdrawal request against a user's bank account.
  */
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
@@ -147,3 +148,6 @@ export async function POST(request: NextRequest) {
     { status: 201 },
   )
 }
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)


### PR DESCRIPTION
## Description
Adds routes-b request ID correlation, notification unread count, dashboard sparkline data, and audit-log CSV export.

Closes #550
Closes #543
Closes #559
Closes #560

## Changes proposed

### What were you told to do?
Implement four routes-b issues in one PR, keeping all new work inside app/api/routes-b.

### What did I do?
#### Request correlation
- Added a routes-b request-id wrapper.
- Echoes X-Request-Id on routes-b responses.
- Honors valid client-supplied UUID request ids.

#### Notifications
- Added GET /notifications/unread-count.
- Added 10s per-user cache and cache busting on mark-all-read.

#### Dashboard
- Added 14-day sparkline data with zero-filled daily points.

#### Audit log
- Added streaming CSV export for invoice audit logs.
- Reused CSV streaming helper and applied filters plus 50k row cap.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Routes-b Vitest suite passed: 73 tests before upstream merge conflict resolution.
- Conflict resolution pulled upstream/main and preserved upstream routes-b additions plus this PR's request-id, unread count, sparkline, and audit CSV changes.