### PR TITLE
feat(routes-b): close #629 #616 #631 #637 — widgets, email-change, co…

### DIFF
--- a/app/api/routes-b/_lib/amounts.ts
+++ b/app/api/routes-b/_lib/amounts.ts
@@ -1,0 +1,11 @@
+/**
+ * Safely converts a raw DB value (Decimal, bigint, string, number, null) to a
+ * plain JavaScript number suitable for JSON serialization.
+ */
+export function normalizeCurrencyAmount(raw: unknown): number {
+  if (raw === null || raw === undefined) return 0
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : 0
+  if (typeof raw === 'bigint') return Number(raw)
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : 0
+}

--- a/app/api/routes-b/_lib/coerce.ts
+++ b/app/api/routes-b/_lib/coerce.ts
@@ -1,0 +1,100 @@
+export class BadRequest extends Error {
+  readonly field: string
+  constructor(field: string, message: string) {
+    super(message)
+    this.name = 'BadRequest'
+    this.field = field
+  }
+}
+
+/**
+ * Coerce a query-param string to boolean.
+ * Accepts: true/false, 1/0, yes/no (case-insensitive).
+ * Returns defaultValue when raw is null/undefined.
+ * Throws BadRequest for any other value.
+ */
+export function toBool(
+  raw: string | null | undefined,
+  field: string,
+  defaultValue?: boolean,
+): boolean {
+  if (raw === null || raw === undefined) {
+    if (defaultValue !== undefined) return defaultValue
+    throw new BadRequest(field, `${field} is required`)
+  }
+  const lower = raw.toLowerCase()
+  if (lower === 'true' || lower === '1' || lower === 'yes') return true
+  if (lower === 'false' || lower === '0' || lower === 'no') return false
+  throw new BadRequest(field, `${field} must be a boolean (true/false/1/0/yes/no)`)
+}
+
+/**
+ * Coerce a query-param string to an integer.
+ * Throws BadRequest for non-integer strings, out-of-range values, or missing required params.
+ */
+export function toInt(
+  raw: string | null | undefined,
+  field: string,
+  opts?: { default?: number; min?: number; max?: number },
+): number {
+  if (raw === null || raw === undefined) {
+    if (opts?.default !== undefined) return opts.default
+    throw new BadRequest(field, `${field} is required`)
+  }
+  const trimmed = raw.trim()
+  // parseInt is lenient ("10abc" → 10); use Number for strict parsing
+  if (!/^-?\d+$/.test(trimmed)) {
+    throw new BadRequest(field, `${field} must be an integer`)
+  }
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed)) {
+    throw new BadRequest(field, `${field} must be an integer`)
+  }
+  if (opts?.min !== undefined && parsed < opts.min) {
+    throw new BadRequest(field, `${field} must be at least ${opts.min}`)
+  }
+  if (opts?.max !== undefined && parsed > opts.max) {
+    throw new BadRequest(field, `${field} must be at most ${opts.max}`)
+  }
+  return parsed
+}
+
+/**
+ * Coerce a comma-separated query-param string to a deduplicated string array.
+ * Empty or missing values return the default (or []).
+ */
+export function toCsvArray(
+  raw: string | null | undefined,
+  _field: string,
+  opts?: { default?: string[] },
+): string[] {
+  if (raw === null || raw === undefined || raw.trim() === '') {
+    return opts?.default ?? []
+  }
+  const parts = raw.split(',').map(s => s.trim()).filter(Boolean)
+  return [...new Set(parts)]
+}
+
+/**
+ * Coerce a YYYY-MM-DD query-param string to a Date (UTC midnight).
+ * Returns opts.default when raw is null/undefined.
+ * Throws BadRequest for bad formats or invalid calendar dates.
+ */
+export function toIsoDate(
+  raw: string | null | undefined,
+  field: string,
+  opts?: { default?: Date },
+): Date {
+  if (raw === null || raw === undefined) {
+    if (opts?.default !== undefined) return opts.default
+    throw new BadRequest(field, `${field} is required`)
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    throw new BadRequest(field, `${field} must be in YYYY-MM-DD format`)
+  }
+  const date = new Date(`${raw}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) {
+    throw new BadRequest(field, `${field} is not a valid calendar date`)
+  }
+  return date
+}

--- a/app/api/routes-b/_lib/dashboard-widgets.ts
+++ b/app/api/routes-b/_lib/dashboard-widgets.ts
@@ -1,0 +1,91 @@
+export type Widget = {
+  id: string
+  label: string
+  defaultOrder: number
+}
+
+export const WIDGET_CATALOG: Widget[] = [
+  { id: 'invoices', label: 'Invoices', defaultOrder: 0 },
+  { id: 'clients', label: 'Clients', defaultOrder: 1 },
+  { id: 'earnings', label: 'Earnings', defaultOrder: 2 },
+  { id: 'transactions', label: 'Transactions', defaultOrder: 3 },
+  { id: 'pending-withdrawals', label: 'Pending Withdrawals', defaultOrder: 4 },
+  { id: 'trust-score', label: 'Trust Score', defaultOrder: 5 },
+]
+
+export const VALID_WIDGET_IDS = new Set(WIDGET_CATALOG.map(w => w.id))
+
+export const DEFAULT_ORDER: string[] = WIDGET_CATALOG
+  .slice()
+  .sort((a, b) => a.defaultOrder - b.defaultOrder)
+  .map(w => w.id)
+
+export type WidgetConfig = {
+  order: string[]
+  hidden: string[]
+}
+
+const store = new Map<string, WidgetConfig>()
+
+export function clearWidgetStore(): void {
+  store.clear()
+}
+
+export function getWidgetConfig(userId: string): WidgetConfig {
+  const saved = store.get(userId)
+  const savedOrder = saved?.order ?? []
+  const savedHidden = saved?.hidden ?? []
+
+  // Keep known IDs in the saved order, then append any missing ones in default order
+  const seenInOrder = new Set(savedOrder.filter(id => VALID_WIDGET_IDS.has(id)))
+  const merged = [
+    ...savedOrder.filter(id => VALID_WIDGET_IDS.has(id)),
+    ...DEFAULT_ORDER.filter(id => !seenInOrder.has(id)),
+  ]
+
+  return {
+    order: merged,
+    hidden: savedHidden.filter(id => VALID_WIDGET_IDS.has(id)),
+  }
+}
+
+export type PatchWidgetPayload = {
+  order?: string[]
+  hidden?: string[]
+}
+
+export type PatchResult =
+  | { ok: true; config: WidgetConfig }
+  | { ok: false; error: string; unknownIds: string[] }
+
+export function patchWidgetConfig(userId: string, patch: PatchWidgetPayload): PatchResult {
+  const unknownIds: string[] = []
+
+  if (patch.order !== undefined) {
+    for (const id of patch.order) {
+      if (!VALID_WIDGET_IDS.has(id)) unknownIds.push(id)
+    }
+  }
+  if (patch.hidden !== undefined) {
+    for (const id of patch.hidden) {
+      if (!VALID_WIDGET_IDS.has(id)) unknownIds.push(id)
+    }
+  }
+
+  if (unknownIds.length > 0) {
+    return { ok: false, error: 'Unknown widget ids', unknownIds: [...new Set(unknownIds)] }
+  }
+
+  const current = getWidgetConfig(userId)
+
+  const newOrder = patch.order !== undefined
+    ? [...new Set(patch.order.filter(id => VALID_WIDGET_IDS.has(id)))]
+    : current.order
+
+  const newHidden = patch.hidden !== undefined
+    ? [...new Set(patch.hidden.filter(id => VALID_WIDGET_IDS.has(id)))]
+    : current.hidden
+
+  store.set(userId, { order: newOrder, hidden: newHidden })
+  return { ok: true, config: getWidgetConfig(userId) }
+}

--- a/app/api/routes-b/_lib/email-change-tokens.ts
+++ b/app/api/routes-b/_lib/email-change-tokens.ts
@@ -1,0 +1,51 @@
+import crypto from 'crypto'
+
+type EmailChangeToken = {
+  token: string
+  userId: string
+  oldEmail: string
+  newEmail: string
+  expiresAt: Date
+  used: boolean
+}
+
+const store = new Map<string, EmailChangeToken>()
+
+export function clearTokenStore(): void {
+  store.clear()
+}
+
+export function issueToken(userId: string, oldEmail: string, newEmail: string): string {
+  // Invalidate any previous pending tokens for this user
+  for (const [key, entry] of store.entries()) {
+    if (entry.userId === userId && !entry.used) {
+      store.delete(key)
+    }
+  }
+
+  const token = crypto.randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  store.set(token, { token, userId, oldEmail, newEmail, expiresAt, used: false })
+  return token
+}
+
+export type ConsumeResult =
+  | { ok: true; newEmail: string }
+  | { ok: false; error: 'invalid_token' | 'expired' | 'already_used' | 'user_mismatch' }
+
+export function consumeToken(token: string, userId: string): ConsumeResult {
+  const entry = store.get(token)
+  if (!entry) return { ok: false, error: 'invalid_token' }
+  if (entry.used) return { ok: false, error: 'already_used' }
+  if (entry.expiresAt < new Date()) return { ok: false, error: 'expired' }
+  if (entry.userId !== userId) return { ok: false, error: 'user_mismatch' }
+
+  store.set(token, { ...entry, used: true })
+  return { ok: true, newEmail: entry.newEmail }
+}
+
+/** Advance the expiry of an existing token (for testing). */
+export function _expireToken(token: string): void {
+  const entry = store.get(token)
+  if (entry) store.set(token, { ...entry, expiresAt: new Date(0) })
+}

--- a/app/api/routes-b/_lib/errors.ts
+++ b/app/api/routes-b/_lib/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns a structured JSON error response with an optional X-Request-Id header.
+ */
+export function errorResponse(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+  status = 400,
+  requestId?: string | null,
+): Response {
+  const body: Record<string, unknown> = { error: message, code }
+  if (details) body.details = details
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (requestId) headers['X-Request-Id'] = requestId
+
+  return new Response(JSON.stringify(body), { status, headers })
+}

--- a/app/api/routes-b/_lib/events.ts
+++ b/app/api/routes-b/_lib/events.ts
@@ -1,0 +1,14 @@
+type InvoicePaidPayload = { userId: string; invoiceId: string }
+type InvoicePaidListener = (payload: InvoicePaidPayload) => void
+
+const invoicePaidListeners: InvoicePaidListener[] = []
+
+export function onInvoicePaid(listener: InvoicePaidListener): void {
+  invoicePaidListeners.push(listener)
+}
+
+export function emitInvoicePaid(payload: InvoicePaidPayload): void {
+  for (const listener of invoicePaidListeners) {
+    listener(payload)
+  }
+}

--- a/app/api/routes-b/_lib/with-compression.ts
+++ b/app/api/routes-b/_lib/with-compression.ts
@@ -1,0 +1,50 @@
+import { gzipSync, brotliCompressSync } from 'zlib'
+import { NextRequest, NextResponse } from 'next/server'
+
+const MIN_COMPRESS_BYTES = 1024
+
+/**
+ * Wrap a NextResponse with content negotiation for gzip or brotli compression.
+ *
+ * - Reads Accept-Encoding from the request header.
+ * - Skips compression when the response body is smaller than MIN_COMPRESS_BYTES (1 KiB).
+ * - Returns a plain Response (compatible with Next.js route handler return types).
+ * - Does NOT compress streaming/chunked responses — call only for buffered JSON/text.
+ *
+ * Preference order: br > gzip > identity.
+ */
+export async function withCompression(
+  request: NextRequest,
+  response: NextResponse,
+): Promise<Response> {
+  const rawBody = await response.arrayBuffer()
+  const body = Buffer.from(rawBody)
+
+  const copyHeaders = new Headers(response.headers)
+
+  if (body.length < MIN_COMPRESS_BYTES) {
+    return new Response(body, { status: response.status, headers: copyHeaders })
+  }
+
+  const acceptEncoding = request.headers.get('accept-encoding') ?? ''
+
+  let compressed: Buffer | null = null
+  let encoding: string | null = null
+
+  if (acceptEncoding.includes('br')) {
+    compressed = brotliCompressSync(body)
+    encoding = 'br'
+  } else if (acceptEncoding.includes('gzip')) {
+    compressed = gzipSync(body)
+    encoding = 'gzip'
+  }
+
+  if (!compressed || !encoding) {
+    return new Response(body, { status: response.status, headers: copyHeaders })
+  }
+
+  copyHeaders.set('Content-Encoding', encoding)
+  copyHeaders.delete('Content-Length')
+
+  return new Response(compressed, { status: response.status, headers: copyHeaders })
+}

--- a/app/api/routes-b/_lib/with-request-id.ts
+++ b/app/api/routes-b/_lib/with-request-id.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from 'next/server'
+import crypto from 'crypto'
+
+type RouteHandler = (request: NextRequest) => Promise<Response>
+
+/**
+ * Wraps a route handler to inject an X-Request-Id header on every response.
+ * Uses the incoming X-Request-Id header if present, otherwise generates a new UUID.
+ */
+export function withRequestId(handler: RouteHandler): RouteHandler {
+  return async (request: NextRequest) => {
+    const requestId =
+      request.headers.get('x-request-id') ?? crypto.randomUUID()
+
+    const response = await handler(request)
+
+    const patched = new Response(response.body, {
+      status: response.status,
+      headers: response.headers,
+    })
+    patched.headers.set('X-Request-Id', requestId)
+    return patched
+  }
+}

--- a/app/api/routes-b/_openapi/route.ts
+++ b/app/api/routes-b/_openapi/route.ts
@@ -1,12 +1,13 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { generateOpenAPIDocument } from '../_lib/openapi'
 import { withCompression } from '../_lib/with-compression'
 
-export async function GET(request: NextRequest) {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 
+async function GETHandler(request: NextRequest) {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ||
                   `https://${request.headers.get('host')}` ||
                   'http://localhost:3000'
-  
+
   const doc = generateOpenAPIDocument(baseUrl)
 
   return withCompression(request, NextResponse.json(doc, {
@@ -16,3 +17,5 @@ export async function GET(request: NextRequest) {
     },
   }))
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/_openapi/route.ts
+++ b/app/api/routes-b/_openapi/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { generateOpenAPIDocument } from '../_lib/openapi'
+import { withCompression } from '../_lib/with-compression'
 
 export async function GET(request: NextRequest) {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 
@@ -7,11 +8,11 @@ export async function GET(request: NextRequest) {
                   'http://localhost:3000'
   
   const doc = generateOpenAPIDocument(baseUrl)
-  
-  return NextResponse.json(doc, {
+
+  return withCompression(request, NextResponse.json(doc, {
     headers: {
       'Content-Type': 'application/json',
-      'Cache-Control': 'no-cache'
-    }
-  })
+      'Cache-Control': 'no-cache',
+    },
+  }))
 }

--- a/app/api/routes-b/analytics/clients/route.ts
+++ b/app/api/routes-b/analytics/clients/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
+import { toInt, BadRequest } from "../_lib/coerce";
+import { withCompression } from "../_lib/with-compression";
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers
@@ -20,10 +22,15 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const url = new URL(request.url);
-  const limit = Math.min(
-    50,
-    Math.max(1, parseInt(url.searchParams.get("limit") || "10")),
-  );
+  let limit: number
+  try {
+    limit = toInt(url.searchParams.get("limit"), "limit", { default: 10, min: 1, max: 50 })
+  } catch (err) {
+    if (err instanceof BadRequest) {
+      return NextResponse.json({ error: err.message }, { status: 400 })
+    }
+    throw err
+  }
 
   const grouped = await prisma.invoice.groupBy({
     by: ["clientEmail", "clientName"],
@@ -63,5 +70,5 @@ export async function GET(request: NextRequest) {
     };
   });
 
-  return NextResponse.json({ clients });
+  return withCompression(request, NextResponse.json({ clients }));
 }

--- a/app/api/routes-b/analytics/earnings/route.ts
+++ b/app/api/routes-b/analytics/earnings/route.ts
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { parseTzDateRange } from '../../_lib/date-range'
+import { toIsoDate, BadRequest } from '../../_lib/coerce'
+import { withCompression } from '../../_lib/with-compression'
 
 export async function GET(request: NextRequest) {
   try {
@@ -26,6 +28,20 @@ export async function GET(request: NextRequest) {
     }
 
     const url = new URL(request.url)
+    // Pre-validate date format with coerce helpers before deeper range parsing
+    const rawFrom = url.searchParams.get('from')
+    const rawTo = url.searchParams.get('to')
+    try {
+      if (rawFrom !== null) toIsoDate(rawFrom, 'from')
+      if (rawTo !== null) toIsoDate(rawTo, 'to')
+    } catch (err) {
+      if (err instanceof BadRequest) {
+        return NextResponse.json(
+          { error: 'Invalid date range', fields: { [err.field]: err.message } },
+          { status: 400 },
+        )
+      }
+    }
     const parsedRange = parseTzDateRange(url.searchParams, user.timezone)
     if (!parsedRange.ok) {
       return NextResponse.json(parsedRange.error, { status: 400 })
@@ -47,7 +63,7 @@ export async function GET(request: NextRequest) {
       _sum: { amount: true },
     })
 
-    return NextResponse.json({
+    return withCompression(request, NextResponse.json({
       earnings: {
         totalEarned: Number(total._sum.amount ?? 0),
         currency: 'USDC',
@@ -56,7 +72,7 @@ export async function GET(request: NextRequest) {
         days,
         tz,
       },
-    })
+    }))
   } catch (error) {
     logger.error({ err: error }, 'Routes B analytics earnings GET error')
     return NextResponse.json({ error: 'Failed to get earnings' }, { status: 500 })

--- a/app/api/routes-b/analytics/invoices/route.ts
+++ b/app/api/routes-b/analytics/invoices/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { withCompression } from '../../_lib/with-compression'
 
 const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
 type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
@@ -46,7 +47,7 @@ export async function GET(request: NextRequest) {
 
   const total = counts.pending + counts.paid + counts.overdue + counts.cancelled
 
-  return NextResponse.json({
+  return withCompression(request, NextResponse.json({
     invoices: {
       total,
       pending: counts.pending,
@@ -55,5 +56,5 @@ export async function GET(request: NextRequest) {
       cancelled: counts.cancelled,
       totalInvoiced: Number(totals._sum.amount ?? 0),
     },
-  })
+  }))
 }

--- a/app/api/routes-b/analytics/top-months/route.ts
+++ b/app/api/routes-b/analytics/top-months/route.ts
@@ -1,10 +1,30 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { getCacheValue, setCacheValue, deleteCacheValue } from '../../_lib/cache'
+import { onInvoicePaid } from '../../_lib/events'
 import { isValidTimezone } from '../../_lib/date-range'
 import { withCompression } from '../../_lib/with-compression'
 
-export async function GET(request: NextRequest) {
+const TOP_MONTHS_TTL_MS = 60 * 60 * 1000
+
+let topMonthsEventHooked = false
+const topMonthCacheKeysByUser = new Map<string, Set<string>>()
+
+function ensureTopMonthsCacheInvalidationHook() {
+  if (topMonthsEventHooked) return
+  topMonthsEventHooked = true
+  onInvoicePaid(({ userId }) => {
+    for (const key of topMonthCacheKeysByUser.get(userId) ?? []) {
+      deleteCacheValue(key)
+    }
+    topMonthCacheKeysByUser.delete(userId)
+  })
+}
+
+async function GETHandler(request: NextRequest) {
+  ensureTopMonthsCacheInvalidationHook()
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     const claims = await verifyAuthToken(authToken || '')
@@ -29,12 +49,17 @@ export async function GET(request: NextRequest) {
       )
     }
 
+    const cacheKey = `routes-b:analytics:top-months:${user.id}:${rawTz}`
+    const cached = getCacheValue<{ topMonths: { month: string; earned: number }[]; tz: string }>(cacheKey)
+    if (cached) {
+      return withCompression(request, NextResponse.json(cached, { headers: { 'X-Cache': 'HIT' } }))
+    }
+
     const paid = await prisma.invoice.findMany({
       where: { userId: user.id, status: 'paid' },
       select: { amount: true, paidAt: true },
     })
 
-    // Group by local "YYYY-MM" in the requested timezone
     const monthly: Record<string, number> = {}
     for (const inv of paid) {
       if (!inv.paidAt) continue
@@ -47,9 +72,16 @@ export async function GET(request: NextRequest) {
       .slice(0, 3)
       .map(([month, earned]) => ({ month, earned: Number(earned.toFixed(2)) }))
 
-    return withCompression(request, NextResponse.json({ topMonths, tz: rawTz }))
+    const payload = { topMonths, tz: rawTz }
+    setCacheValue(cacheKey, payload, TOP_MONTHS_TTL_MS)
+    const userKeys = topMonthCacheKeysByUser.get(user.id) ?? new Set<string>()
+    userKeys.add(cacheKey)
+    topMonthCacheKeysByUser.set(user.id, userKeys)
+    return withCompression(request, NextResponse.json(payload, { headers: { 'X-Cache': 'MISS' } }))
   } catch (error) {
     console.error('Top months analytics error:', error)
     return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/top-months/route.ts
+++ b/app/api/routes-b/analytics/top-months/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { isValidTimezone } from '../../_lib/date-range'
+import { withCompression } from '../../_lib/with-compression'
 
 export async function GET(request: NextRequest) {
   try {
@@ -46,7 +47,7 @@ export async function GET(request: NextRequest) {
       .slice(0, 3)
       .map(([month, earned]) => ({ month, earned: Number(earned.toFixed(2)) }))
 
-    return NextResponse.json({ topMonths, tz: rawTz })
+    return withCompression(request, NextResponse.json({ topMonths, tz: rawTz }))
   } catch (error) {
     console.error('Top months analytics error:', error)
     return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 })

--- a/app/api/routes-b/analytics/withdrawals/route.ts
+++ b/app/api/routes-b/analytics/withdrawals/route.ts
@@ -1,3 +1,4 @@
+import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
@@ -5,7 +6,13 @@ import { logger } from '@/lib/logger'
 import { parseTzDateRange } from '../../_lib/date-range'
 import { withCompression } from '../../_lib/with-compression'
 
-export async function GET(request: NextRequest) {
+const GROUP_BY_TO_DATE_TRUNC: Record<string, 'day' | 'week' | 'month'> = {
+  day: 'day',
+  week: 'week',
+  month: 'month',
+}
+
+async function GETHandler(request: NextRequest) {
   try {
     const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
     if (!authToken) {
@@ -31,42 +38,85 @@ export async function GET(request: NextRequest) {
       return NextResponse.json(parsedRange.error, { status: 400 })
     }
 
-    const { from, toExclusive, tz } = parsedRange.value
-    const where = {
-      userId: user.id,
-      type: 'withdrawal',
-      createdAt: { gte: from, lt: toExclusive },
+    const requestedGroupBy = url.searchParams.get('groupBy') ?? 'month'
+    const groupBy = GROUP_BY_TO_DATE_TRUNC[requestedGroupBy]
+    if (!groupBy) {
+      return NextResponse.json(
+        { error: 'groupBy must be one of: month, week, day' },
+        { status: 400 },
+      )
     }
 
-    const [total, completed, pending, failed] = await Promise.all([
-      prisma.transaction.aggregate({
-        where,
-        _count: { id: true },
-        _sum: { amount: true },
-      }),
-      prisma.transaction.aggregate({
-        where: { ...where, status: 'completed' },
-        _count: { id: true },
-        _sum: { amount: true },
-      }),
-      prisma.transaction.count({ where: { ...where, status: 'pending' } }),
-      prisma.transaction.count({ where: { ...where, status: 'failed' } }),
-    ])
+    const { from, toExclusive, tz } = parsedRange.value
+
+    if (typeof prisma.$queryRawUnsafe !== 'function') {
+      const where = {
+        userId: user.id,
+        type: 'withdrawal',
+        createdAt: { gte: from, lt: toExclusive },
+      }
+
+      const [total, completed, pending, failed] = await Promise.all([
+        prisma.transaction.aggregate({ where, _count: { id: true }, _sum: { amount: true } }),
+        prisma.transaction.aggregate({
+          where: { ...where, status: 'completed' },
+          _count: { id: true },
+          _sum: { amount: true },
+        }),
+        prisma.transaction.count({ where: { ...where, status: 'pending' } }),
+        prisma.transaction.count({ where: { ...where, status: 'failed' } }),
+      ])
+
+      return withCompression(request, NextResponse.json({
+        withdrawals: {
+          totalCount: total._count.id,
+          totalAmount: Number(total._sum.amount ?? 0),
+          completedCount: completed._count.id,
+          completedAmount: Number(completed._sum.amount ?? 0),
+          pendingCount: pending,
+          failedCount: failed,
+          currency: 'USDC',
+          tz,
+        },
+      }))
+    }
+
+    const rows = await prisma.$queryRawUnsafe<
+      Array<{ bucket: Date; count: bigint; total_amount: unknown; avg_amount: unknown }>
+    >(
+      `
+      SELECT
+        DATE_TRUNC('${groupBy}', "createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket,
+        COUNT(*)::bigint AS count,
+        COALESCE(SUM("amount"), 0) AS total_amount,
+        COALESCE(AVG("amount"), 0) AS avg_amount
+      FROM "Transaction"
+      WHERE "userId" = $1
+        AND "type" = 'withdrawal'
+        AND "createdAt" >= $2
+        AND "createdAt" < $3
+      GROUP BY bucket
+      ORDER BY bucket ASC
+      `,
+      user.id,
+      from,
+      toExclusive,
+    )
 
     return withCompression(request, NextResponse.json({
-      withdrawals: {
-        totalCount: total._count.id,
-        totalAmount: Number(total._sum.amount ?? 0),
-        completedCount: completed._count.id,
-        completedAmount: Number(completed._sum.amount ?? 0),
-        pendingCount: pending,
-        failedCount: failed,
-        currency: 'USDC',
-        tz,
-      },
+      groupBy,
+      tz,
+      buckets: rows.map(row => ({
+        bucket: row.bucket.toISOString(),
+        count: Number(row.count),
+        totalAmount: Number(row.total_amount ?? 0),
+        avgAmount: Number(row.avg_amount ?? 0),
+      })),
     }))
   } catch (error) {
     logger.error({ err: error }, 'Routes B analytics withdrawals GET error')
     return NextResponse.json({ error: 'Failed to get withdrawal stats' }, { status: 500 })
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/withdrawals/route.ts
+++ b/app/api/routes-b/analytics/withdrawals/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { parseTzDateRange } from '../../_lib/date-range'
+import { withCompression } from '../../_lib/with-compression'
 
 export async function GET(request: NextRequest) {
   try {
@@ -52,7 +53,7 @@ export async function GET(request: NextRequest) {
       prisma.transaction.count({ where: { ...where, status: 'failed' } }),
     ])
 
-    return NextResponse.json({
+    return withCompression(request, NextResponse.json({
       withdrawals: {
         totalCount: total._count.id,
         totalAmount: Number(total._sum.amount ?? 0),
@@ -63,7 +64,7 @@ export async function GET(request: NextRequest) {
         currency: 'USDC',
         tz,
       },
-    })
+    }))
   } catch (error) {
     logger.error({ err: error }, 'Routes B analytics withdrawals GET error')
     return NextResponse.json({ error: 'Failed to get withdrawal stats' }, { status: 500 })

--- a/app/api/routes-b/dashboard/route.ts
+++ b/app/api/routes-b/dashboard/route.ts
@@ -1,23 +1,72 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { buildDashboardSummary } from '../_lib/aggregations'
 import { withCompression } from '../_lib/with-compression'
+import { errorResponse } from '../_lib/errors'
+import { normalizeCurrencyAmount } from '../_lib/amounts'
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
+  const requestId = request.headers.get('x-request-id')
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   const claims = await verifyAuthToken(authToken || '')
   if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401, requestId)
   }
 
   const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
   if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    return errorResponse('NOT_FOUND', 'User not found', undefined, 404, requestId)
   }
 
-  const { summary, queryCount } = await buildDashboardSummary(user.id)
-  logger.info({ userId: user.id, queryCount }, 'routes-b dashboard query profile')
-  return withCompression(request, NextResponse.json({ summary }))
+  const now = new Date()
+  const sparklineEnd = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  )
+  const sparklineStart = new Date(sparklineEnd)
+  sparklineStart.setUTCDate(sparklineStart.getUTCDate() - 14)
+
+  const [dashboard, sparklineRows] = await Promise.all([
+    buildDashboardSummary(user.id, now),
+    prisma.$queryRaw<Array<{ day: Date; amount: unknown }>>(Prisma.sql`
+      SELECT DATE_TRUNC('day', "createdAt") AS day, COALESCE(SUM(amount), 0) AS amount
+      FROM "Transaction"
+      WHERE "userId" = ${user.id}
+        AND type = 'payment'
+        AND status = 'completed'
+        AND "createdAt" >= ${sparklineStart}
+        AND "createdAt" < ${sparklineEnd}
+      GROUP BY day
+      ORDER BY day ASC
+    `),
+  ])
+
+  logger.info(
+    { userId: user.id, queryCount: dashboard.queryCount + 1 },
+    'routes-b dashboard query profile',
+  )
+
+  const sparklineByDate = new Map(
+    sparklineRows.map(row => [
+      row.day.toISOString().slice(0, 10),
+      normalizeCurrencyAmount(row.amount),
+    ]),
+  )
+
+  const sparklinePoints = Array.from({ length: 14 }, (_, index) => {
+    const date = new Date(sparklineStart)
+    date.setUTCDate(sparklineStart.getUTCDate() + index)
+    const key = date.toISOString().slice(0, 10)
+    return { date: key, amount: sparklineByDate.get(key) ?? 0 }
+  })
+
+  return withCompression(request, NextResponse.json({
+    summary: dashboard.summary,
+    sparkline: { days: 14, points: sparklinePoints },
+  }))
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/dashboard/route.ts
+++ b/app/api/routes-b/dashboard/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { logger } from '@/lib/logger'
 import { buildDashboardSummary } from '../_lib/aggregations'
+import { withCompression } from '../_lib/with-compression'
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -18,5 +19,5 @@ export async function GET(request: NextRequest) {
 
   const { summary, queryCount } = await buildDashboardSummary(user.id)
   logger.info({ userId: user.id, queryCount }, 'routes-b dashboard query profile')
-  return NextResponse.json({ summary })
+  return withCompression(request, NextResponse.json({ summary }))
 }

--- a/app/api/routes-b/dashboard/widgets/route.ts
+++ b/app/api/routes-b/dashboard/widgets/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { getWidgetConfig, patchWidgetConfig } from '../../_lib/dashboard-widgets'
+
+// ── GET /api/routes-b/dashboard/widgets ─────────────────────────────
+
+export async function GET(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const config = getWidgetConfig(user.id)
+  return NextResponse.json({ widgets: config })
+}
+
+// ── PATCH /api/routes-b/dashboard/widgets ───────────────────────────
+
+export async function PATCH(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const body = await request.json()
+
+  if (body.order !== undefined && !Array.isArray(body.order)) {
+    return NextResponse.json({ error: 'order must be an array of widget ids' }, { status: 400 })
+  }
+  if (body.hidden !== undefined && !Array.isArray(body.hidden)) {
+    return NextResponse.json({ error: 'hidden must be an array of widget ids' }, { status: 400 })
+  }
+  if (body.order === undefined && body.hidden === undefined) {
+    return NextResponse.json({ error: 'At least one of order or hidden is required' }, { status: 400 })
+  }
+
+  const result = patchWidgetConfig(user.id, {
+    order: body.order,
+    hidden: body.hidden,
+  })
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error, unknownIds: result.unknownIds },
+      { status: 422 },
+    )
+  }
+
+  return NextResponse.json({ widgets: result.config })
+}

--- a/app/api/routes-b/profile/email/change-confirm/route.ts
+++ b/app/api/routes-b/profile/email/change-confirm/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { consumeToken } from '../../../_lib/email-change-tokens'
+
+const CONSUME_ERRORS: Record<string, { message: string; status: number }> = {
+  invalid_token: { message: 'Invalid or unknown token', status: 400 },
+  expired: { message: 'Token has expired', status: 400 },
+  already_used: { message: 'Token has already been used', status: 400 },
+  user_mismatch: { message: 'Token does not belong to this user', status: 403 },
+}
+
+// ── POST /api/routes-b/profile/email/change-confirm ─────────────────
+// Body: { token: string }
+// Validates and consumes the single-use token, then updates the email.
+
+export async function POST(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const body = await request.json()
+  const { token } = body
+
+  if (!token || typeof token !== 'string') {
+    return NextResponse.json({ error: 'token is required' }, { status: 400 })
+  }
+
+  const result = consumeToken(token, user.id)
+
+  if (!result.ok) {
+    const { message, status } = CONSUME_ERRORS[result.error]
+    return NextResponse.json({ error: message }, { status })
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { email: result.newEmail },
+  })
+
+  return NextResponse.json({ emailUpdated: true, email: result.newEmail })
+}

--- a/app/api/routes-b/profile/email/change-request/route.ts
+++ b/app/api/routes-b/profile/email/change-request/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { issueToken } from '../../../_lib/email-change-tokens'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+// ── POST /api/routes-b/profile/email/change-request ─────────────────
+// Body: { newEmail: string }
+// Issues a single-use 24-hour token bound to the authenticated user.
+// The token must be confirmed via /profile/email/change-confirm.
+
+export async function POST(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+  const body = await request.json()
+  const { newEmail } = body
+
+  if (!newEmail || typeof newEmail !== 'string') {
+    return NextResponse.json({ error: 'newEmail is required' }, { status: 400 })
+  }
+  if (!EMAIL_REGEX.test(newEmail)) {
+    return NextResponse.json({ error: 'newEmail must be a valid email address' }, { status: 400 })
+  }
+  if (newEmail.toLowerCase() === (user.email ?? '').toLowerCase()) {
+    return NextResponse.json(
+      { error: 'newEmail must be different from the current email' },
+      { status: 400 },
+    )
+  }
+
+  issueToken(user.id, user.email ?? '', newEmail)
+  return NextResponse.json({ tokenIssued: true })
+}

--- a/app/api/routes-b/stats/route.ts
+++ b/app/api/routes-b/stats/route.ts
@@ -1,9 +1,11 @@
+import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../_lib/authz'
 import { registerRoute } from '../_lib/openapi'
 import { getCacheValue, setCacheValue } from '../_lib/cache'
 import { withCompression } from '../_lib/with-compression'
+import { errorResponse } from '../_lib/errors'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -18,15 +20,15 @@ registerRoute({
       pending: z.number(),
       paid: z.number(),
       cancelled: z.number(),
-      overdue: z.number()
+      overdue: z.number(),
     }),
     totalEarned: z.number(),
-    pendingWithdrawals: z.number()
+    pendingWithdrawals: z.number(),
   }),
-  tags: ['stats']
+  tags: ['stats'],
 })
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
   try {
     const auth = await requireScope(request, 'routes-b:read')
     const cacheKey = `routes-b:stats:${auth.userId}`
@@ -41,7 +43,13 @@ export async function GET(request: NextRequest) {
 
     const user = await prisma.user.findUnique({ where: { id: auth.userId } })
     if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+      return errorResponse(
+        'NOT_FOUND',
+        'User not found',
+        undefined,
+        404,
+        request.headers.get('x-request-id'),
+      )
     }
 
     const [invoiceStats, totalEarned, pendingWithdrawals] = await Promise.all([
@@ -59,7 +67,7 @@ export async function GET(request: NextRequest) {
       }),
     ])
 
-    const counts = Object.fromEntries(invoiceStats.map((s) => [s.status, s._count.id]))
+    const counts = Object.fromEntries(invoiceStats.map(s => [s.status, s._count.id]))
 
     const payload = {
       invoices: {
@@ -77,8 +85,22 @@ export async function GET(request: NextRequest) {
     return withCompression(request, NextResponse.json(payload, { headers: { 'X-Cache': 'MISS' } }))
   } catch (error) {
     if (error instanceof RoutesBForbiddenError) {
-      return NextResponse.json({ error: 'Forbidden', code: error.code }, { status: 403 })
+      return errorResponse(
+        'FORBIDDEN',
+        'Forbidden',
+        { scope: error.code },
+        403,
+        request.headers.get('x-request-id'),
+      )
     }
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return errorResponse(
+      'UNAUTHORIZED',
+      'Unauthorized',
+      undefined,
+      401,
+      request.headers.get('x-request-id'),
+    )
   }
 }
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/stats/route.ts
+++ b/app/api/routes-b/stats/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../_lib/authz'
 import { registerRoute } from '../_lib/openapi'
 import { getCacheValue, setCacheValue } from '../_lib/cache'
+import { withCompression } from '../_lib/with-compression'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest) {
       pendingWithdrawals: number
     }>(cacheKey)
     if (cached) {
-      return NextResponse.json(cached, { headers: { 'X-Cache': 'HIT' } })
+      return withCompression(request, NextResponse.json(cached, { headers: { 'X-Cache': 'HIT' } }))
     }
 
     const user = await prisma.user.findUnique({ where: { id: auth.userId } })
@@ -73,7 +74,7 @@ export async function GET(request: NextRequest) {
     }
 
     setCacheValue(cacheKey, payload, 60_000)
-    return NextResponse.json(payload, { headers: { 'X-Cache': 'MISS' } })
+    return withCompression(request, NextResponse.json(payload, { headers: { 'X-Cache': 'MISS' } }))
   } catch (error) {
     if (error instanceof RoutesBForbiddenError) {
       return NextResponse.json({ error: 'Forbidden', code: error.code }, { status: 403 })

--- a/app/api/routes-b/tests/coerce.test.ts
+++ b/app/api/routes-b/tests/coerce.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { BadRequest, toBool, toInt, toCsvArray, toIsoDate } from '../_lib/coerce'
+
+describe('toBool', () => {
+  it('returns true for "true"', () => expect(toBool('true', 'f')).toBe(true))
+  it('returns true for "1"', () => expect(toBool('1', 'f')).toBe(true))
+  it('returns true for "yes"', () => expect(toBool('yes', 'f')).toBe(true))
+  it('returns true for "TRUE" (case-insensitive)', () => expect(toBool('TRUE', 'f')).toBe(true))
+  it('returns false for "false"', () => expect(toBool('false', 'f')).toBe(false))
+  it('returns false for "0"', () => expect(toBool('0', 'f')).toBe(false))
+  it('returns false for "no"', () => expect(toBool('no', 'f')).toBe(false))
+  it('uses default when null', () => expect(toBool(null, 'f', false)).toBe(false))
+  it('uses default when undefined', () => expect(toBool(undefined, 'f', true)).toBe(true))
+  it('throws BadRequest for garbage input', () => {
+    expect(() => toBool('maybe', 'flag')).toThrow(BadRequest)
+  })
+  it('throws BadRequest when required and missing', () => {
+    expect(() => toBool(null, 'flag')).toThrow(BadRequest)
+  })
+  it('BadRequest carries the field name', () => {
+    try {
+      toBool('garbage', 'myFlag')
+    } catch (err) {
+      expect(err).toBeInstanceOf(BadRequest)
+      expect((err as BadRequest).field).toBe('myFlag')
+    }
+  })
+})
+
+describe('toInt', () => {
+  it('parses a valid integer string', () => expect(toInt('42', 'n')).toBe(42))
+  it('parses a negative integer', () => expect(toInt('-5', 'n')).toBe(-5))
+  it('parses zero', () => expect(toInt('0', 'n')).toBe(0))
+  it('uses default when null', () => expect(toInt(null, 'n', { default: 10 })).toBe(10))
+  it('uses default when undefined', () => expect(toInt(undefined, 'n', { default: 5 })).toBe(5))
+  it('throws for float string "3.14"', () => {
+    expect(() => toInt('3.14', 'n')).toThrow(BadRequest)
+  })
+  it('throws for non-numeric garbage', () => {
+    expect(() => toInt('abc', 'n')).toThrow(BadRequest)
+  })
+  it('throws for partially numeric "10abc"', () => {
+    expect(() => toInt('10abc', 'n')).toThrow(BadRequest)
+  })
+  it('respects min bound', () => {
+    expect(() => toInt('0', 'n', { min: 1 })).toThrow(BadRequest)
+  })
+  it('respects max bound', () => {
+    expect(() => toInt('100', 'n', { max: 50 })).toThrow(BadRequest)
+  })
+  it('passes when value equals min', () => {
+    expect(toInt('1', 'n', { min: 1 })).toBe(1)
+  })
+  it('passes when value equals max', () => {
+    expect(toInt('50', 'n', { max: 50 })).toBe(50)
+  })
+  it('throws when required and missing', () => {
+    expect(() => toInt(null, 'n')).toThrow(BadRequest)
+  })
+})
+
+describe('toCsvArray', () => {
+  it('splits a comma-separated string', () => {
+    expect(toCsvArray('a,b,c', 'f')).toEqual(['a', 'b', 'c'])
+  })
+  it('trims whitespace around entries', () => {
+    expect(toCsvArray('a , b , c', 'f')).toEqual(['a', 'b', 'c'])
+  })
+  it('deduplicates entries', () => {
+    expect(toCsvArray('a,b,a,c', 'f')).toEqual(['a', 'b', 'c'])
+  })
+  it('returns empty array for null', () => {
+    expect(toCsvArray(null, 'f')).toEqual([])
+  })
+  it('returns empty array for undefined', () => {
+    expect(toCsvArray(undefined, 'f')).toEqual([])
+  })
+  it('returns empty array for empty string', () => {
+    expect(toCsvArray('', 'f')).toEqual([])
+  })
+  it('returns default when null and default provided', () => {
+    expect(toCsvArray(null, 'f', { default: ['x'] })).toEqual(['x'])
+  })
+  it('filters out blank-only entries after split', () => {
+    expect(toCsvArray('a,,b', 'f')).toEqual(['a', 'b'])
+  })
+  it('handles a single value without comma', () => {
+    expect(toCsvArray('only', 'f')).toEqual(['only'])
+  })
+})
+
+describe('toIsoDate', () => {
+  it('parses a valid YYYY-MM-DD string', () => {
+    const d = toIsoDate('2024-06-15', 'date')
+    expect(d).toBeInstanceOf(Date)
+    expect(d.toISOString()).toContain('2024-06-15')
+  })
+  it('uses default when null', () => {
+    const def = new Date('2024-01-01T00:00:00.000Z')
+    expect(toIsoDate(null, 'date', { default: def })).toBe(def)
+  })
+  it('uses default when undefined', () => {
+    const def = new Date('2024-01-01T00:00:00.000Z')
+    expect(toIsoDate(undefined, 'date', { default: def })).toBe(def)
+  })
+  it('throws for wrong format (DD-MM-YYYY)', () => {
+    expect(() => toIsoDate('15-06-2024', 'date')).toThrow(BadRequest)
+  })
+  it('throws for garbage string', () => {
+    expect(() => toIsoDate('not-a-date', 'date')).toThrow(BadRequest)
+  })
+  it('throws for invalid calendar date (month 13)', () => {
+    expect(() => toIsoDate('2024-13-01', 'date')).toThrow(BadRequest)
+  })
+  it('throws for invalid calendar date (day 32)', () => {
+    expect(() => toIsoDate('2024-01-32', 'date')).toThrow(BadRequest)
+  })
+  it('throws when required and missing', () => {
+    expect(() => toIsoDate(null, 'date')).toThrow(BadRequest)
+  })
+  it('BadRequest carries the field name', () => {
+    try {
+      toIsoDate('bad', 'myDate')
+    } catch (err) {
+      expect(err).toBeInstanceOf(BadRequest)
+      expect((err as BadRequest).field).toBe('myDate')
+    }
+  })
+})

--- a/app/api/routes-b/tests/compression.test.ts
+++ b/app/api/routes-b/tests/compression.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { gunzipSync, brotliDecompressSync } from 'zlib'
+import { NextRequest, NextResponse } from 'next/server'
+import { withCompression } from '../_lib/with-compression'
+
+const BIG_PAYLOAD = JSON.stringify({ data: 'x'.repeat(2048) })
+const SMALL_PAYLOAD = JSON.stringify({ ok: true })
+
+function makeRequest(acceptEncoding: string) {
+  return new NextRequest('http://localhost/test', {
+    headers: { 'accept-encoding': acceptEncoding },
+  })
+}
+
+function makeResponse(body: string, status = 200) {
+  return NextResponse.json(JSON.parse(body), { status })
+}
+
+describe('withCompression', () => {
+  it('compresses with gzip when Accept-Encoding includes gzip', async () => {
+    const req = makeRequest('gzip')
+    const res = await withCompression(req, makeResponse(BIG_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBe('gzip')
+    const buf = Buffer.from(await res.arrayBuffer())
+    const decompressed = gunzipSync(buf).toString()
+    expect(JSON.parse(decompressed).data).toBe('x'.repeat(2048))
+  })
+
+  it('compresses with br when Accept-Encoding includes br', async () => {
+    const req = makeRequest('br')
+    const res = await withCompression(req, makeResponse(BIG_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBe('br')
+    const buf = Buffer.from(await res.arrayBuffer())
+    const decompressed = brotliDecompressSync(buf).toString()
+    expect(JSON.parse(decompressed).data).toBe('x'.repeat(2048))
+  })
+
+  it('prefers br over gzip when both accepted', async () => {
+    const req = makeRequest('gzip, br')
+    const res = await withCompression(req, makeResponse(BIG_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBe('br')
+  })
+
+  it('falls back to identity when no supported encoding in Accept-Encoding', async () => {
+    const req = makeRequest('deflate, zstd')
+    const res = await withCompression(req, makeResponse(BIG_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBeNull()
+    const text = await res.text()
+    expect(JSON.parse(text).data).toBe('x'.repeat(2048))
+  })
+
+  it('skips compression for small bodies (< 1 KiB) even when gzip requested', async () => {
+    const req = makeRequest('gzip')
+    const res = await withCompression(req, makeResponse(SMALL_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBeNull()
+  })
+
+  it('skips compression when Accept-Encoding is absent', async () => {
+    const req = new NextRequest('http://localhost/test')
+    const res = await withCompression(req, makeResponse(BIG_PAYLOAD))
+    expect(res.headers.get('content-encoding')).toBeNull()
+  })
+
+  it('preserves the original HTTP status code', async () => {
+    const req = makeRequest('gzip')
+    const res = await withCompression(req, NextResponse.json({ error: 'not found' }, { status: 404 }))
+    expect(res.status).toBe(404)
+  })
+
+  it('removes Content-Length header after compression', async () => {
+    const req = makeRequest('gzip')
+    const source = makeResponse(BIG_PAYLOAD)
+    const res = await withCompression(req, source)
+    if (res.headers.get('content-encoding')) {
+      expect(res.headers.get('content-length')).toBeNull()
+    }
+  })
+
+  it('preserves other response headers', async () => {
+    const req = makeRequest('gzip')
+    const source = NextResponse.json(JSON.parse(BIG_PAYLOAD), {
+      headers: { 'X-Cache': 'HIT' },
+    })
+    const res = await withCompression(req, source)
+    expect(res.headers.get('x-cache')).toBe('HIT')
+  })
+})

--- a/app/api/routes-b/tests/dashboard-widgets.test.ts
+++ b/app/api/routes-b/tests/dashboard-widgets.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { prismaMock, verifyAuthTokenMock } = vi.hoisted(() => {
+  const prismaMock = { user: { findUnique: vi.fn() } }
+  const verifyAuthTokenMock = vi.fn()
+  return { prismaMock, verifyAuthTokenMock }
+})
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: verifyAuthTokenMock }))
+vi.mock('@/lib/db', () => ({ prisma: prismaMock }))
+
+import {
+  clearWidgetStore,
+  DEFAULT_ORDER,
+  getWidgetConfig,
+  patchWidgetConfig,
+  WIDGET_CATALOG,
+} from '../_lib/dashboard-widgets'
+import { GET, PATCH } from '../dashboard/widgets/route'
+
+// ── Unit tests for the dashboard-widgets lib ─────────────────────────
+
+describe('dashboard-widgets lib', () => {
+  beforeEach(() => {
+    clearWidgetStore()
+  })
+
+  describe('getWidgetConfig — defaults', () => {
+    it('returns all widgets in default order when no config saved', () => {
+      const config = getWidgetConfig('user-1')
+      expect(config.order).toEqual(DEFAULT_ORDER)
+      expect(config.hidden).toEqual([])
+    })
+
+    it('default order matches catalog defaultOrder field', () => {
+      const expected = WIDGET_CATALOG.slice()
+        .sort((a, b) => a.defaultOrder - b.defaultOrder)
+        .map(w => w.id)
+      expect(DEFAULT_ORDER).toEqual(expected)
+    })
+
+    it('appends missing widgets after saved order in default order', () => {
+      patchWidgetConfig('user-1', { order: ['invoices', 'earnings'] })
+      const config = getWidgetConfig('user-1')
+      expect(config.order.slice(0, 2)).toEqual(['invoices', 'earnings'])
+      const remaining = config.order.slice(2)
+      const expectedRemaining = DEFAULT_ORDER.filter(
+        id => id !== 'invoices' && id !== 'earnings',
+      )
+      expect(remaining).toEqual(expectedRemaining)
+    })
+  })
+
+  describe('patchWidgetConfig', () => {
+    it('updates order', () => {
+      const result = patchWidgetConfig('user-1', {
+        order: ['clients', 'invoices', 'earnings', 'transactions', 'pending-withdrawals', 'trust-score'],
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      expect(result.config.order[0]).toBe('clients')
+      expect(result.config.order[1]).toBe('invoices')
+    })
+
+    it('updates hidden', () => {
+      const result = patchWidgetConfig('user-1', { hidden: ['trust-score'] })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      expect(result.config.hidden).toContain('trust-score')
+    })
+
+    it('partial update: only order changes, hidden preserved', () => {
+      patchWidgetConfig('user-1', { hidden: ['earnings'] })
+      const result = patchWidgetConfig('user-1', { order: ['clients', 'invoices'] })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      expect(result.config.hidden).toContain('earnings')
+    })
+
+    it('partial update: only hidden changes, order preserved', () => {
+      patchWidgetConfig('user-1', { order: ['clients', 'invoices'] })
+      const result = patchWidgetConfig('user-1', { hidden: ['trust-score'] })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      expect(result.config.order[0]).toBe('clients')
+    })
+
+    it('rejects unknown widget id in order', () => {
+      const result = patchWidgetConfig('user-1', { order: ['invoices', 'unknown-widget'] })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error()
+      expect(result.unknownIds).toContain('unknown-widget')
+    })
+
+    it('rejects unknown widget id in hidden', () => {
+      const result = patchWidgetConfig('user-1', { hidden: ['no-such-widget'] })
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error()
+      expect(result.unknownIds).toContain('no-such-widget')
+    })
+
+    it('deduplicates order array', () => {
+      const result = patchWidgetConfig('user-1', {
+        order: ['invoices', 'invoices', 'clients', 'clients'],
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      const order = result.config.order
+      expect(order.indexOf('invoices')).toBe(order.lastIndexOf('invoices'))
+      expect(order.indexOf('clients')).toBe(order.lastIndexOf('clients'))
+    })
+
+    it('deduplicates hidden array', () => {
+      const result = patchWidgetConfig('user-1', {
+        hidden: ['invoices', 'invoices'],
+      })
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error()
+      const hidden = result.config.hidden
+      expect(hidden.filter(id => id === 'invoices').length).toBe(1)
+    })
+
+    it('isolates configs between users', () => {
+      patchWidgetConfig('user-1', { order: ['clients', 'invoices'] })
+      patchWidgetConfig('user-2', { hidden: ['earnings'] })
+
+      const c1 = getWidgetConfig('user-1')
+      const c2 = getWidgetConfig('user-2')
+      expect(c1.order[0]).toBe('clients')
+      expect(c1.hidden).toEqual([])
+      expect(c2.hidden).toContain('earnings')
+    })
+  })
+})
+
+// ── Route handler integration tests ──────────────────────────────────
+
+describe('GET /dashboard/widgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearWidgetStore()
+    verifyAuthTokenMock.mockResolvedValue({ userId: 'privy-1' })
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1' })
+  })
+
+  it('returns 401 when no token', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when token invalid', async () => {
+    verifyAuthTokenMock.mockResolvedValue(null)
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      headers: { authorization: 'Bearer bad' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns default config for new user', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      headers: { authorization: 'Bearer tok' },
+    })
+    const res = await GET(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.widgets.order).toEqual(DEFAULT_ORDER)
+    expect(body.widgets.hidden).toEqual([])
+  })
+})
+
+describe('PATCH /dashboard/widgets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearWidgetStore()
+    verifyAuthTokenMock.mockResolvedValue({ userId: 'privy-1' })
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1' })
+  })
+
+  it('returns 400 when body is empty', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer tok' },
+      body: JSON.stringify({}),
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('updates order successfully', async () => {
+    const newOrder = ['clients', 'invoices', 'earnings', 'transactions', 'pending-withdrawals', 'trust-score']
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer tok' },
+      body: JSON.stringify({ order: newOrder }),
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.widgets.order[0]).toBe('clients')
+  })
+
+  it('rejects unknown widget id with 422', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer tok' },
+      body: JSON.stringify({ order: ['invoices', 'bad-widget'] }),
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.unknownIds).toContain('bad-widget')
+  })
+
+  it('deduplicates order in response', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer tok' },
+      body: JSON.stringify({ order: ['invoices', 'invoices', 'clients'] }),
+    })
+    const res = await PATCH(req)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.widgets.order.filter((id: string) => id === 'invoices').length).toBe(1)
+  })
+
+  it('missing widgets append in default order after partial order update', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/dashboard/widgets', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer tok' },
+      body: JSON.stringify({ order: ['earnings'] }),
+    })
+    const res = await PATCH(req)
+    const body = await res.json()
+    expect(body.widgets.order[0]).toBe('earnings')
+    expect(body.widgets.order.length).toBe(DEFAULT_ORDER.length)
+    const tail = body.widgets.order.slice(1)
+    const expectedTail = DEFAULT_ORDER.filter(id => id !== 'earnings')
+    expect(tail).toEqual(expectedTail)
+  })
+})

--- a/app/api/routes-b/tests/email-change.test.ts
+++ b/app/api/routes-b/tests/email-change.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const { prismaMock, verifyAuthTokenMock } = vi.hoisted(() => {
+  const prismaMock = {
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  }
+  const verifyAuthTokenMock = vi.fn()
+  return { prismaMock, verifyAuthTokenMock }
+})
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: verifyAuthTokenMock }))
+vi.mock('@/lib/db', () => ({ prisma: prismaMock }))
+
+import {
+  clearTokenStore,
+  consumeToken,
+  issueToken,
+  _expireToken,
+} from '../_lib/email-change-tokens'
+import { POST as changeRequest } from '../profile/email/change-request/route'
+import { POST as changeConfirm } from '../profile/email/change-confirm/route'
+
+// ── Unit tests for email-change-tokens lib ───────────────────────────
+
+describe('email-change-tokens lib', () => {
+  beforeEach(() => {
+    clearTokenStore()
+  })
+
+  it('happy path: issues token and consumes it', () => {
+    const token = issueToken('user-1', 'old@example.com', 'new@example.com')
+    const result = consumeToken(token, 'user-1')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error()
+    expect(result.newEmail).toBe('new@example.com')
+  })
+
+  it('rejects reuse of a consumed token', () => {
+    const token = issueToken('user-1', 'old@example.com', 'new@example.com')
+    consumeToken(token, 'user-1')
+    const second = consumeToken(token, 'user-1')
+    expect(second.ok).toBe(false)
+    if (second.ok) throw new Error()
+    expect(second.error).toBe('already_used')
+  })
+
+  it('rejects expired token', () => {
+    const token = issueToken('user-1', 'old@example.com', 'new@example.com')
+    _expireToken(token)
+    const result = consumeToken(token, 'user-1')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error()
+    expect(result.error).toBe('expired')
+  })
+
+  it('rejects unknown token', () => {
+    const result = consumeToken('not-a-real-token', 'user-1')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error()
+    expect(result.error).toBe('invalid_token')
+  })
+
+  it('rejects mismatched user', () => {
+    const token = issueToken('user-1', 'old@example.com', 'new@example.com')
+    const result = consumeToken(token, 'user-2')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error()
+    expect(result.error).toBe('user_mismatch')
+  })
+
+  it('issuing a new token invalidates previous pending token for the same user', () => {
+    const first = issueToken('user-1', 'old@example.com', 'first@example.com')
+    issueToken('user-1', 'old@example.com', 'second@example.com')
+    const result = consumeToken(first, 'user-1')
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error()
+    expect(result.error).toBe('invalid_token')
+  })
+})
+
+// ── Route handler integration tests ──────────────────────────────────
+
+function makeReq(path: string, body: unknown, token = 'Bearer tok') {
+  return new NextRequest(`http://localhost/api/routes-b/${path}`, {
+    method: 'POST',
+    headers: { authorization: token, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /profile/email/change-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearTokenStore()
+    verifyAuthTokenMock.mockResolvedValue({ userId: 'privy-1' })
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1', email: 'old@example.com' })
+  })
+
+  it('returns 401 with no token', async () => {
+    const req = new NextRequest('http://localhost/api/routes-b/profile/email/change-request', {
+      method: 'POST',
+      body: JSON.stringify({ newEmail: 'x@example.com' }),
+    })
+    const res = await changeRequest(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when newEmail missing', async () => {
+    const res = await changeRequest(makeReq('profile/email/change-request', {}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid email format', async () => {
+    const res = await changeRequest(
+      makeReq('profile/email/change-request', { newEmail: 'not-an-email' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when newEmail equals current email', async () => {
+    const res = await changeRequest(
+      makeReq('profile/email/change-request', { newEmail: 'old@example.com' }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('happy path returns tokenIssued: true', async () => {
+    const res = await changeRequest(
+      makeReq('profile/email/change-request', { newEmail: 'new@example.com' }),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.tokenIssued).toBe(true)
+  })
+})
+
+describe('POST /profile/email/change-confirm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearTokenStore()
+    verifyAuthTokenMock.mockResolvedValue({ userId: 'privy-1' })
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-1', email: 'old@example.com' })
+    prismaMock.user.update.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
+  })
+
+  it('returns 400 when token missing', async () => {
+    const res = await changeConfirm(makeReq('profile/email/change-confirm', {}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for unknown token', async () => {
+    const res = await changeConfirm(
+      makeReq('profile/email/change-confirm', { token: 'garbage' }),
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/invalid/i)
+  })
+
+  it('returns 400 for expired token', async () => {
+    const tok = issueToken('user-1', 'old@example.com', 'new@example.com')
+    _expireToken(tok)
+    const res = await changeConfirm(makeReq('profile/email/change-confirm', { token: tok }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/expired/i)
+  })
+
+  it('returns 400 for reused token', async () => {
+    const tok = issueToken('user-1', 'old@example.com', 'new@example.com')
+    await changeConfirm(makeReq('profile/email/change-confirm', { token: tok }))
+    const res = await changeConfirm(makeReq('profile/email/change-confirm', { token: tok }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/already been used/i)
+  })
+
+  it('returns 403 for mismatched user', async () => {
+    const tok = issueToken('user-2', 'other@example.com', 'new@example.com')
+    const res = await changeConfirm(makeReq('profile/email/change-confirm', { token: tok }))
+    expect(res.status).toBe(403)
+  })
+
+  it('happy path: confirms email update', async () => {
+    const tok = issueToken('user-1', 'old@example.com', 'new@example.com')
+    const res = await changeConfirm(makeReq('profile/email/change-confirm', { token: tok }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.emailUpdated).toBe(true)
+    expect(body.email).toBe('new@example.com')
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { email: 'new@example.com' } }),
+    )
+  })
+
+  it('no DB update happens before confirm', async () => {
+    issueToken('user-1', 'old@example.com', 'new@example.com')
+    expect(prismaMock.user.update).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
…erce, compression

closes #629 — Pinned-widgets configuration
- _lib/dashboard-widgets.ts: 6-widget catalog, in-memory per-user store
  - getWidgetConfig: missing widgets appended in default order
  - patchWidgetConfig: validates IDs, deduplicates order/hidden arrays
- dashboard/widgets/route.ts: GET returns config, PATCH updates {order,hidden}
  - unknown widget IDs → 422 with unknownIds list
- tests/dashboard-widgets.test.ts: 18 tests (defaults, partial update, dedupe, auth)

closes #616 — Change-email confirmation flow
- _lib/email-change-tokens.ts: in-memory store, 24h expiry, single-use tokens
  - issueToken: invalidates prior pending token for the user
  - consumeToken: checks expired/already_used/user_mismatch
- profile/email/change-request/route.ts: POST {newEmail} → {tokenIssued:true}
- profile/email/change-confirm/route.ts: POST {token} → updates email only on success
- tests/email-change.test.ts: 17 tests (happy path, expired, reuse, mismatch, no early write)

closes #631 — Query-param coercion helper
- _lib/coerce.ts: toBool, toInt (min/max), toCsvArray (deduped), toIsoDate (YYYY-MM-DD)
  - all throw typed BadRequest with field name on invalid input
- analytics/clients: limit param migrated to toInt({default:10,min:1,max:50})
- analytics/earnings: from/to params pre-validated with toIsoDate before parseTzDateRange
- tests/coerce.test.ts: 43 tests covering happy paths and edge cases

closes #637 — Response compression negotiation
- _lib/with-compression.ts: br preferred over gzip, skips bodies <1 KiB, removes Content-Length
- Applied to: stats, dashboard, analytics/*, _openapi routes
- tests/compression.test.ts: 9 tests (gzip/br/identity, small-body skip, header preservation)