### PR TITLE
feat(routes-b): late-fee helper, webhook backoff config, tag bulk rename, audit action filter

### DIFF
--- a/app/api/routes-b/_lib/__tests__/audit-action-filter.test.ts
+++ b/app/api/routes-b/_lib/__tests__/audit-action-filter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for buildActionFilter — Issue #621
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildActionFilter } from '../audit-action-filter'
+
+function params(record: Record<string, string>): URLSearchParams {
+  return new URLSearchParams(record)
+}
+
+describe('buildActionFilter (#621)', () => {
+  it('returns empty clause when both filters are missing', () => {
+    const result = buildActionFilter(params({}))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.clause).toEqual({})
+  })
+
+  it('builds equals filter for ?action', () => {
+    const result = buildActionFilter(params({ action: 'refund.created' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.clause).toEqual({ eventType: { equals: 'refund.created' } })
+    }
+  })
+
+  it('builds startsWith filter for ?actionPrefix', () => {
+    const result = buildActionFilter(params({ actionPrefix: 'webhook.' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.clause).toEqual({ eventType: { startsWith: 'webhook.' } })
+    }
+  })
+
+  it('rejects actionPrefix shorter than 2 chars', () => {
+    const result = buildActionFilter(params({ actionPrefix: 'a' }))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/2 and 64/)
+  })
+
+  it('rejects actionPrefix longer than 64 chars', () => {
+    const result = buildActionFilter(params({ actionPrefix: 'x'.repeat(65) }))
+    expect(result.ok).toBe(false)
+  })
+
+  it('action takes precedence when both are present', () => {
+    const result = buildActionFilter(
+      params({ action: 'refund.created', actionPrefix: 'webhook.' }),
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.clause).toEqual({ eventType: { equals: 'refund.created' } })
+    }
+  })
+
+  it('trims whitespace from inputs', () => {
+    const result = buildActionFilter(params({ action: '  refund.created  ' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.clause).toEqual({ eventType: { equals: 'refund.created' } })
+    }
+  })
+
+  it('treats empty string action as missing', () => {
+    const result = buildActionFilter(params({ action: '   ' }))
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.clause).toEqual({})
+  })
+})

--- a/app/api/routes-b/_lib/__tests__/late-fee.test.ts
+++ b/app/api/routes-b/_lib/__tests__/late-fee.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for computeLateFee — Issue #599
+ */
+
+import { describe, it, expect } from 'vitest'
+import { computeLateFee, DEFAULT_LATE_FEE_POLICY } from '../late-fee'
+
+const baseInvoice = {
+  amount: 1000,
+  currency: 'USD',
+  dueDate: new Date('2026-01-01'),
+}
+
+describe('computeLateFee (#599)', () => {
+  it('returns zero when invoice is not overdue', () => {
+    const result = computeLateFee(baseInvoice, new Date('2025-12-31'))
+    expect(result.amount).toBe(0)
+    expect(result.applied).toBe(false)
+    expect(result.daysLate).toBe(0)
+  })
+
+  it('returns zero when overdue but less than one period', () => {
+    const result = computeLateFee(baseInvoice, new Date('2026-01-15')) // 14 days late
+    expect(result.amount).toBe(0)
+    expect(result.applied).toBe(false)
+    expect(result.daysLate).toBe(14)
+  })
+
+  it('charges 1.5% for one full period (30 days)', () => {
+    const result = computeLateFee(baseInvoice, new Date('2026-01-31')) // 30 days late
+    // 1000 * 0.015 * 1 = 15
+    expect(result.amount).toBe(15)
+    expect(result.applied).toBe(true)
+    expect(result.daysLate).toBe(30)
+    expect(result.currency).toBe('USD')
+  })
+
+  it('scales linearly across multiple periods', () => {
+    const result = computeLateFee(baseInvoice, new Date('2026-04-01')) // 90 days = 3 periods
+    // 1000 * 0.015 * 3 = 45
+    expect(result.amount).toBe(45)
+    expect(result.applied).toBe(true)
+  })
+
+  it('caps at 10% of principal', () => {
+    // 8 periods (240 days) → would be 12% → cap at 10%
+    const result = computeLateFee(baseInvoice, new Date('2026-08-29'))
+    expect(result.amount).toBe(100) // 10% of 1000
+    expect(result.applied).toBe(true)
+  })
+
+  it('returns zero for invoice with no due date', () => {
+    const result = computeLateFee(
+      { amount: 1000, currency: 'USD', dueDate: null },
+      new Date(),
+    )
+    expect(result.amount).toBe(0)
+    expect(result.applied).toBe(false)
+  })
+
+  it('preserves currency', () => {
+    const result = computeLateFee(
+      { ...baseInvoice, currency: 'EUR' },
+      new Date('2026-01-31'),
+    )
+    expect(result.currency).toBe('EUR')
+  })
+
+  it('accepts ISO string dates', () => {
+    const result = computeLateFee(
+      { ...baseInvoice, dueDate: '2026-01-01' },
+      '2026-01-31',
+    )
+    expect(result.amount).toBe(15)
+  })
+
+  it('uses default policy when none supplied', () => {
+    const result = computeLateFee(baseInvoice, new Date('2026-01-31'))
+    expect(result.amount).toBe(1000 * DEFAULT_LATE_FEE_POLICY.ratePerPeriod * 1)
+  })
+
+  it('respects custom policy', () => {
+    const result = computeLateFee(
+      baseInvoice,
+      new Date('2026-01-31'),
+      { ratePerPeriod: 0.05, periodDays: 30, capFraction: 0.5 },
+    )
+    expect(result.amount).toBe(50) // 1000 * 0.05 * 1
+  })
+})

--- a/app/api/routes-b/_lib/__tests__/tag-validation.test.ts
+++ b/app/api/routes-b/_lib/__tests__/tag-validation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for validateTagName — Issue #610
+ */
+
+import { describe, it, expect } from 'vitest'
+import { validateTagName } from '../tag-validation'
+
+describe('validateTagName (#610)', () => {
+  it('accepts a valid name', () => {
+    const result = validateTagName('Important')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('Important')
+  })
+
+  it('trims whitespace', () => {
+    const result = validateTagName('  spaced  ')
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toBe('spaced')
+  })
+
+  it('rejects non-string input', () => {
+    expect(validateTagName(null).ok).toBe(false)
+    expect(validateTagName(123).ok).toBe(false)
+    expect(validateTagName(undefined).ok).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(validateTagName('').ok).toBe(false)
+    expect(validateTagName('   ').ok).toBe(false)
+  })
+
+  it('rejects names longer than 32 chars', () => {
+    expect(validateTagName('x'.repeat(33)).ok).toBe(false)
+  })
+
+  it('accepts names exactly 32 chars', () => {
+    expect(validateTagName('x'.repeat(32)).ok).toBe(true)
+  })
+
+  it('rejects control characters', () => {
+    expect(validateTagName('bad\x00name').ok).toBe(false)
+    expect(validateTagName('bad\x07name').ok).toBe(false)
+  })
+})

--- a/app/api/routes-b/_lib/__tests__/webhook-backoff.test.ts
+++ b/app/api/routes-b/_lib/__tests__/webhook-backoff.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for webhook backoff config — Issue #607
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  validateBackoff,
+  computeBackoffDelay,
+  DEFAULT_BACKOFF,
+} from '../webhook-backoff'
+
+describe('validateBackoff (#607)', () => {
+  it('returns defaults when input is null', () => {
+    const result = validateBackoff(null)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.value).toEqual(DEFAULT_BACKOFF)
+  })
+
+  it('merges partial config with defaults', () => {
+    const result = validateBackoff({ initialMs: 500 })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.initialMs).toBe(500)
+      expect(result.value.maxMs).toBe(DEFAULT_BACKOFF.maxMs)
+    }
+  })
+
+  it('rejects initialMs below 50', () => {
+    const result = validateBackoff({ initialMs: 10 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects initialMs above 5000', () => {
+    const result = validateBackoff({ initialMs: 6000 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects maxMs below initialMs', () => {
+    const result = validateBackoff({ initialMs: 1000, maxMs: 500 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects maxMs above 60000', () => {
+    const result = validateBackoff({ maxMs: 70_000 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects multiplier below 1', () => {
+    const result = validateBackoff({ multiplier: 0.5 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects multiplier above 5', () => {
+    const result = validateBackoff({ multiplier: 6 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects jitter outside [0, 1]', () => {
+    expect(validateBackoff({ jitter: -0.1 }).ok).toBe(false)
+    expect(validateBackoff({ jitter: 1.1 }).ok).toBe(false)
+  })
+
+  it('accepts boundary values', () => {
+    const result = validateBackoff({
+      initialMs: 50,
+      maxMs: 60_000,
+      multiplier: 5,
+      jitter: 0,
+    })
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('computeBackoffDelay (#607)', () => {
+  it('returns initialMs for attempt 0 with zero jitter', () => {
+    const delay = computeBackoffDelay(
+      0,
+      { ...DEFAULT_BACKOFF, jitter: 0 },
+      () => 0.5,
+    )
+    expect(delay).toBe(DEFAULT_BACKOFF.initialMs)
+  })
+
+  it('multiplies on each successive attempt', () => {
+    const cfg = { initialMs: 100, maxMs: 10_000, multiplier: 2, jitter: 0 }
+    expect(computeBackoffDelay(0, cfg, () => 0.5)).toBe(100)
+    expect(computeBackoffDelay(1, cfg, () => 0.5)).toBe(200)
+    expect(computeBackoffDelay(2, cfg, () => 0.5)).toBe(400)
+    expect(computeBackoffDelay(3, cfg, () => 0.5)).toBe(800)
+  })
+
+  it('caps at maxMs', () => {
+    const cfg = { initialMs: 100, maxMs: 500, multiplier: 2, jitter: 0 }
+    expect(computeBackoffDelay(10, cfg, () => 0.5)).toBe(500)
+  })
+
+  it('respects jitter bounds', () => {
+    const cfg = { initialMs: 1000, maxMs: 10_000, multiplier: 1, jitter: 0.5 }
+    // With random()=0 → variance = 1000*0.5*-0.5 = -250 → 750
+    // With random()=1 → variance = 1000*0.5*0.5 = 250 → 1250
+    expect(computeBackoffDelay(0, cfg, () => 0)).toBe(750)
+    expect(computeBackoffDelay(0, cfg, () => 1)).toBe(1250)
+  })
+
+  it('never returns negative delays', () => {
+    const cfg = { initialMs: 100, maxMs: 10_000, multiplier: 1, jitter: 1 }
+    expect(computeBackoffDelay(0, cfg, () => -10)).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/app/api/routes-b/_lib/audit-action-filter.ts
+++ b/app/api/routes-b/_lib/audit-action-filter.ts
@@ -1,0 +1,50 @@
+/**
+ * audit-action-filter.ts — Issue #621
+ *
+ * Validates and builds the Prisma `where` clause for the audit-log
+ * `?action=...` (exact match) and `?actionPrefix=...` (prefix match)
+ * query parameters. Both compose with existing filters via AND.
+ */
+
+const PREFIX_MIN = 2;
+const PREFIX_MAX = 64;
+
+export type ActionFilterResult =
+  | { ok: true; clause: { eventType?: { equals?: string; startsWith?: string } } }
+  | { ok: false; error: string };
+
+/**
+ * Build a Prisma `eventType` filter clause from URL search params.
+ *
+ * - When both `action` and `actionPrefix` are missing → returns `{}` (no filter).
+ * - When `action` is present → `{ eventType: { equals: action } }`.
+ * - When `actionPrefix` is present → validates length [2, 64]; returns
+ *   `{ eventType: { startsWith: actionPrefix } }`.
+ * - When `actionPrefix` is invalid → returns `{ ok: false, error }`.
+ *
+ * If both are provided, `action` (exact) takes precedence — the more
+ * specific filter wins.
+ */
+export function buildActionFilter(
+  searchParams: URLSearchParams,
+): ActionFilterResult {
+  const action = searchParams.get('action')?.trim();
+  const actionPrefix = searchParams.get('actionPrefix')?.trim();
+
+  if (action) {
+    return { ok: true, clause: { eventType: { equals: action } } };
+  }
+
+  if (!actionPrefix) {
+    return { ok: true, clause: {} };
+  }
+
+  if (actionPrefix.length < PREFIX_MIN || actionPrefix.length > PREFIX_MAX) {
+    return {
+      ok: false,
+      error: `actionPrefix must be between ${PREFIX_MIN} and ${PREFIX_MAX} characters`,
+    };
+  }
+
+  return { ok: true, clause: { eventType: { startsWith: actionPrefix } } };
+}

--- a/app/api/routes-b/_lib/late-fee.ts
+++ b/app/api/routes-b/_lib/late-fee.ts
@@ -1,0 +1,110 @@
+/**
+ * late-fee.ts — Issue #599
+ *
+ * Pure helper for computing late fees on overdue invoices.
+ * Default policy: 1.5% flat per 30-day period overdue, capped at 10% of principal.
+ * The helper is deterministic given inputs and has no side effects.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export interface InvoiceForLateFee {
+  /** Principal amount in the smallest unit (e.g. cents). Numbers are accepted for simplicity. */
+  amount: number;
+  currency: string;
+  /** ISO date string or Date instance — must be set for an invoice to be considered for late fees. */
+  dueDate: Date | string | null;
+}
+
+export interface LateFeePolicy {
+  /** Fee charged per period as a fraction (0.015 = 1.5%). */
+  ratePerPeriod: number;
+  /** Period length in days (default 30). */
+  periodDays: number;
+  /** Cap as a fraction of the principal (0.10 = 10%). */
+  capFraction: number;
+}
+
+export const DEFAULT_LATE_FEE_POLICY: LateFeePolicy = {
+  ratePerPeriod: 0.015, // 1.5%
+  periodDays: 30,
+  capFraction: 0.10, // 10%
+};
+
+export interface LateFeeResult {
+  /** Computed fee amount in the same unit as the invoice principal. */
+  amount: number;
+  currency: string;
+  /** Days the invoice is overdue (0 if not overdue). */
+  daysLate: number;
+  /** True when a non-zero fee was applied. */
+  applied: boolean;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toDate(value: Date | string | null): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the late fee for an invoice given a policy and an as-of date.
+ *
+ * Rules:
+ *  - If the invoice has no dueDate or asOf <= dueDate → no fee, daysLate=0, applied=false
+ *  - Otherwise: floor(daysLate / periodDays) periods × ratePerPeriod × principal
+ *  - Result is capped at capFraction × principal
+ *  - Currency is preserved from the invoice
+ */
+export function computeLateFee(
+  invoice: InvoiceForLateFee,
+  asOf: Date | string,
+  policy: LateFeePolicy = DEFAULT_LATE_FEE_POLICY,
+): LateFeeResult {
+  const dueDate = toDate(invoice.dueDate);
+  const asOfDate = toDate(asOf as Date | string);
+  const principal = Math.max(0, invoice.amount);
+
+  // Not overdue or missing data
+  if (!dueDate || !asOfDate || asOfDate <= dueDate || principal === 0) {
+    return {
+      amount: 0,
+      currency: invoice.currency,
+      daysLate: 0,
+      applied: false,
+    };
+  }
+
+  const daysLate = Math.floor((asOfDate.getTime() - dueDate.getTime()) / MS_PER_DAY);
+  const periodsLate = Math.floor(daysLate / Math.max(1, policy.periodDays));
+
+  if (periodsLate <= 0) {
+    return {
+      amount: 0,
+      currency: invoice.currency,
+      daysLate,
+      applied: false,
+    };
+  }
+
+  const rawFee = principal * policy.ratePerPeriod * periodsLate;
+  const cap = principal * policy.capFraction;
+  const amount = Math.min(rawFee, cap);
+
+  // Round to 2 decimal places for currency precision
+  const rounded = Math.round(amount * 100) / 100;
+
+  return {
+    amount: rounded,
+    currency: invoice.currency,
+    daysLate,
+    applied: rounded > 0,
+  };
+}

--- a/app/api/routes-b/_lib/tag-validation.ts
+++ b/app/api/routes-b/_lib/tag-validation.ts
@@ -1,0 +1,31 @@
+/**
+ * tag-validation.ts — Issue #610
+ *
+ * Reusable tag-name validation helper. Mirrors the rules used elsewhere in
+ * the tag router (length 1–32, trimmed, no control characters).
+ */
+
+export type TagNameValidation =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 32;
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+
+export function validateTagName(input: unknown): TagNameValidation {
+  if (typeof input !== 'string') {
+    return { ok: false, error: 'newName must be a string' };
+  }
+  const trimmed = input.trim();
+  if (trimmed.length < MIN_LENGTH) {
+    return { ok: false, error: `newName must be at least ${MIN_LENGTH} character(s)` };
+  }
+  if (trimmed.length > MAX_LENGTH) {
+    return { ok: false, error: `newName must be at most ${MAX_LENGTH} characters` };
+  }
+  if (CONTROL_CHARS.test(trimmed)) {
+    return { ok: false, error: 'newName contains control characters' };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/app/api/routes-b/_lib/webhook-backoff.ts
+++ b/app/api/routes-b/_lib/webhook-backoff.ts
@@ -1,0 +1,89 @@
+/**
+ * webhook-backoff.ts — Issue #607
+ *
+ * Per-webhook retry backoff configuration with validation and computation.
+ * Backwards compatible: when no config is provided, the default curve
+ * matches the previous global behaviour.
+ */
+
+// ── Types & defaults ──────────────────────────────────────────────────────────
+
+export interface BackoffConfig {
+  /** Initial retry delay in ms (50–5000). */
+  initialMs: number;
+  /** Maximum retry delay in ms (initialMs–60000). */
+  maxMs: number;
+  /** Multiplier applied to each successive attempt (1–5). */
+  multiplier: number;
+  /** Jitter as a fraction of the delay (0–1). 0 = deterministic, 1 = ±delay/2. */
+  jitter: number;
+}
+
+/** Default curve — matches existing global behaviour. */
+export const DEFAULT_BACKOFF: BackoffConfig = {
+  initialMs: 1_000,
+  maxMs: 30_000,
+  multiplier: 2,
+  jitter: 0.1,
+};
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+export type BackoffValidation =
+  | { ok: true; value: BackoffConfig }
+  | { ok: false; error: string };
+
+/**
+ * Validate a partial backoff config and return a complete config or an error.
+ * Missing fields fall back to DEFAULT_BACKOFF values.
+ */
+export function validateBackoff(input: Partial<BackoffConfig> | null | undefined): BackoffValidation {
+  const merged: BackoffConfig = {
+    initialMs: input?.initialMs ?? DEFAULT_BACKOFF.initialMs,
+    maxMs: input?.maxMs ?? DEFAULT_BACKOFF.maxMs,
+    multiplier: input?.multiplier ?? DEFAULT_BACKOFF.multiplier,
+    jitter: input?.jitter ?? DEFAULT_BACKOFF.jitter,
+  };
+
+  if (!Number.isFinite(merged.initialMs) || merged.initialMs < 50 || merged.initialMs > 5_000) {
+    return { ok: false, error: 'initialMs must be a number in [50, 5000]' };
+  }
+  if (!Number.isFinite(merged.maxMs) || merged.maxMs < merged.initialMs || merged.maxMs > 60_000) {
+    return { ok: false, error: `maxMs must be in [initialMs (${merged.initialMs}), 60000]` };
+  }
+  if (!Number.isFinite(merged.multiplier) || merged.multiplier < 1 || merged.multiplier > 5) {
+    return { ok: false, error: 'multiplier must be a number in [1, 5]' };
+  }
+  if (!Number.isFinite(merged.jitter) || merged.jitter < 0 || merged.jitter > 1) {
+    return { ok: false, error: 'jitter must be a number in [0, 1]' };
+  }
+
+  return { ok: true, value: merged };
+}
+
+// ── Compute next delay ────────────────────────────────────────────────────────
+
+/**
+ * Compute the delay (in ms) before the next retry attempt.
+ *
+ * @param attempt 0-based attempt index. attempt=0 is the first retry after the
+ *                initial failed delivery.
+ * @param config  Per-webhook backoff configuration.
+ * @param random  Optional RNG for deterministic tests; defaults to Math.random.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  config: BackoffConfig = DEFAULT_BACKOFF,
+  random: () => number = Math.random,
+): number {
+  const safeAttempt = Math.max(0, Math.floor(attempt));
+  const exponential = config.initialMs * Math.pow(config.multiplier, safeAttempt);
+  const capped = Math.min(exponential, config.maxMs);
+
+  if (config.jitter <= 0) return capped;
+
+  // Apply ±(jitter * delay / 2) variance — bounds: [capped*(1-j/2), capped*(1+j/2)]
+  const variance = capped * config.jitter * (random() - 0.5);
+  const delayed = capped + variance;
+  return Math.max(0, Math.round(delayed));
+}

--- a/app/api/routes-b/audit-log/route.ts
+++ b/app/api/routes-b/audit-log/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { buildActionFilter } from '../_lib/audit-action-filter' // Issue #621
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -18,11 +19,15 @@ export async function GET(request: NextRequest) {
   const parsedLimit = parseInt(searchParams.get('limit') || '20', 10)
   const limit = Math.min(50, Math.max(1, Number.isNaN(parsedLimit) ? 20 : parsedLimit))
 
-  const action = searchParams.get('action')
+  // Issue #621 — exact-match (?action) and prefix-match (?actionPrefix) filters
+  const actionFilter = buildActionFilter(searchParams)
+  if (!actionFilter.ok) {
+    return NextResponse.json({ error: actionFilter.error }, { status: 400 })
+  }
 
   const where = {
     actorId: user.id,
-    ...(action ? { eventType: action } : {}),
+    ...actionFilter.clause,
   }
 
   const [total, events] = await Promise.all([

--- a/app/api/routes-b/invoices/overdue/route.ts
+++ b/app/api/routes-b/invoices/overdue/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { Invoice } from '@prisma/client'
 import { verifyAuthToken } from '@/lib/auth'
+import { computeLateFee } from '../../_lib/late-fee' // Issue #599
 
 export async function GET(request: NextRequest) {
   // 1. Verify auth
@@ -17,6 +18,8 @@ export async function GET(request: NextRequest) {
   }
 
   const now = new Date()
+  const { searchParams } = new URL(request.url)
+  const withLateFee = searchParams.get('withLateFee') === 'true' // Issue #599
 
   // 2. Fetch overdue invoices
   // An invoice is overdue when status is 'pending' and dueDate < now
@@ -39,7 +42,7 @@ export async function GET(request: NextRequest) {
       (now.getTime() - inv.dueDate!.getTime()) / (1000 * 60 * 60 * 24)
     )
 
-    return {
+    const base = {
       id: inv.id,
       invoiceNumber: inv.invoiceNumber,
       clientName: inv.clientName,
@@ -48,6 +51,16 @@ export async function GET(request: NextRequest) {
       dueDate: inv.dueDate,
       daysOverdue: Math.max(0, daysOverdue), // Ensure non-negative
     }
+
+    if (withLateFee) {
+      const fee = computeLateFee(
+        { amount: Number(inv.amount), currency: inv.currency, dueDate: inv.dueDate },
+        now,
+      )
+      return { ...base, lateFee: fee }
+    }
+
+    return base
   })
 
   // 4. Return results

--- a/app/api/routes-b/tags/[id]/rename/route.ts
+++ b/app/api/routes-b/tags/[id]/rename/route.ts
@@ -1,0 +1,79 @@
+/**
+ * POST /api/routes-b/tags/[id]/rename — Issue #610
+ *
+ * Rename a tag in a single atomic UPDATE. References to the tag are preserved.
+ * Returns 409 with `mergeIntoId` hint when another tag with the new name
+ * already exists for the same user.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { validateTagName } from '../../../_lib/tag-validation'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  // 1. Auth
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  // 2. Parse and validate body
+  const { id } = await params
+  let body: { newName?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const validation = validateTagName(body.newName)
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 })
+  }
+  const newName = validation.value
+
+  // 3. Verify ownership of the source tag
+  const tag = await prisma.tag.findUnique({ where: { id } })
+  if (!tag) return NextResponse.json({ error: 'Tag not found' }, { status: 404 })
+  if (tag.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  // No-op if name unchanged
+  if (tag.name === newName) {
+    return NextResponse.json({ id: tag.id, name: tag.name, renamed: false })
+  }
+
+  // 4. Conflict check — does the user already have a tag with newName?
+  const existing = await prisma.tag.findFirst({
+    where: { userId: user.id, name: newName, NOT: { id } },
+    select: { id: true },
+  })
+  if (existing) {
+    return NextResponse.json(
+      {
+        error: 'A tag with that name already exists',
+        mergeIntoId: existing.id,
+      },
+      { status: 409 },
+    )
+  }
+
+  // 5. Atomic rename — single UPDATE
+  const updated = await prisma.tag.update({
+    where: { id },
+    data: { name: newName },
+    select: { id: true, name: true, color: true },
+  })
+
+  return NextResponse.json({
+    id: updated.id,
+    name: updated.name,
+    color: updated.color,
+    renamed: true,
+  })
+}


### PR DESCRIPTION
## Summary

All work scoped to `app/api/routes-b/` per issue requirements.

- **#599** — `app/api/routes-b/_lib/late-fee.ts`: pure `computeLateFee(invoice, asOf, policy)` helper. Default policy: 1.5% per 30-day period, capped at 10% of principal. Returns `{ amount, currency, daysLate, applied }`. Wired into `/invoices/overdue?withLateFee=true` — existing default response unchanged when flag is absent.

- **#607** — `app/api/routes-b/_lib/webhook-backoff.ts`: `validateBackoff(input)` validates per-webhook backoff config (initialMs ∈ [50,5000], maxMs ∈ [initialMs, 60000], multiplier ∈ [1,5], jitter ∈ [0,1]); `computeBackoffDelay(attempt, config, random?)` computes the next-retry delay with jitter bounds. Defaults match current global behaviour for backwards compatibility.

- **#610** — `app/api/routes-b/tags/[id]/rename/route.ts`: `POST /tags/:id/rename` with body `{ newName }`. Atomic single UPDATE preserves all references. Returns 409 with `{ error, mergeIntoId }` when another tag with the new name already exists. Uses `_lib/tag-validation.ts` for the name rules (1–32 chars, no control chars).

- **#621** — `app/api/routes-b/_lib/audit-action-filter.ts`: `buildActionFilter(searchParams)` returns a Prisma `eventType` clause from `?action=<exact>` or `?actionPrefix=<prefix>` (length 2–64). Wired into `/audit-log` route — composes with existing date/actor filters via AND. `?action` (exact) wins when both are passed.

## Test plan

**40 tests pass** (`npx vitest run app/api/routes-b/_lib/__tests__/`):
- `late-fee.test.ts` — 10 tests (not overdue, partial period, full period, multiple periods, cap, no due date, currency preservation, ISO strings, default + custom policy)
- `webhook-backoff.test.ts` — 15 tests (defaults, partial merge, range rejections for all four fields, boundary values, exponential growth, cap, jitter bounds, no negatives)
- `audit-action-filter.test.ts` — 8 tests (no filters, equals, startsWith, prefix length bounds, action precedence, whitespace, empty)
- `tag-validation.test.ts` — 7 tests (valid, trim, non-string, empty, length cap, control chars)

Closes #599
Closes #607
Closes #610
Closes #621