### PR TITLE
feat: add invoice status distribution to analytics

### DIFF
--- a/app/api/routes-b/analytics/invoices/route.ts
+++ b/app/api/routes-b/analytics/invoices/route.ts
@@ -19,45 +19,62 @@ async function GETHandler(request: NextRequest) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
-  const [grouped, totals] = await Promise.all([
-    prisma.invoice.groupBy({
-      by: ['status'],
-      where: { userId: user.id },
-      _count: { id: true },
-    }),
-    prisma.invoice.aggregate({
-      where: { userId: user.id },
-      _count: { id: true },
-      _sum: { amount: true },
-    }),
-  ])
+  const grouped = await prisma.invoice.groupBy({
+    by: ['status'],
+    where: { userId: user.id },
+    _count: { id: true },
+    _sum: { amount: true },
+  })
 
-  const counts = INVOICE_STATUSES.reduce<Record<InvoiceStatus, number>>(
+  const stats = INVOICE_STATUSES.reduce<Record<InvoiceStatus, { count: number; totalAmount: number }>>(
     (acc, status) => {
-      acc[status] = 0
+      acc[status] = { count: 0, totalAmount: 0 }
       return acc
     },
-    {} as Record<InvoiceStatus, number>,
+    {} as any,
   )
 
+  let totalCount = 0
+  let totalInvoiced = 0
+
   for (const row of grouped) {
-    if (INVOICE_STATUSES.includes(row.status as InvoiceStatus)) {
-      counts[row.status as InvoiceStatus] = row._count.id
+    const status = row.status as InvoiceStatus
+    if (INVOICE_STATUSES.includes(status)) {
+      stats[status].count = row._count.id
+      const amount = Number(row._sum.amount ?? 0)
+      stats[status].totalAmount = amount
+      totalCount += row._count.id
+      totalInvoiced += amount
     }
   }
 
-  const total = counts.pending + counts.paid + counts.overdue + counts.cancelled
-
-  return withCompression(request, NextResponse.json({
-    invoices: {
-      total,
-      pending: counts.pending,
-      paid: counts.paid,
-      overdue: counts.overdue,
-      cancelled: counts.cancelled,
-      totalInvoiced: Number(totals._sum.amount ?? 0),
+  const distribution = INVOICE_STATUSES.reduce<Record<InvoiceStatus, { count: number; percentage: number }>>(
+    (acc, status) => {
+      const count = stats[status].count
+      acc[status] = {
+        count,
+        percentage: totalCount > 0 ? Number(((count / totalCount) * 100).toFixed(2)) : 0,
+      }
+      return acc
     },
-  }))
+    {} as any,
+  )
+
+  return withCompression(
+    request,
+    NextResponse.json({
+      invoices: {
+        total: totalCount,
+        pending: stats.pending.count,
+        paid: stats.paid.count,
+        overdue: stats.overdue.count,
+        cancelled: stats.cancelled.count,
+        totalInvoiced,
+        distribution,
+      },
+    }),
+  )
 }
+
 
 export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/analytics/invoices/tests/distribution.test.ts
+++ b/app/api/routes-b/analytics/invoices/tests/distribution.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '../route'
+import { buildRequest } from '../../../_lib/test-helpers'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    invoice: {
+      groupBy: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const mockedFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedGroupBy = vi.mocked(prisma.invoice.groupBy)
+const mockedVerifyAuthToken = vi.mocked(verifyAuthToken)
+
+describe('GET /api/routes-b/analytics/invoices', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerifyAuthToken.mockResolvedValue({ userId: 'user-1' } as any)
+    mockedFindUnique.mockResolvedValue({ id: 'db-user-1' } as any)
+  })
+
+  it('handles all-zero user', async () => {
+    mockedGroupBy.mockResolvedValue([])
+
+    const req = buildRequest('GET', 'http://localhost/api/routes-b/analytics/invoices', { token: 'valid' })
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.invoices.total).toBe(0)
+    expect(body.invoices.distribution.paid.count).toBe(0)
+    expect(body.invoices.distribution.paid.percentage).toBe(0)
+    expect(body.invoices.distribution.pending.percentage).toBe(0)
+    expect(body.invoices.distribution.overdue.percentage).toBe(0)
+    expect(body.invoices.distribution.cancelled.percentage).toBe(0)
+  })
+
+  it('handles mixed statuses', async () => {
+    mockedGroupBy.mockResolvedValue([
+      { status: 'paid', _count: { id: 2 }, _sum: { amount: 200 } },
+      { status: 'pending', _count: { id: 2 }, _sum: { amount: 200 } },
+    ] as any)
+
+    const req = buildRequest('GET', 'http://localhost/api/routes-b/analytics/invoices', { token: 'valid' })
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.invoices.total).toBe(4)
+    expect(body.invoices.distribution.paid.count).toBe(2)
+    expect(body.invoices.distribution.paid.percentage).toBe(50)
+    expect(body.invoices.distribution.pending.count).toBe(2)
+    expect(body.invoices.distribution.pending.percentage).toBe(50)
+    expect(body.invoices.distribution.overdue.count).toBe(0)
+    expect(body.invoices.distribution.overdue.percentage).toBe(0)
+  })
+
+  it('handles single status', async () => {
+     mockedGroupBy.mockResolvedValue([
+      { status: 'overdue', _count: { id: 10 }, _sum: { amount: 1000 } },
+    ] as any)
+
+    const req = buildRequest('GET', 'http://localhost/api/routes-b/analytics/invoices', { token: 'valid' })
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(body.invoices.total).toBe(10)
+    expect(body.invoices.distribution.overdue.percentage).toBe(100)
+    expect(body.invoices.distribution.paid.percentage).toBe(0)
+  })
+
+  it('ensures percentages sum to 100 with tolerance', async () => {
+    mockedGroupBy.mockResolvedValue([
+      { status: 'paid', _count: { id: 1 }, _sum: { amount: 100 } },
+      { status: 'pending', _count: { id: 1 }, _sum: { amount: 100 } },
+      { status: 'overdue', _count: { id: 1 }, _sum: { amount: 100 } },
+    ] as any)
+
+    const req = buildRequest('GET', 'http://localhost/api/routes-b/analytics/invoices', { token: 'valid' })
+    const res = await GET(req)
+    const body = await res.json()
+
+    const sum = 
+      body.invoices.distribution.paid.percentage + 
+      body.invoices.distribution.pending.percentage + 
+      body.invoices.distribution.overdue.percentage + 
+      body.invoices.distribution.cancelled.percentage
+
+    expect(Math.abs(sum - 100)).toBeLessThanOrEqual(0.01)
+  })
+})


### PR DESCRIPTION
## Description
This PR extends the invoice analytics API endpoint (`/api/routes-b/analytics/invoices`) to include a per-status distribution slice. Finance users can now view the breakdown of their invoices by status both as raw counts and as percentages of the total.

## Key Changes
- Extended API response with `distribution` object.
- Optimized database interaction by using a single `groupBy` query instead of separate count and sum queries.
- Guaranteed presence of all four statuses (`paid`, `pending`, `overdue`, `cancelled`) in the response.
- Added comprehensive unit tests covering various data scenarios.

## Acceptance Criteria
- [x] Percentages sum to 100 (allowing for rounding tolerance).
- [x] All four statuses always present.
- [x] 0% buckets are included.

Fixes #548
