### PR TITLE
feat(routes-b): add invoice refund action (#602)

### DIFF
--- a/app/api/routes-b/invoices/[id]/refund/route.ts
+++ b/app/api/routes-b/invoices/[id]/refund/route.ts
@@ -1,0 +1,137 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const REFUND_EVENT_TYPE = 'invoice.refunded'
+const MAX_REASON_LENGTH = 500
+
+function toCents(amount: number) {
+  return Math.round(amount * 100)
+}
+
+function fromCents(cents: number) {
+  return cents / 100
+}
+
+async function POSTHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: { id: true, userId: true, status: true, amount: true, currency: true },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (invoice.status !== 'paid') {
+    return NextResponse.json(
+      { error: 'Only paid invoices can be refunded', code: 'INVOICE_NOT_PAID' },
+      { status: 422 },
+    )
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { amount, reason } = body as { amount?: unknown; reason?: unknown }
+
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+    return NextResponse.json({ error: 'amount must be a positive number' }, { status: 400 })
+  }
+  if (typeof reason !== 'string' || reason.trim() === '') {
+    return NextResponse.json({ error: 'reason must be a non-empty string' }, { status: 400 })
+  }
+  if (reason.length > MAX_REASON_LENGTH) {
+    return NextResponse.json(
+      { error: `reason must be ${MAX_REASON_LENGTH} characters or fewer` },
+      { status: 400 },
+    )
+  }
+
+  const amountCents = toCents(amount)
+  if (amountCents <= 0) {
+    return NextResponse.json({ error: 'amount must be at least 0.01' }, { status: 400 })
+  }
+
+  const priorRefunds = await prisma.auditEvent.findMany({
+    where: { invoiceId: invoice.id, eventType: REFUND_EVENT_TYPE },
+    select: { metadata: true },
+  })
+
+  const totalAlreadyRefundedCents = priorRefunds.reduce((sum, ev) => {
+    const meta = ev.metadata as { amount?: number } | null
+    return sum + (typeof meta?.amount === 'number' ? toCents(meta.amount) : 0)
+  }, 0)
+
+  const invoiceTotalCents = toCents(Number(invoice.amount))
+  const remainingCents = invoiceTotalCents - totalAlreadyRefundedCents
+
+  if (amountCents > remainingCents) {
+    return NextResponse.json(
+      {
+        error: 'Refund amount exceeds remaining refundable',
+        code: 'REFUND_EXCEEDS_REMAINING',
+        remainingRefundable: fromCents(remainingCents),
+      },
+      { status: 422 },
+    )
+  }
+
+  const newTotalRefundedCents = totalAlreadyRefundedCents + amountCents
+  const normalizedAmount = fromCents(amountCents)
+  const trimmedReason = reason.trim()
+
+  const event = await prisma.auditEvent.create({
+    data: {
+      invoiceId: invoice.id,
+      eventType: REFUND_EVENT_TYPE,
+      actorId: user.id,
+      metadata: {
+        amount: normalizedAmount,
+        currency: invoice.currency,
+        reason: trimmedReason,
+        cumulativeRefundedAfter: fromCents(newTotalRefundedCents),
+      } as Record<string, unknown>,
+      signature: 'system-refund',
+    },
+  })
+
+  return NextResponse.json(
+    {
+      refund: {
+        id: event.id,
+        invoiceId: invoice.id,
+        amount: normalizedAmount,
+        currency: invoice.currency,
+        reason: trimmedReason,
+        refundedAt: event.createdAt,
+      },
+      totalRefunded: fromCents(newTotalRefundedCents),
+      remainingRefundable: fromCents(invoiceTotalCents - newTotalRefundedCents),
+    },
+    { status: 201 },
+  )
+}
+
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/__tests__/refund.test.ts
+++ b/app/api/routes-b/invoices/__tests__/refund.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    auditEvent: { findMany: vi.fn(), create: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { POST } from '../[id]/refund/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindUnique = vi.mocked(prisma.invoice.findUnique)
+const mockedAuditFindMany = vi.mocked(prisma.auditEvent.findMany)
+const mockedAuditCreate = vi.mocked(prisma.auditEvent.create)
+
+const fakeUser = { id: 'user-1', privyId: 'privy-1' }
+
+const paidInvoice = {
+  id: 'inv-1',
+  userId: 'user-1',
+  status: 'paid',
+  amount: 100,
+  currency: 'USD',
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/routes-b/invoices/inv-1/refund', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token' },
+    body: JSON.stringify(body),
+  })
+}
+
+const params = { params: Promise.resolve({ id: 'inv-1' }) }
+
+describe('POST /api/routes-b/invoices/[id]/refund', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(paidInvoice as never)
+    mockedAuditFindMany.mockResolvedValue([] as never)
+    mockedAuditCreate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) =>
+      ({
+        id: 'audit-1',
+        ...data,
+        createdAt: new Date('2026-04-29T00:00:00.000Z'),
+      } as never),
+    )
+  })
+
+  it('processes a full refund on a paid invoice', async () => {
+    const res = await POST(makeRequest({ amount: 100, reason: 'customer satisfaction' }), params)
+    const json = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(json.refund.amount).toBe(100)
+    expect(json.totalRefunded).toBe(100)
+    expect(json.remainingRefundable).toBe(0)
+    expect(mockedAuditCreate).toHaveBeenCalledOnce()
+    expect(mockedAuditCreate.mock.calls[0][0].data).toMatchObject({
+      eventType: 'invoice.refunded',
+      actorId: 'user-1',
+      invoiceId: 'inv-1',
+    })
+  })
+
+  it('processes a partial refund and reports remaining', async () => {
+    const res = await POST(makeRequest({ amount: 30, reason: 'partial' }), params)
+    const json = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(json.totalRefunded).toBe(30)
+    expect(json.remainingRefundable).toBe(70)
+  })
+
+  it('stacks a second partial refund on top of the first', async () => {
+    mockedAuditFindMany.mockResolvedValue([{ metadata: { amount: 30 } }] as never)
+
+    const res = await POST(makeRequest({ amount: 25, reason: 'second partial' }), params)
+    const json = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(json.totalRefunded).toBe(55)
+    expect(json.remainingRefundable).toBe(45)
+  })
+
+  it('rejects a refund that would exceed the remaining refundable', async () => {
+    mockedAuditFindMany.mockResolvedValue([{ metadata: { amount: 80 } }] as never)
+
+    const res = await POST(makeRequest({ amount: 25, reason: 'too much' }), params)
+    const json = await res.json()
+
+    expect(res.status).toBe(422)
+    expect(json.code).toBe('REFUND_EXCEEDS_REMAINING')
+    expect(json.remainingRefundable).toBe(20)
+    expect(mockedAuditCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a refund on an unpaid invoice', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue({ ...paidInvoice, status: 'pending' } as never)
+
+    const res = await POST(makeRequest({ amount: 10, reason: 'nope' }), params)
+    const json = await res.json()
+
+    expect(res.status).toBe(422)
+    expect(json.code).toBe('INVOICE_NOT_PAID')
+    expect(mockedAuditCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects when amount is missing or non-positive', async () => {
+    const noAmount = await POST(makeRequest({ reason: 'x' }), params)
+    expect(noAmount.status).toBe(400)
+
+    const zero = await POST(makeRequest({ amount: 0, reason: 'x' }), params)
+    expect(zero.status).toBe(400)
+
+    const negative = await POST(makeRequest({ amount: -1, reason: 'x' }), params)
+    expect(negative.status).toBe(400)
+  })
+
+  it('rejects when reason is missing or too long', async () => {
+    const noReason = await POST(makeRequest({ amount: 10 }), params)
+    expect(noReason.status).toBe(400)
+
+    const empty = await POST(makeRequest({ amount: 10, reason: '   ' }), params)
+    expect(empty.status).toBe(400)
+
+    const tooLong = await POST(makeRequest({ amount: 10, reason: 'x'.repeat(501) }), params)
+    expect(tooLong.status).toBe(400)
+  })
+
+  it('returns 403 when invoice belongs to another user', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue({ ...paidInvoice, userId: 'other-user' } as never)
+
+    const res = await POST(makeRequest({ amount: 10, reason: 'x' }), params)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 when invoice does not exist', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue(null as never)
+
+    const res = await POST(makeRequest({ amount: 10, reason: 'x' }), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 401 when auth token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+
+    const res = await POST(makeRequest({ amount: 10, reason: 'x' }), params)
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `POST /api/routes-b/invoices/[id]/refund` accepting `{ amount, reason }`
- Tracks cumulative refunded across multiple partial refunds via `invoice.refunded` `AuditEvent` rows so totals never exceed the invoice amount
- Audit-logs each refund with actor, amount, reason, and post-refund cumulative
- Returns the refund record plus `totalRefunded` and `remainingRefundable`

## Scope
All work is contained in `app/api/routes-b/` per the scope rule. No schema migration was added — refund accounting is derived from existing `AuditEvent` rows (the issue notes the cumulative refunded field is logical and may be derived).

## Behavior / acceptance
- Rejects refunds on non-paid invoices with `INVOICE_NOT_PAID` (422)
- Rejects refunds exceeding remaining refundable with `REFUND_EXCEEDS_REMAINING` (422), echoing the remaining amount
- Validates `amount` is a positive number and `reason` is a non-empty string ≤ 500 chars
- Cumulative refunds never exceed invoice total (enforced in cents to avoid float drift)
- Audit trail captures who and why on every refund

## Test plan
- [x] Full refund of paid invoice
- [x] Partial refund returns remaining
- [x] Second partial stacks on top of the first
- [x] Refund exceeding remaining is rejected with 422
- [x] Refund on unpaid invoice rejected with 422
- [x] 400 on missing/invalid amount or reason
- [x] 403 on cross-user invoice; 404 on missing invoice; 401 on bad auth

Closes #602