### PR TITLE
Implements four routes-b features

### DIFF
--- a/app/api/routes-b/_lib/account-state.ts
+++ b/app/api/routes-b/_lib/account-state.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+
+const DELETION_WINDOW_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+
+export type DeletionRequest = {
+  requestedAt: Date
+  token: string
+}
+
+// In-process store: userId → deletion request
+const deletionStore = new Map<string, DeletionRequest>()
+
+export function requestAccountDeletion(userId: string): { token: string; deletesAt: Date } {
+  const token = crypto.randomUUID()
+  const requestedAt = new Date()
+  deletionStore.set(userId, { requestedAt, token })
+  return { token, deletesAt: new Date(requestedAt.getTime() + DELETION_WINDOW_MS) }
+}
+
+export function cancelAccountDeletion(userId: string): boolean {
+  if (!deletionStore.has(userId)) return false
+  deletionStore.delete(userId)
+  return true
+}
+
+export function getDeletionRequest(userId: string): DeletionRequest | null {
+  return deletionStore.get(userId) ?? null
+}
+
+export function isAccountPendingDeletion(userId: string): boolean {
+  const req = deletionStore.get(userId)
+  if (!req) return false
+  const windowEnd = req.requestedAt.getTime() + DELETION_WINDOW_MS
+  if (Date.now() >= windowEnd) {
+    // Window has passed — clean up
+    deletionStore.delete(userId)
+    return false
+  }
+  return true
+}
+
+export function getDeletionWindowEnd(userId: string): Date | null {
+  const req = deletionStore.get(userId)
+  if (!req) return null
+  return new Date(req.requestedAt.getTime() + DELETION_WINDOW_MS)
+}
+
+/**
+ * Returns a 423 Locked response if the account has an active deletion window,
+ * otherwise returns null (caller may proceed).
+ */
+export function checkAccountLocked(userId: string): NextResponse | null {
+  if (isAccountPendingDeletion(userId)) {
+    return NextResponse.json(
+      { error: 'Account is pending deletion', code: 'ACCOUNT_LOCKED' },
+      { status: 423 },
+    )
+  }
+  return null
+}

--- a/app/api/routes-b/_lib/date-range.ts
+++ b/app/api/routes-b/_lib/date-range.ts
@@ -2,6 +2,211 @@ const DEFAULT_RANGE_DAYS = 30
 const MAX_RANGE_DAYS = 366
 const DAY_IN_MS = 24 * 60 * 60 * 1000
 
+// ── Timezone helpers ──────────────────────────────────────────────────────────
+
+export function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Returns the UTC instant that corresponds to local midnight (00:00:00) on
+ * `dateStr` (YYYY-MM-DD) in timezone `tz`.
+ *
+ * Uses two iterations so DST-transition days (where the UTC offset at noon
+ * differs from the offset at midnight) are handled correctly.
+ */
+export function localMidnightToUtc(dateStr: string, tz: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number)
+
+  // Start with UTC midnight as the initial candidate.
+  let candidate = new Date(Date.UTC(year, month - 1, day, 0, 0, 0))
+
+  for (let i = 0; i < 2; i++) {
+    const localStr = candidate.toLocaleString('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+
+    // en-US format: "MM/DD/YYYY, HH:MM:SS"
+    const [datePart, timePart] = localStr.split(', ')
+    const [lm, ld, ly] = datePart.split('/').map(Number)
+    const [lh, lmin, ls] = timePart.split(':').map(Number)
+    const hour = lh === 24 ? 0 : lh
+
+    // Delta from the target local midnight (treating dates as UTC for arithmetic)
+    const currentLocalMs = Date.UTC(ly, lm - 1, ld, hour, lmin, ls)
+    const targetLocalMs = Date.UTC(year, month - 1, day, 0, 0, 0)
+    candidate = new Date(candidate.getTime() - (currentLocalMs - targetLocalMs))
+  }
+
+  return candidate
+}
+
+export type ParsedTzDateRange =
+  | {
+      ok: true
+      value: {
+        from: Date
+        to: Date
+        toExclusive: Date
+        days: number
+        tz: string
+      }
+    }
+  | {
+      ok: false
+      error: {
+        error: string
+        fields: Record<string, string>
+      }
+    }
+
+/**
+ * Like `parseUtcDateRange` but projects local-day boundaries to UTC ranges
+ * using the supplied (or default) IANA timezone.
+ *
+ * Falls back to `defaultTz` (e.g. user.timezone) then UTC when `tz` param is absent.
+ * Returns 400-shaped error when the timezone name is not a valid IANA identifier.
+ */
+export function parseTzDateRange(
+  searchParams: URLSearchParams,
+  defaultTz?: string | null,
+  now = new Date(),
+): ParsedTzDateRange {
+  const rawTz = searchParams.get('tz') ?? defaultTz ?? 'UTC'
+
+  if (!isValidTimezone(rawTz)) {
+    return {
+      ok: false,
+      error: {
+        error: 'Invalid timezone',
+        fields: { tz: `"${rawTz}" is not a valid IANA timezone name` },
+      },
+    }
+  }
+
+  const rawFrom = searchParams.get('from')
+  const rawTo = searchParams.get('to')
+  const fields: Record<string, string> = {}
+
+  // Default range: last DEFAULT_RANGE_DAYS local days ending today in `tz`
+  const todayLocalStr = now
+    .toLocaleDateString('en-CA', { timeZone: rawTz }) // YYYY-MM-DD
+  const todayLocal = todayLocalStr
+
+  function parseDateStr(value: string, field: 'from' | 'to') {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return { ok: false as const, message: `${field} must use YYYY-MM-DD format` }
+    }
+    // Light validation: create UTC date and check it's not NaN
+    if (Number.isNaN(new Date(`${value}T00:00:00.000Z`).getTime())) {
+      return { ok: false as const, message: `${field} must be a valid date` }
+    }
+    return { ok: true as const, value }
+  }
+
+  let fromStr = todayLocal
+  let toStr = todayLocal
+
+  if (rawFrom) {
+    const p = parseDateStr(rawFrom, 'from')
+    if (!p.ok) fields.from = p.message
+    else fromStr = p.value
+  }
+
+  if (rawTo) {
+    const p = parseDateStr(rawTo, 'to')
+    if (!p.ok) fields.to = p.message
+    else toStr = p.value
+  }
+
+  if (Object.keys(fields).length > 0) {
+    return { ok: false, error: { error: 'Invalid date range', fields } }
+  }
+
+  // Apply defaults mirroring parseUtcDateRange behaviour
+  if (!rawFrom && !rawTo) {
+    // subtract DEFAULT_RANGE_DAYS-1 days from today in local space
+    const todayUtcMidnight = localMidnightToUtc(todayLocal, rawTz)
+    const fromUtcMidnight = new Date(todayUtcMidnight.getTime() - (DEFAULT_RANGE_DAYS - 1) * DAY_IN_MS)
+    fromStr = fromUtcMidnight.toLocaleDateString('en-CA', { timeZone: rawTz })
+  } else if (!rawFrom) {
+    const toUtcMidnight = localMidnightToUtc(toStr, rawTz)
+    const fromUtcMidnight = new Date(toUtcMidnight.getTime() - (DEFAULT_RANGE_DAYS - 1) * DAY_IN_MS)
+    fromStr = fromUtcMidnight.toLocaleDateString('en-CA', { timeZone: rawTz })
+  } else if (!rawTo) {
+    const fromUtcMidnight = localMidnightToUtc(fromStr, rawTz)
+    const toUtcMidnight = new Date(fromUtcMidnight.getTime() + (DEFAULT_RANGE_DAYS - 1) * DAY_IN_MS)
+    toStr = toUtcMidnight.toLocaleDateString('en-CA', { timeZone: rawTz })
+  }
+
+  const from = localMidnightToUtc(fromStr, rawTz)
+  const toMidnight = localMidnightToUtc(toStr, rawTz)
+
+  if (from.getTime() > toMidnight.getTime()) {
+    return {
+      ok: false,
+      error: {
+        error: 'Invalid date range',
+        fields: {
+          from: 'from must be on or before to',
+          to: 'to must be on or after from',
+        },
+      },
+    }
+  }
+
+  // Count local days (by iterating local date strings)
+  let days = 0
+  let cursor = from
+  while (cursor.getTime() <= toMidnight.getTime()) {
+    days++
+    cursor = new Date(cursor.getTime() + DAY_IN_MS)
+  }
+
+  if (days > MAX_RANGE_DAYS) {
+    return {
+      ok: false,
+      error: {
+        error: 'Invalid date range',
+        fields: {
+          from: `date range cannot exceed ${MAX_RANGE_DAYS} days`,
+          to: `date range cannot exceed ${MAX_RANGE_DAYS} days`,
+        },
+      },
+    }
+  }
+
+  // toExclusive = start of the next local day after toStr
+  const toExclusive = localMidnightToUtc(toStr, rawTz)
+  // advance by one full day in UTC then re-anchor to local midnight
+  const nextDayStr = new Date(toExclusive.getTime() + DAY_IN_MS)
+    .toLocaleDateString('en-CA', { timeZone: rawTz })
+  const toExclusiveDate = localMidnightToUtc(nextDayStr, rawTz)
+
+  return {
+    ok: true,
+    value: {
+      from,
+      to: toMidnight,
+      toExclusive: toExclusiveDate,
+      days,
+      tz: rawTz,
+    },
+  }
+}
+
 export type ParsedDateRange =
   | {
       ok: true

--- a/app/api/routes-b/_lib/swr-cache.ts
+++ b/app/api/routes-b/_lib/swr-cache.ts
@@ -1,0 +1,45 @@
+export type SwrEntry<T> = {
+  value: T
+  fetchedAt: number
+  freshUntil: number
+  staleUntil: number
+}
+
+const swrStore = new Map<string, SwrEntry<unknown>>()
+
+export function swrGet<T>(key: string): SwrEntry<T> | null {
+  const entry = swrStore.get(key)
+  if (!entry) return null
+  if (Date.now() > entry.staleUntil) {
+    swrStore.delete(key)
+    return null
+  }
+  return entry as SwrEntry<T>
+}
+
+export function swrSet<T>(key: string, value: T, freshMs: number, staleMs: number): void {
+  const now = Date.now()
+  swrStore.set(key, {
+    value,
+    fetchedAt: now,
+    freshUntil: now + freshMs,
+    staleUntil: now + staleMs,
+  })
+}
+
+export function swrDelete(key: string): void {
+  swrStore.delete(key)
+}
+
+export function swrClear(): void {
+  swrStore.clear()
+}
+
+export function swrIsFresh(entry: SwrEntry<unknown>): boolean {
+  return Date.now() < entry.freshUntil
+}
+
+export function swrIsStale(entry: SwrEntry<unknown>): boolean {
+  const now = Date.now()
+  return now >= entry.freshUntil && now < entry.staleUntil
+}

--- a/app/api/routes-b/analytics/earnings/route.ts
+++ b/app/api/routes-b/analytics/earnings/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
-import { parseUtcDateRange } from '../../_lib/date-range'
+import { parseTzDateRange } from '../../_lib/date-range'
 
 export async function GET(request: NextRequest) {
   try {
@@ -18,6 +18,7 @@ export async function GET(request: NextRequest) {
 
     const user = await prisma.user.findUnique({
       where: { privyId: claims.userId },
+      select: { id: true, timezone: true },
     })
 
     if (!user) {
@@ -25,12 +26,12 @@ export async function GET(request: NextRequest) {
     }
 
     const url = new URL(request.url)
-    const parsedRange = parseUtcDateRange(url.searchParams)
+    const parsedRange = parseTzDateRange(url.searchParams, user.timezone)
     if (!parsedRange.ok) {
       return NextResponse.json(parsedRange.error, { status: 400 })
     }
 
-    const { from, to, toExclusive, days } = parsedRange.value
+    const { from, to, toExclusive, days, tz } = parsedRange.value
     const where = {
       userId: user.id,
       type: 'payment',
@@ -50,9 +51,10 @@ export async function GET(request: NextRequest) {
       earnings: {
         totalEarned: Number(total._sum.amount ?? 0),
         currency: 'USDC',
-        from: from.toISOString().slice(0, 10),
-        to: to.toISOString().slice(0, 10),
+        from: from.toLocaleDateString('en-CA', { timeZone: tz }),
+        to: to.toLocaleDateString('en-CA', { timeZone: tz }),
         days,
+        tz,
       },
     })
   } catch (error) {

--- a/app/api/routes-b/analytics/top-months/route.ts
+++ b/app/api/routes-b/analytics/top-months/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { isValidTimezone } from '../../_lib/date-range'
 
-/**
- * GET /api/routes-b/analytics/top-months
- * Returns the three calendar months with the highest paid invoice totals for the authenticated user.
- */
 export async function GET(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -14,35 +11,42 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true, timezone: true },
+    })
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // Fetch all paid invoices for the user
+    const url = new URL(request.url)
+    const rawTz = url.searchParams.get('tz') ?? user.timezone ?? 'UTC'
+    if (!isValidTimezone(rawTz)) {
+      return NextResponse.json(
+        { error: 'Invalid timezone', fields: { tz: `"${rawTz}" is not a valid IANA timezone name` } },
+        { status: 400 },
+      )
+    }
+
     const paid = await prisma.invoice.findMany({
       where: { userId: user.id, status: 'paid' },
       select: { amount: true, paidAt: true },
     })
 
-    // Group by "YYYY-MM" in application code (Prisma does not support month-level groupBy portably)
+    // Group by local "YYYY-MM" in the requested timezone
     const monthly: Record<string, number> = {}
     for (const inv of paid) {
       if (!inv.paidAt) continue
-      const key = inv.paidAt.toISOString().slice(0, 7) // "2025-01"
+      const key = inv.paidAt.toLocaleDateString('en-CA', { timeZone: rawTz }).slice(0, 7)
       monthly[key] = (monthly[key] ?? 0) + Number(inv.amount)
     }
 
-    // Sort by earned amount descending and take top 3
     const topMonths = Object.entries(monthly)
       .sort(([, a], [, b]) => b - a)
       .slice(0, 3)
-      .map(([month, earned]) => ({ 
-        month, 
-        earned: Number(earned.toFixed(2)) 
-      }))
+      .map(([month, earned]) => ({ month, earned: Number(earned.toFixed(2)) }))
 
-    return NextResponse.json({ topMonths })
+    return NextResponse.json({ topMonths, tz: rawTz })
   } catch (error) {
     console.error('Top months analytics error:', error)
     return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 })

--- a/app/api/routes-b/analytics/withdrawals/route.ts
+++ b/app/api/routes-b/analytics/withdrawals/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
+import { parseTzDateRange } from '../../_lib/date-range'
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,12 +16,26 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true, timezone: true },
+    })
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    const where = { userId: user.id, type: 'withdrawal' }
+    const url = new URL(request.url)
+    const parsedRange = parseTzDateRange(url.searchParams, user.timezone)
+    if (!parsedRange.ok) {
+      return NextResponse.json(parsedRange.error, { status: 400 })
+    }
+
+    const { from, toExclusive, tz } = parsedRange.value
+    const where = {
+      userId: user.id,
+      type: 'withdrawal',
+      createdAt: { gte: from, lt: toExclusive },
+    }
 
     const [total, completed, pending, failed] = await Promise.all([
       prisma.transaction.aggregate({
@@ -46,6 +61,7 @@ export async function GET(request: NextRequest) {
         pendingCount: pending,
         failedCount: failed,
         currency: 'USDC',
+        tz,
       },
     })
   } catch (error) {

--- a/app/api/routes-b/profile/delete-cancel/route.ts
+++ b/app/api/routes-b/profile/delete-cancel/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import {
+  cancelAccountDeletion,
+  isAccountPendingDeletion,
+} from '../../_lib/account-state'
+
+export async function POST(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    if (!isAccountPendingDeletion(user.id)) {
+      return NextResponse.json(
+        { error: 'No active deletion request found or window has already closed' },
+        { status: 409 },
+      )
+    }
+
+    const cancelled = cancelAccountDeletion(user.id)
+    if (!cancelled) {
+      return NextResponse.json(
+        { error: 'Could not cancel deletion request' },
+        { status: 500 },
+      )
+    }
+
+    await prisma.auditEvent.create({
+      data: {
+        userId: user.id,
+        action: 'ACCOUNT_DELETION_CANCELLED',
+        entityType: 'User',
+        entityId: user.id,
+        metadata: {
+          cancelledAt: new Date().toISOString(),
+        },
+      },
+    })
+
+    return NextResponse.json({ message: 'Account deletion cancelled successfully.' })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B profile delete-cancel POST error')
+    return NextResponse.json({ error: 'Failed to cancel account deletion' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/profile/delete-request/route.ts
+++ b/app/api/routes-b/profile/delete-request/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import {
+  requestAccountDeletion,
+  isAccountPendingDeletion,
+  getDeletionWindowEnd,
+} from '../../_lib/account-state'
+
+export async function POST(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    // If already pending, return the existing window end instead of creating a new request
+    if (isAccountPendingDeletion(user.id)) {
+      const deletesAt = getDeletionWindowEnd(user.id)
+      return NextResponse.json(
+        { message: 'Account deletion already requested', deletesAt: deletesAt?.toISOString() },
+        { status: 200 },
+      )
+    }
+
+    const { token, deletesAt } = requestAccountDeletion(user.id)
+
+    await prisma.auditEvent.create({
+      data: {
+        userId: user.id,
+        action: 'ACCOUNT_DELETION_REQUESTED',
+        entityType: 'User',
+        entityId: user.id,
+        metadata: {
+          requestedAt: new Date().toISOString(),
+          deletesAt: deletesAt.toISOString(),
+        },
+      },
+    })
+
+    return NextResponse.json({
+      message: 'Account deletion requested. You have 14 days to cancel.',
+      confirmationToken: token,
+      deletesAt: deletesAt.toISOString(),
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B profile delete-request POST error')
+    return NextResponse.json({ error: 'Failed to request account deletion' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/search/saved/[id]/route.ts
+++ b/app/api/routes-b/search/saved/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { id } = await params
+    const saved = await (prisma as any).savedSearch.findFirst({
+      where: { id, userId: user.id },
+      select: { id: true, name: true, query: true, filters: true, createdAt: true },
+    })
+
+    if (!saved) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    return NextResponse.json({ savedQuery: saved })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B saved search [id] GET error')
+    return NextResponse.json({ error: 'Failed to get saved search' }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { id } = await params
+    const existing = await (prisma as any).savedSearch.findFirst({
+      where: { id, userId: user.id },
+    })
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    await (prisma as any).savedSearch.delete({ where: { id } })
+
+    return new NextResponse(null, { status: 204 })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B saved search [id] DELETE error')
+    return NextResponse.json({ error: 'Failed to delete saved search' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/search/saved/[id]/run/route.ts
+++ b/app/api/routes-b/search/saved/[id]/run/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { id } = await params
+    const savedSearch = await (prisma as any).savedSearch.findFirst({
+      where: { id, userId: user.id },
+    })
+
+    if (!savedSearch) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+    const q: string = savedSearch.query
+    const filters = savedSearch.filters as { type?: string } | null
+    const filterType = filters?.type as
+      | 'invoices'
+      | 'bank-accounts'
+      | 'contacts'
+      | 'tags'
+      | null
+      | undefined
+
+    const [invoices, bankAccounts, contacts, tags] = await Promise.all([
+      filterType && filterType !== 'invoices'
+        ? Promise.resolve([])
+        : prisma.invoice.findMany({
+            where: {
+              userId: user.id,
+              OR: [
+                { invoiceNumber: { contains: q, mode: 'insensitive' } },
+                { clientName: { contains: q, mode: 'insensitive' } },
+                { clientEmail: { contains: q, mode: 'insensitive' } },
+                { description: { contains: q, mode: 'insensitive' } },
+              ],
+            },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+            select: {
+              id: true,
+              invoiceNumber: true,
+              clientName: true,
+              amount: true,
+              status: true,
+            },
+          }),
+      filterType && filterType !== 'bank-accounts'
+        ? Promise.resolve([])
+        : prisma.bankAccount.findMany({
+            where: {
+              userId: user.id,
+              OR: [
+                { bankName: { contains: q, mode: 'insensitive' } },
+                { accountName: { contains: q, mode: 'insensitive' } },
+                { accountNumber: { contains: q } },
+              ],
+            },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+          }),
+      filterType && filterType !== 'contacts'
+        ? Promise.resolve([])
+        : prisma.contact.findMany({
+            where: {
+              userId: user.id,
+              OR: [
+                { name: { contains: q, mode: 'insensitive' } },
+                { email: { contains: q, mode: 'insensitive' } },
+                { company: { contains: q, mode: 'insensitive' } },
+              ],
+            },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+          }),
+      filterType && filterType !== 'tags'
+        ? Promise.resolve([])
+        : prisma.tag.findMany({
+            where: { userId: user.id, name: { contains: q, mode: 'insensitive' } },
+            take: 10,
+            orderBy: { createdAt: 'desc' },
+          }),
+    ])
+
+    return NextResponse.json({
+      query: q,
+      savedSearchId: id,
+      results: { invoices, bankAccounts, contacts, tags },
+      facets: {
+        types: {
+          invoice: invoices.length,
+          bankAccount: bankAccounts.length,
+          contact: contacts.length,
+          tag: tags.length,
+        },
+        statuses: {},
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B saved search run error')
+    return NextResponse.json({ error: 'Failed to run saved search' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/search/saved/route.ts
+++ b/app/api/routes-b/search/saved/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { logger } from '@/lib/logger'
+
+const SAVED_QUERY_CAP = 50
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const savedQueries = await (prisma as any).savedSearch.findMany({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, name: true, query: true, filters: true, createdAt: true },
+    })
+
+    return NextResponse.json({ savedQueries })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B saved search GET error')
+    return NextResponse.json({ error: 'Failed to list saved searches' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const body = await request.json()
+
+    if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+    if (body.name.length > 100) {
+      return NextResponse.json({ error: 'name must be 100 characters or fewer' }, { status: 400 })
+    }
+    if (!body.query || typeof body.query !== 'string' || body.query.trim().length === 0) {
+      return NextResponse.json({ error: 'query is required' }, { status: 400 })
+    }
+
+    const count = await (prisma as any).savedSearch.count({ where: { userId: user.id } })
+    if (count >= SAVED_QUERY_CAP) {
+      return NextResponse.json(
+        { error: `Saved query limit of ${SAVED_QUERY_CAP} reached` },
+        { status: 422 },
+      )
+    }
+
+    const saved = await (prisma as any).savedSearch.create({
+      data: {
+        userId: user.id,
+        name: body.name.trim(),
+        query: body.query.trim(),
+        filters: body.filters ?? null,
+      },
+      select: { id: true, name: true, query: true, filters: true, createdAt: true },
+    })
+
+    return NextResponse.json({ savedQuery: saved }, { status: 201 })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B saved search POST error')
+    return NextResponse.json({ error: 'Failed to create saved search' }, { status: 500 })
+  }
+}

--- a/app/api/routes-b/tests/account-deletion.test.ts
+++ b/app/api/routes-b/tests/account-deletion.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  requestAccountDeletion,
+  cancelAccountDeletion,
+  isAccountPendingDeletion,
+  getDeletionRequest,
+  getDeletionWindowEnd,
+  checkAccountLocked,
+} from '../_lib/account-state'
+
+// ── account-state pure logic ──────────────────────────────────────────────────
+
+describe('account-state helpers', () => {
+  const userId = 'user-state-test'
+
+  beforeEach(() => {
+    // Cancel any leftover request from previous test
+    cancelAccountDeletion(userId)
+  })
+
+  it('isAccountPendingDeletion returns false before any request', () => {
+    expect(isAccountPendingDeletion(userId)).toBe(false)
+  })
+
+  it('requestAccountDeletion marks account pending and returns token + deletesAt', () => {
+    const before = Date.now()
+    const { token, deletesAt } = requestAccountDeletion(userId)
+    const after = Date.now()
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(0)
+    const windowMs = 14 * 24 * 60 * 60 * 1000
+    expect(deletesAt.getTime()).toBeGreaterThanOrEqual(before + windowMs)
+    expect(deletesAt.getTime()).toBeLessThanOrEqual(after + windowMs)
+    expect(isAccountPendingDeletion(userId)).toBe(true)
+  })
+
+  it('cancelAccountDeletion within window removes the request', () => {
+    requestAccountDeletion(userId)
+    expect(isAccountPendingDeletion(userId)).toBe(true)
+    const result = cancelAccountDeletion(userId)
+    expect(result).toBe(true)
+    expect(isAccountPendingDeletion(userId)).toBe(false)
+  })
+
+  it('cancelAccountDeletion returns false when no pending request exists', () => {
+    expect(cancelAccountDeletion(userId)).toBe(false)
+  })
+
+  it('getDeletionRequest returns null when no request', () => {
+    expect(getDeletionRequest(userId)).toBeNull()
+  })
+
+  it('getDeletionRequest returns the stored entry after requesting', () => {
+    requestAccountDeletion(userId)
+    const req = getDeletionRequest(userId)
+    expect(req).not.toBeNull()
+    expect(req!.token).toBeTruthy()
+    expect(req!.requestedAt).toBeInstanceOf(Date)
+  })
+
+  it('getDeletionWindowEnd returns null when no request', () => {
+    expect(getDeletionWindowEnd(userId)).toBeNull()
+  })
+
+  it('getDeletionWindowEnd returns a date 14 days from requestedAt', () => {
+    requestAccountDeletion(userId)
+    const end = getDeletionWindowEnd(userId)
+    expect(end).toBeInstanceOf(Date)
+    const req = getDeletionRequest(userId)!
+    expect(end!.getTime()).toBe(req.requestedAt.getTime() + 14 * 24 * 60 * 60 * 1000)
+  })
+
+  it('checkAccountLocked returns null when account is not locked', () => {
+    expect(checkAccountLocked(userId)).toBeNull()
+  })
+
+  it('checkAccountLocked returns 423 response when account is locked', () => {
+    requestAccountDeletion(userId)
+    const response = checkAccountLocked(userId)
+    expect(response).not.toBeNull()
+    expect(response!.status).toBe(423)
+  })
+
+  it('isAccountPendingDeletion returns false after window expires (time-travel)', () => {
+    // Manually insert an expired entry by overriding clock via requestedAt manipulation
+    const { } = requestAccountDeletion(userId)
+    const req = getDeletionRequest(userId)!
+    // Backdate requestedAt by 15 days
+    req.requestedAt = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000)
+    expect(isAccountPendingDeletion(userId)).toBe(false)
+  })
+})
+
+// ── Route handler tests ───────────────────────────────────────────────────────
+
+const mockAuditCreate = vi.hoisted(() => vi.fn().mockResolvedValue({}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn().mockResolvedValue({ userId: 'privy-1' }),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'user-route-1', privyId: 'privy-1' }),
+    },
+    auditEvent: {
+      create: mockAuditCreate,
+    },
+  },
+}))
+
+import { POST as deleteRequest } from '../profile/delete-request/route'
+import { POST as deleteCancel } from '../profile/delete-cancel/route'
+import { prisma } from '@/lib/db'
+
+function req(url: string) {
+  return new Request(url, {
+    method: 'POST',
+    headers: { authorization: 'Bearer tok' },
+  }) as any
+}
+
+// Use a dedicated userId for route tests to avoid collision with unit tests above
+const ROUTE_USER_ID = 'user-route-1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    id: ROUTE_USER_ID,
+    privyId: 'privy-1',
+  } as any)
+  mockAuditCreate.mockResolvedValue({})
+  // Ensure no leftover deletion state
+  cancelAccountDeletion(ROUTE_USER_ID)
+})
+
+describe('POST /profile/delete-request', () => {
+  it('returns 201-shape with token and deletesAt', async () => {
+    const res = await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('confirmationToken')
+    expect(body).toHaveProperty('deletesAt')
+    expect(body.message).toMatch(/14 days/)
+  })
+
+  it('writes an audit event on request', async () => {
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    expect(mockAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'ACCOUNT_DELETION_REQUESTED' }),
+      }),
+    )
+  })
+
+  it('marks the account as locked after requesting', async () => {
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    expect(isAccountPendingDeletion(ROUTE_USER_ID)).toBe(true)
+  })
+
+  it('returns 200 idempotently if already pending', async () => {
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    // Request again
+    const res2 = await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    expect(res2.status).toBe(200)
+    const body = await res2.json()
+    expect(body.message).toMatch(/already requested/)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await deleteRequest(
+      new Request('http://localhost/api/routes-b/profile/delete-request', { method: 'POST' }) as any,
+    )
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('POST /profile/delete-cancel', () => {
+  it('returns 200 after successful cancel within window', async () => {
+    // First: request deletion
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    // Then: cancel
+    const res = await deleteCancel(req('http://localhost/api/routes-b/profile/delete-cancel'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toMatch(/cancelled/)
+  })
+
+  it('writes an audit event on cancel', async () => {
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    mockAuditCreate.mockClear()
+    await deleteCancel(req('http://localhost/api/routes-b/profile/delete-cancel'))
+    expect(mockAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ action: 'ACCOUNT_DELETION_CANCELLED' }),
+      }),
+    )
+  })
+
+  it('clears the lock after cancel', async () => {
+    await deleteRequest(req('http://localhost/api/routes-b/profile/delete-request'))
+    await deleteCancel(req('http://localhost/api/routes-b/profile/delete-cancel'))
+    expect(isAccountPendingDeletion(ROUTE_USER_ID)).toBe(false)
+  })
+
+  it('returns 409 when no active deletion request exists', async () => {
+    const res = await deleteCancel(req('http://localhost/api/routes-b/profile/delete-cancel'))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 409 after window has already expired', async () => {
+    // Set up an expired deletion request
+    requestAccountDeletion(ROUTE_USER_ID)
+    const req2 = getDeletionRequest(ROUTE_USER_ID)!
+    req2.requestedAt = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000)
+
+    // isAccountPendingDeletion should now return false (expired)
+    const res = await deleteCancel(req('http://localhost/api/routes-b/profile/delete-cancel'))
+    expect(res.status).toBe(409)
+  })
+})
+
+describe('checkAccountLocked gating', () => {
+  it('checkAccountLocked returns 423 for locked account', () => {
+    requestAccountDeletion(ROUTE_USER_ID)
+    const response = checkAccountLocked(ROUTE_USER_ID)
+    expect(response).not.toBeNull()
+    expect(response!.status).toBe(423)
+  })
+
+  it('checkAccountLocked returns null for unlocked account', () => {
+    cancelAccountDeletion(ROUTE_USER_ID)
+    expect(checkAccountLocked(ROUTE_USER_ID)).toBeNull()
+  })
+
+  it('gating unblocks after cancellation', async () => {
+    requestAccountDeletion(ROUTE_USER_ID)
+    expect(checkAccountLocked(ROUTE_USER_ID)!.status).toBe(423)
+    cancelAccountDeletion(ROUTE_USER_ID)
+    expect(checkAccountLocked(ROUTE_USER_ID)).toBeNull()
+  })
+})

--- a/app/api/routes-b/tests/saved-search.test.ts
+++ b/app/api/routes-b/tests/saved-search.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockSavedSearch = vi.hoisted(() => ({
+  count: vi.fn(),
+  findMany: vi.fn(),
+  findFirst: vi.fn(),
+  create: vi.fn(),
+  delete: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn().mockResolvedValue({ userId: 'privy-1' }),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'user-1', privyId: 'privy-1' }),
+    },
+    invoice: { findMany: vi.fn().mockResolvedValue([]) },
+    bankAccount: { findMany: vi.fn().mockResolvedValue([]) },
+    contact: { findMany: vi.fn().mockResolvedValue([]) },
+    tag: { findMany: vi.fn().mockResolvedValue([]) },
+    savedSearch: mockSavedSearch,
+  },
+}))
+
+import { GET as listSaved, POST as createSaved } from '../search/saved/route'
+import { GET as getSaved, DELETE as deleteSaved } from '../search/saved/[id]/route'
+import { POST as runSaved } from '../search/saved/[id]/run/route'
+import { prisma } from '@/lib/db'
+
+function req(method: string, url: string, body?: unknown) {
+  return new Request(url, {
+    method,
+    headers: { authorization: 'Bearer tok', 'content-type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  }) as any
+}
+
+function idParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1', privyId: 'privy-1' } as any)
+  mockSavedSearch.findMany.mockResolvedValue([])
+  mockSavedSearch.findFirst.mockResolvedValue(null)
+  mockSavedSearch.count.mockResolvedValue(0)
+  mockSavedSearch.create.mockResolvedValue({
+    id: 'sq-1',
+    name: 'My Query',
+    query: 'acme',
+    filters: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+  })
+  mockSavedSearch.delete.mockResolvedValue({})
+  vi.mocked(prisma.invoice.findMany).mockResolvedValue([])
+  vi.mocked(prisma.bankAccount.findMany).mockResolvedValue([])
+  vi.mocked(prisma.contact.findMany).mockResolvedValue([])
+  vi.mocked(prisma.tag.findMany).mockResolvedValue([])
+})
+
+// ── GET /search/saved ──────────────────────────────────────────────────────────
+
+describe('GET /search/saved', () => {
+  it('returns empty list when no saved queries', async () => {
+    const res = await listSaved(req('GET', 'http://localhost/api/routes-b/search/saved'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.savedQueries).toEqual([])
+  })
+
+  it('returns saved queries for the user', async () => {
+    const entry = {
+      id: 'sq-1',
+      name: 'Invoice search',
+      query: 'acme',
+      filters: null,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    }
+    mockSavedSearch.findMany.mockResolvedValueOnce([entry])
+    const res = await listSaved(req('GET', 'http://localhost/api/routes-b/search/saved'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.savedQueries).toHaveLength(1)
+    expect(body.savedQueries[0].name).toBe('Invoice search')
+  })
+
+  it('returns 401 when no token', async () => {
+    const res = await listSaved(new Request('http://localhost/api/routes-b/search/saved') as any)
+    expect(res.status).toBe(401)
+  })
+})
+
+// ── POST /search/saved ─────────────────────────────────────────────────────────
+
+describe('POST /search/saved', () => {
+  it('creates a saved query and returns 201', async () => {
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', { name: 'My Query', query: 'acme' }),
+    )
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.savedQuery).toHaveProperty('id', 'sq-1')
+    expect(body.savedQuery).toHaveProperty('name', 'My Query')
+  })
+
+  it('returns 400 when name is missing', async () => {
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', { query: 'acme' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when query is missing', async () => {
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', { name: 'My Query' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when name is empty string', async () => {
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', { name: '', query: 'acme' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when name exceeds 100 chars', async () => {
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', {
+        name: 'x'.repeat(101),
+        query: 'acme',
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('enforces cap of 50 saved queries', async () => {
+    mockSavedSearch.count.mockResolvedValueOnce(50)
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', { name: 'Extra', query: 'test' }),
+    )
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.error).toMatch(/50/)
+  })
+
+  it('allows creation when count is exactly 49', async () => {
+    mockSavedSearch.count.mockResolvedValueOnce(49)
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', {
+        name: 'Query 50',
+        query: 'test',
+      }),
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('stores filters JSON when provided', async () => {
+    const filters = { type: 'invoices' }
+    mockSavedSearch.create.mockResolvedValueOnce({
+      id: 'sq-2',
+      name: 'Invoice only',
+      query: 'acme',
+      filters,
+      createdAt: new Date(),
+    })
+    const res = await createSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved', {
+        name: 'Invoice only',
+        query: 'acme',
+        filters,
+      }),
+    )
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.savedQuery.filters).toEqual(filters)
+  })
+})
+
+// ── GET /search/saved/[id] ─────────────────────────────────────────────────────
+
+describe('GET /search/saved/[id]', () => {
+  it('returns the saved query by id', async () => {
+    const entry = { id: 'sq-1', name: 'My Query', query: 'acme', filters: null, createdAt: new Date() }
+    mockSavedSearch.findFirst.mockResolvedValueOnce(entry)
+    const res = await getSaved(req('GET', 'http://localhost/api/routes-b/search/saved/sq-1'), idParams('sq-1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.savedQuery.id).toBe('sq-1')
+  })
+
+  it('returns 404 for unknown id', async () => {
+    const res = await getSaved(
+      req('GET', 'http://localhost/api/routes-b/search/saved/nope'),
+      idParams('nope'),
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── DELETE /search/saved/[id] ──────────────────────────────────────────────────
+
+describe('DELETE /search/saved/[id]', () => {
+  it('deletes and returns 204', async () => {
+    mockSavedSearch.findFirst.mockResolvedValueOnce({ id: 'sq-1', userId: 'user-1' })
+    const res = await deleteSaved(
+      req('DELETE', 'http://localhost/api/routes-b/search/saved/sq-1'),
+      idParams('sq-1'),
+    )
+    expect(res.status).toBe(204)
+  })
+
+  it('returns 404 for unknown id', async () => {
+    const res = await deleteSaved(
+      req('DELETE', 'http://localhost/api/routes-b/search/saved/nope'),
+      idParams('nope'),
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── POST /search/saved/[id]/run ────────────────────────────────────────────────
+
+describe('POST /search/saved/[id]/run', () => {
+  it('returns results in search response shape', async () => {
+    mockSavedSearch.findFirst.mockResolvedValueOnce({
+      id: 'sq-1',
+      userId: 'user-1',
+      query: 'acme',
+      filters: null,
+    })
+    const res = await runSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved/sq-1/run'),
+      idParams('sq-1'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('query', 'acme')
+    expect(body).toHaveProperty('savedSearchId', 'sq-1')
+    expect(body.results).toHaveProperty('invoices')
+    expect(body.results).toHaveProperty('bankAccounts')
+    expect(body.results).toHaveProperty('contacts')
+    expect(body.results).toHaveProperty('tags')
+    expect(body.facets).toHaveProperty('types')
+    expect(body.facets).toHaveProperty('statuses')
+  })
+
+  it('returns 404 for unknown saved search id', async () => {
+    const res = await runSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved/nope/run'),
+      idParams('nope'),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('respects type filter from saved filters', async () => {
+    mockSavedSearch.findFirst.mockResolvedValueOnce({
+      id: 'sq-2',
+      userId: 'user-1',
+      query: 'acme',
+      filters: { type: 'invoices' },
+    })
+    const res = await runSaved(
+      req('POST', 'http://localhost/api/routes-b/search/saved/sq-2/run'),
+      idParams('sq-2'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // contacts, bankAccounts, tags should be empty arrays (filter = invoices only)
+    expect(body.results.contacts).toEqual([])
+    expect(body.results.bankAccounts).toEqual([])
+    expect(body.results.tags).toEqual([])
+  })
+
+  it('base /search endpoint still works after a saved search is deleted', async () => {
+    // Deleting a saved search must not affect the savedSearch.findMany that lists them
+    mockSavedSearch.findFirst.mockResolvedValueOnce({ id: 'sq-1', userId: 'user-1' })
+    await deleteSaved(
+      req('DELETE', 'http://localhost/api/routes-b/search/saved/sq-1'),
+      idParams('sq-1'),
+    )
+    // After deletion, listing returns empty (no saved searches remain)
+    mockSavedSearch.findMany.mockResolvedValueOnce([])
+    const listRes = await listSaved(req('GET', 'http://localhost/api/routes-b/search/saved'))
+    expect(listRes.status).toBe(200)
+    const body = await listRes.json()
+    expect(body.savedQueries).toEqual([])
+  })
+})

--- a/app/api/routes-b/tests/timezone-analytics.test.ts
+++ b/app/api/routes-b/tests/timezone-analytics.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  isValidTimezone,
+  localMidnightToUtc,
+  parseTzDateRange,
+} from '../_lib/date-range'
+
+// ── isValidTimezone ───────────────────────────────────────────────────────────
+
+describe('isValidTimezone', () => {
+  it('accepts UTC', () => expect(isValidTimezone('UTC')).toBe(true))
+  it('accepts Africa/Lagos', () => expect(isValidTimezone('Africa/Lagos')).toBe(true))
+  it('accepts America/Los_Angeles', () => expect(isValidTimezone('America/Los_Angeles')).toBe(true))
+  it('accepts Europe/London', () => expect(isValidTimezone('Europe/London')).toBe(true))
+  it('rejects empty string', () => expect(isValidTimezone('')).toBe(false))
+  it('rejects made-up name', () => expect(isValidTimezone('Foo/Bar')).toBe(false))
+  it('rejects plainly invalid string', () => expect(isValidTimezone('UTC+5')).toBe(false))
+})
+
+// ── localMidnightToUtc ────────────────────────────────────────────────────────
+
+describe('localMidnightToUtc', () => {
+  it('UTC midnight stays at UTC midnight', () => {
+    const result = localMidnightToUtc('2024-01-15', 'UTC')
+    expect(result.toISOString()).toBe('2024-01-15T00:00:00.000Z')
+  })
+
+  it('Africa/Lagos (UTC+1): midnight is 23:00 UTC the previous day', () => {
+    const result = localMidnightToUtc('2024-01-15', 'Africa/Lagos')
+    expect(result.toISOString()).toBe('2024-01-14T23:00:00.000Z')
+  })
+
+  it('America/Los_Angeles (PST = UTC-8): midnight is 08:00 UTC', () => {
+    const result = localMidnightToUtc('2024-01-15', 'America/Los_Angeles')
+    expect(result.toISOString()).toBe('2024-01-15T08:00:00.000Z')
+  })
+
+  it('DST spring-forward day (America/Los_Angeles 2024-03-10): midnight is 08:00 UTC (PST)', () => {
+    // Clocks spring forward at 2am PST → 3am PDT on 2024-03-10
+    // Midnight on Mar 10 is still PST (UTC-8) → 08:00 UTC
+    const result = localMidnightToUtc('2024-03-10', 'America/Los_Angeles')
+    expect(result.toISOString()).toBe('2024-03-10T08:00:00.000Z')
+  })
+
+  it('DST fall-back day (America/Los_Angeles 2024-11-03): midnight is 07:00 UTC (PDT)', () => {
+    // Clocks fall back at 2am PDT → 1am PST on 2024-11-03
+    // Midnight on Nov 3 is still PDT (UTC-7) → 07:00 UTC
+    const result = localMidnightToUtc('2024-11-03', 'America/Los_Angeles')
+    expect(result.toISOString()).toBe('2024-11-03T07:00:00.000Z')
+  })
+})
+
+// ── parseTzDateRange ──────────────────────────────────────────────────────────
+
+describe('parseTzDateRange', () => {
+  it('defaults to UTC when no tz param and no user timezone', () => {
+    const params = new URLSearchParams({ from: '2024-01-01', to: '2024-01-01' })
+    const result = parseTzDateRange(params, null, new Date('2024-01-01T12:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.tz).toBe('UTC')
+    expect(result.value.from.toISOString()).toBe('2024-01-01T00:00:00.000Z')
+  })
+
+  it('uses explicit ?tz= over user default', () => {
+    const params = new URLSearchParams({
+      from: '2024-01-15',
+      to: '2024-01-15',
+      tz: 'Africa/Lagos',
+    })
+    const result = parseTzDateRange(params, 'UTC', new Date('2024-01-15T12:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.tz).toBe('Africa/Lagos')
+    // from should be 23:00 UTC on Jan 14 (Lagos midnight Jan 15)
+    expect(result.value.from.toISOString()).toBe('2024-01-14T23:00:00.000Z')
+  })
+
+  it('falls back to user.timezone when no ?tz=', () => {
+    const params = new URLSearchParams({ from: '2024-01-15', to: '2024-01-15' })
+    const result = parseTzDateRange(params, 'America/Los_Angeles', new Date('2024-01-15T12:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.tz).toBe('America/Los_Angeles')
+    expect(result.value.from.toISOString()).toBe('2024-01-15T08:00:00.000Z')
+  })
+
+  it('rejects unknown IANA name with error', () => {
+    const params = new URLSearchParams({ tz: 'Fake/Zone', from: '2024-01-01', to: '2024-01-01' })
+    const result = parseTzDateRange(params, null)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.fields).toHaveProperty('tz')
+  })
+
+  it('Africa/Lagos rollup: toExclusive is end of local day in UTC', () => {
+    const params = new URLSearchParams({
+      from: '2024-01-15',
+      to: '2024-01-15',
+      tz: 'Africa/Lagos',
+    })
+    const result = parseTzDateRange(params, null, new Date('2024-01-15T12:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // Lagos Jan 15 = UTC Jan 14 23:00 → Jan 15 23:00 (exclusive)
+    expect(result.value.toExclusive.toISOString()).toBe('2024-01-15T23:00:00.000Z')
+    expect(result.value.days).toBe(1)
+  })
+
+  it('America/Los_Angeles rollup: from and toExclusive span one local day', () => {
+    const params = new URLSearchParams({
+      from: '2024-01-15',
+      to: '2024-01-15',
+      tz: 'America/Los_Angeles',
+    })
+    const result = parseTzDateRange(params, null, new Date('2024-01-15T20:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.value.from.toISOString()).toBe('2024-01-15T08:00:00.000Z')
+    expect(result.value.toExclusive.toISOString()).toBe('2024-01-16T08:00:00.000Z')
+  })
+
+  it('DST transition: spring-forward day has correct boundaries', () => {
+    // America/Los_Angeles 2024-03-10: PST → PDT at 2am
+    const params = new URLSearchParams({
+      from: '2024-03-10',
+      to: '2024-03-10',
+      tz: 'America/Los_Angeles',
+    })
+    const result = parseTzDateRange(params, null, new Date('2024-03-10T12:00:00Z'))
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // Midnight PST = 08:00 UTC; end of day = midnight PDT Mar 11 = 07:00 UTC Mar 11
+    expect(result.value.from.toISOString()).toBe('2024-03-10T08:00:00.000Z')
+    expect(result.value.toExclusive.toISOString()).toBe('2024-03-11T07:00:00.000Z')
+  })
+
+  it('returns error for invalid date format', () => {
+    const params = new URLSearchParams({ from: '15-01-2024', to: '2024-01-15', tz: 'UTC' })
+    const result = parseTzDateRange(params, null)
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error when from > to', () => {
+    const params = new URLSearchParams({ from: '2024-01-20', to: '2024-01-15', tz: 'UTC' })
+    const result = parseTzDateRange(params, null)
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ── Route handler tests ───────────────────────────────────────────────────────
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn().mockResolvedValue({ userId: 'privy-1' }),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'user-1', privyId: 'privy-1', timezone: null }),
+    },
+    transaction: {
+      aggregate: vi.fn().mockResolvedValue({ _sum: { amount: 500 }, _count: { id: 2 } }),
+      count: vi.fn().mockResolvedValue(1),
+    },
+    invoice: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}))
+
+import { GET as earningsGET } from '../analytics/earnings/route'
+import { GET as withdrawalsGET } from '../analytics/withdrawals/route'
+import { GET as topMonthsGET } from '../analytics/top-months/route'
+import { prisma } from '@/lib/db'
+
+function makeReq(searchParams: Record<string, string>) {
+  const url = new URL('http://localhost/api/routes-b/analytics/earnings')
+  for (const [k, v] of Object.entries(searchParams)) url.searchParams.set(k, v)
+  return new Request(url.toString(), { headers: { authorization: 'Bearer tok' } }) as any
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    id: 'user-1',
+    privyId: 'privy-1',
+    timezone: null,
+  } as any)
+  vi.mocked(prisma.transaction.aggregate).mockResolvedValue({ _sum: { amount: 500 }, _count: { id: 2 } } as any)
+  vi.mocked(prisma.transaction.count).mockResolvedValue(1)
+  vi.mocked(prisma.invoice.findMany).mockResolvedValue([])
+})
+
+describe('GET /analytics/earnings with ?tz=', () => {
+  it('defaults to UTC and returns 200', async () => {
+    const res = await earningsGET(makeReq({ from: '2024-01-01', to: '2024-01-31' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.earnings.tz).toBe('UTC')
+  })
+
+  it('accepts Africa/Lagos and reflects timezone in response', async () => {
+    const res = await earningsGET(
+      makeReq({ from: '2024-01-01', to: '2024-01-31', tz: 'Africa/Lagos' }),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.earnings.tz).toBe('Africa/Lagos')
+  })
+
+  it('returns 400 for invalid timezone', async () => {
+    const res = await earningsGET(makeReq({ from: '2024-01-01', to: '2024-01-31', tz: 'Fake/Zone' }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.fields).toHaveProperty('tz')
+  })
+
+  it('uses user.timezone when no ?tz= param', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
+      id: 'user-1',
+      timezone: 'America/Los_Angeles',
+    } as any)
+    const res = await earningsGET(makeReq({ from: '2024-01-15', to: '2024-01-15' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.earnings.tz).toBe('America/Los_Angeles')
+  })
+})
+
+describe('GET /analytics/withdrawals with ?tz=', () => {
+  it('returns 200 with UTC default', async () => {
+    const res = await withdrawalsGET(makeReq({ from: '2024-01-01', to: '2024-01-31' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.withdrawals.tz).toBe('UTC')
+  })
+
+  it('returns 400 for invalid tz', async () => {
+    const res = await withdrawalsGET(makeReq({ tz: 'Not/Valid' }))
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /analytics/top-months with ?tz=', () => {
+  it('returns 200 with UTC default', async () => {
+    const res = await topMonthsGET(makeReq({}))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('tz', 'UTC')
+    expect(body).toHaveProperty('topMonths')
+  })
+
+  it('groups invoices by local month in Africa/Lagos', async () => {
+    // Invoice paidAt just after midnight UTC would be the previous local day in UTC+1
+    vi.mocked(prisma.invoice.findMany).mockResolvedValueOnce([
+      // 23:30 UTC Dec 31 = 00:30 Jan 1 in Lagos → counts as Jan
+      { amount: 100, paidAt: new Date('2024-12-31T23:30:00Z') },
+      { amount: 200, paidAt: new Date('2024-01-15T10:00:00Z') },
+    ] as any)
+    const res = await topMonthsGET(makeReq({ tz: 'Africa/Lagos' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.tz).toBe('Africa/Lagos')
+    // 23:30 UTC Dec 31 = Jan 1 00:30 Lagos → key '2025-01'
+    const months = body.topMonths.map((m: any) => m.month)
+    expect(months).toContain('2025-01')
+  })
+
+  it('returns 400 for invalid tz', async () => {
+    const res = await topMonthsGET(makeReq({ tz: 'Bad/Zone' }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/app/api/routes-b/tests/wallet-swr.test.ts
+++ b/app/api/routes-b/tests/wallet-swr.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { swrGet, swrSet, swrClear, swrIsFresh, swrIsStale, type SwrEntry } from '../_lib/swr-cache'
+
+// ── swr-cache unit tests ──────────────────────────────────────────────────────
+
+describe('swr-cache', () => {
+  beforeEach(() => swrClear())
+
+  it('returns null on cold miss', () => {
+    expect(swrGet('missing')).toBeNull()
+  })
+
+  it('returns entry immediately after set', () => {
+    swrSet('k', 'value', 15_000, 60_000)
+    const entry = swrGet<string>('k')
+    expect(entry).not.toBeNull()
+    expect(entry!.value).toBe('value')
+  })
+
+  it('fresh hit: swrIsFresh returns true within freshMs', () => {
+    swrSet('k', 42, 15_000, 60_000)
+    const entry = swrGet<number>('k')!
+    expect(swrIsFresh(entry)).toBe(true)
+    expect(swrIsStale(entry)).toBe(false)
+  })
+
+  it('stale hit: swrIsStale returns true after freshMs but before staleMs', () => {
+    const now = Date.now()
+    swrSet('k', 'val', 0, 60_000) // freshMs = 0 so already stale
+    const entry = swrGet<string>('k')!
+    // Force freshUntil into the past
+    entry.freshUntil = now - 1
+    entry.staleUntil = now + 60_000
+    expect(swrIsFresh(entry)).toBe(false)
+    expect(swrIsStale(entry)).toBe(true)
+  })
+
+  it('beyond-stale: swrGet returns null after staleMs expires', () => {
+    swrSet('k', 'val', 0, 0) // both windows expired immediately
+    // Manually expire the entry
+    const entry = swrGet<string>('k')
+    if (entry) {
+      entry.freshUntil = Date.now() - 2
+      entry.staleUntil = Date.now() - 1
+    }
+    // After staleUntil passes, a fresh swrGet should return null
+    // Simulate by setting with zero windows and checking after the store evicts
+    swrClear()
+    swrSet('k2', 'v', -1, -1)
+    expect(swrGet('k2')).toBeNull()
+  })
+
+  it('swrDelete removes an entry', () => {
+    const { swrDelete } = require('../_lib/swr-cache')
+    swrSet('x', 1, 15_000, 60_000)
+    swrDelete('x')
+    expect(swrGet('x')).toBeNull()
+  })
+})
+
+// ── Wallet route tests ────────────────────────────────────────────────────────
+
+const mockWalletFindUnique = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn().mockResolvedValue({ userId: 'privy-1' }),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn().mockResolvedValue({ id: 'user-swr-1', privyId: 'privy-1' }),
+    },
+    wallet: {
+      findUnique: mockWalletFindUnique,
+    },
+  },
+}))
+
+import { GET } from '../wallet/route'
+import { prisma } from '@/lib/db'
+
+const WALLET_DB = {
+  id: 'w-1',
+  address: 'GADDR123',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  userId: 'user-swr-1',
+}
+
+function makeReq() {
+  return new Request('http://localhost/api/routes-b/wallet', {
+    headers: { authorization: 'Bearer tok' },
+  }) as any
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  swrClear()
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-swr-1', privyId: 'privy-1' } as any)
+  mockWalletFindUnique.mockResolvedValue(WALLET_DB)
+})
+
+describe('GET /wallet — SWR caching', () => {
+  it('cold miss: fetches from DB and returns wallet', async () => {
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.wallet).toHaveProperty('stellarAddress', 'GADDR123')
+    expect(mockWalletFindUnique).toHaveBeenCalledTimes(1)
+  })
+
+  it('fresh hit: does not call DB again within fresh window', async () => {
+    // First call populates cache
+    await GET(makeReq())
+    // Second call should be a fresh hit
+    const res2 = await GET(makeReq())
+    expect(res2.status).toBe(200)
+    // DB called only once (during first request)
+    expect(mockWalletFindUnique).toHaveBeenCalledTimes(1)
+  })
+
+  it('stale hit: returns X-Cache: STALE header', async () => {
+    // Seed the cache with an already-stale entry
+    const staleEntry: SwrEntry<{ id: string; stellarAddress: string; createdAt: Date }> = {
+      value: { id: 'w-1', stellarAddress: 'GADDR123', createdAt: new Date() },
+      fetchedAt: Date.now() - 30_000,
+      freshUntil: Date.now() - 1, // past fresh window
+      staleUntil: Date.now() + 30_000, // still within stale window
+    }
+    swrSet('wallet:user-swr-1', staleEntry.value, -1, 60_000)
+    // Manually backdate the freshUntil
+    const entry = swrGet<any>('wallet:user-swr-1')!
+    entry.freshUntil = Date.now() - 1
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('X-Cache')).toBe('STALE')
+  })
+
+  it('beyond-stale: synchronously fetches when cache is fully expired', async () => {
+    // Seed cache with an entry that is beyond the stale window
+    swrSet('wallet:user-swr-1', WALLET_DB, -1, -1)
+    // Beyond stale → swrGet returns null → triggers sync fetch
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    expect(mockWalletFindUnique).toHaveBeenCalledTimes(1)
+  })
+
+  it('error during fetch falls back to last known cached value', async () => {
+    // First: populate the cache successfully
+    await GET(makeReq())
+    // Expire the fresh window but keep stale alive
+    const entry = swrGet<any>('wallet:user-swr-1')!
+    entry.freshUntil = Date.now() - 1
+
+    // Now DB throws on revalidation
+    mockWalletFindUnique.mockRejectedValueOnce(new Error('RPC down'))
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    // Still returns the stale cached wallet
+    const body = await res.json()
+    expect(body.wallet).toHaveProperty('stellarAddress', 'GADDR123')
+  })
+
+  it('returns null wallet gracefully when DB returns null', async () => {
+    mockWalletFindUnique.mockResolvedValueOnce(null)
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.wallet).toBeNull()
+  })
+})

--- a/app/api/routes-b/wallet/route.ts
+++ b/app/api/routes-b/wallet/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { swrGet, swrSet, swrIsFresh, swrIsStale } from '../_lib/swr-cache'
+
+const FRESH_MS = 15_000 // 15 s: serve from cache, no upstream call
+const STALE_MS = 60_000 // 60 s: serve stale + revalidate in background
+
+type WalletPayload = { id: string; stellarAddress: string; createdAt: Date } | null
+
+async function fetchWalletFromDb(userId: string): Promise<WalletPayload> {
+  const wallet = await prisma.wallet.findUnique({ where: { userId } })
+  if (!wallet) return null
+  return { id: wallet.id, stellarAddress: wallet.address, createdAt: wallet.createdAt }
+}
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -15,16 +27,45 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
-  const wallet = await prisma.wallet.findUnique({ where: { userId: user.id } })
-  if (!wallet) {
-    return NextResponse.json({ wallet: null }, { status: 200 })
+  const cacheKey = `wallet:${user.id}`
+  const cached = swrGet<WalletPayload>(cacheKey)
+
+  if (cached) {
+    if (swrIsFresh(cached)) {
+      // Within the fresh window — return immediately, no upstream call
+      return NextResponse.json({ wallet: cached.value })
+    }
+
+    if (swrIsStale(cached)) {
+      // Within the stale window — return the cached value and revalidate in background
+      setImmediate(async () => {
+        try {
+          const fresh = await fetchWalletFromDb(user.id)
+          swrSet(cacheKey, fresh, FRESH_MS, STALE_MS)
+        } catch {
+          // Keep serving the last known value; do not evict
+        }
+      })
+
+      const headers = new Headers()
+      headers.set('X-Cache', 'STALE')
+      return NextResponse.json({ wallet: cached.value }, { headers })
+    }
   }
 
-  return NextResponse.json({
-    wallet: {
-      id: wallet.id,
-      stellarAddress: wallet.address,
-      createdAt: wallet.createdAt,
-    },
-  })
+  // Cache miss or beyond stale window — synchronous upstream fetch
+  try {
+    const wallet = await fetchWalletFromDb(user.id)
+    swrSet(cacheKey, wallet, FRESH_MS, STALE_MS)
+    return NextResponse.json({ wallet })
+  } catch (error) {
+    // If we still have a (now-expired) value fall back to it rather than hard-failing
+    const stale = swrGet<WalletPayload>(cacheKey)
+    if (stale) {
+      const headers = new Headers()
+      headers.set('X-Cache', 'STALE')
+      return NextResponse.json({ wallet: stale.value }, { headers })
+    }
+    return NextResponse.json({ error: 'Failed to fetch wallet' }, { status: 500 })
+  }
 }


### PR DESCRIPTION
## Summary

This PR implements four routes-b features. All new code lives inside
`app/api/routes-b/` with shared helpers in `_lib/` and tests in `tests/`.

---

### Task 1 — Saved search queries (`/search/saved`)

- **GET /search/saved** — list all saved queries for the authenticated user
- **POST /search/saved** — create a saved query (`name`, `query`, optional `filters` JSON);
  returns 422 when the user already has 50 saved queries (hard cap)
- **GET /search/saved/[id]** — fetch a single saved query
- **DELETE /search/saved/[id]** — remove a saved query (204)
- **POST /search/saved/[id]/run** — execute the saved query and return the same
  shape as `GET /search` (`query`, `savedSearchId`, `results`, `facets`)
- 19 tests covering full CRUD, cap enforcement at exactly 50, run response shape,
  type-filter propagation, and post-delete safety of the list endpoint

---

### Task 2 — Timezone-aware analytics date boundaries

Extended `_lib/date-range.ts` with:
- `isValidTimezone(tz)` — validates IANA timezone names via `Intl`
- `localMidnightToUtc(dateStr, tz)` — two-iteration algorithm that correctly
  projects local midnight to UTC including DST transition days
- `parseTzDateRange(searchParams, defaultTz?)` — drop-in replacement for
  `parseUtcDateRange` that honours `?tz=`, falls back to `user.timezone` then UTC;
  rejects unknown IANA names with HTTP 400

Updated routes:
- **analytics/earnings** — accepts `?tz=`; returns local `from`/`to` strings and `tz`
- **analytics/withdrawals** — accepts `?tz=`; scopes the date filter to local-day boundaries
- **analytics/top-months** — groups invoices by local `YYYY-MM` in the requested timezone
  instead of UTC

30 tests: UTC default, Africa/Lagos, America/Los_Angeles, spring-forward and fall-back
DST days, invalid timezone rejection, route-level integration.

---

### Task 3 — Account deletion flow (`/profile/delete-request`, `/profile/delete-cancel`)

- **POST /profile/delete-request** — marks account pending deletion with a 14-day
  reversible window; returns a `confirmationToken` and `deletesAt` timestamp;
  idempotent if already pending; writes `ACCOUNT_DELETION_REQUESTED` audit event
- **POST /profile/delete-cancel** — cancels within the window (409 if no active
  request or window expired); writes `ACCOUNT_DELETION_CANCELLED` audit event
- `_lib/account-state.ts` — in-process store exposing `requestAccountDeletion`,
  `cancelAccountDeletion`, `isAccountPendingDeletion`, `getDeletionWindowEnd`,
  and `checkAccountLocked(userId)` which returns a 423 Locked response for
  any endpoint to use as a guard
- Tests cover: request, cancel within window, cancel after window expires
  (via time-travel backdating), 423 gating, audit events written, post-cancel unlock

---

### Task 4 — Stale-while-revalidate caching for `GET /wallet`

- `_lib/swr-cache.ts` — generic in-process SWR cache with `freshMs`/`staleMs`
  windows; exports `swrGet`, `swrSet`, `swrDelete`, `swrClear`, `swrIsFresh`, `swrIsStale`
- **wallet/route.ts** rewritten with SWR logic:
  - **Fresh (0–15 s):** return cached value, no DB call
  - **Stale (15–60 s):** return cached value with `X-Cache: STALE` header +
    trigger background revalidation via `setImmediate`
  - **Beyond stale (> 60 s):** synchronous fetch from DB
  - Error during background revalidation silently keeps last known value
- Tests: cold miss, fresh hit (single DB call across two requests), stale hit
  (`X-Cache` header present), beyond-stale sync path, error fallback to last
  known, null wallet shape

## Related Issues
Closes #608 
Closes #618 
Closes #537
Closes #596 
