### PR TITLE
feat(routes-b): per-webhook custom headers (#605)

### DIFF
--- a/app/api/routes-b/_lib/webhook-custom-headers.ts
+++ b/app/api/routes-b/_lib/webhook-custom-headers.ts
@@ -1,0 +1,100 @@
+export type CustomHeaders = Record<string, string>
+
+export const MAX_CUSTOM_HEADERS = 10
+export const MAX_HEADER_VALUE_LENGTH = 256
+export const MAX_HEADER_NAME_LENGTH = 100
+
+const HEADER_NAME_PATTERN = /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/
+const RESERVED_EXACT = new Set(['host', 'content-length'])
+const RESERVED_PREFIX = 'x-lancepay-'
+
+export type HeaderValidationResult =
+  | { ok: true; headers: CustomHeaders }
+  | { ok: false; error: string }
+
+export function isReservedHeader(name: string): boolean {
+  const lower = name.toLowerCase()
+  return RESERVED_EXACT.has(lower) || lower.startsWith(RESERVED_PREFIX)
+}
+
+export function validateCustomHeaders(input: unknown): HeaderValidationResult {
+  if (input === null || input === undefined) {
+    return { ok: true, headers: {} }
+  }
+
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    return { ok: false, error: 'headers must be an object mapping name to value' }
+  }
+
+  const entries = Object.entries(input as Record<string, unknown>)
+  if (entries.length > MAX_CUSTOM_HEADERS) {
+    return { ok: false, error: `headers may contain at most ${MAX_CUSTOM_HEADERS} entries` }
+  }
+
+  const out: CustomHeaders = {}
+  const seen = new Set<string>()
+
+  for (const [name, value] of entries) {
+    if (typeof name !== 'string' || name.length === 0 || name.length > MAX_HEADER_NAME_LENGTH) {
+      return { ok: false, error: `header name "${name}" is empty or exceeds ${MAX_HEADER_NAME_LENGTH} characters` }
+    }
+    if (!HEADER_NAME_PATTERN.test(name)) {
+      return { ok: false, error: `header name "${name}" contains invalid characters` }
+    }
+    if (isReservedHeader(name)) {
+      return { ok: false, error: `header "${name}" is reserved and cannot be set` }
+    }
+
+    const lower = name.toLowerCase()
+    if (seen.has(lower)) {
+      return { ok: false, error: `duplicate header "${name}"` }
+    }
+    seen.add(lower)
+
+    if (typeof value !== 'string') {
+      return { ok: false, error: `header "${name}" must have a string value` }
+    }
+    if (value.length > MAX_HEADER_VALUE_LENGTH) {
+      return { ok: false, error: `header "${name}" exceeds ${MAX_HEADER_VALUE_LENGTH} characters` }
+    }
+
+    out[name] = value
+  }
+
+  return { ok: true, headers: out }
+}
+
+const headerStore = new Map<string, CustomHeaders>()
+
+export function setCustomHeaders(webhookId: string, headers: CustomHeaders): void {
+  if (Object.keys(headers).length === 0) {
+    headerStore.delete(webhookId)
+    return
+  }
+  headerStore.set(webhookId, { ...headers })
+}
+
+export function getCustomHeaders(webhookId: string): CustomHeaders {
+  const stored = headerStore.get(webhookId)
+  return stored ? { ...stored } : {}
+}
+
+export function clearCustomHeaders(webhookId: string): void {
+  headerStore.delete(webhookId)
+}
+
+export function applyCustomHeaders(
+  baseHeaders: Record<string, string>,
+  custom: CustomHeaders,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...baseHeaders }
+  for (const [name, value] of Object.entries(custom)) {
+    if (isReservedHeader(name)) continue
+    merged[name] = value
+  }
+  return merged
+}
+
+export function resetCustomHeaderStore(): void {
+  headerStore.clear()
+}

--- a/app/api/routes-b/_lib/webhook-delivery.ts
+++ b/app/api/routes-b/_lib/webhook-delivery.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/db'
 import { signWebhookPayload } from './hmac'
 import { shouldDeadLetter, pushToDeadLetter } from './dead-letter'
 import { recordWebhookDelivery } from './webhook-history'
+import { applyCustomHeaders, getCustomHeaders } from './webhook-custom-headers'
 
 type WebhookForDelivery = {
   id: string
@@ -27,13 +28,18 @@ export async function dispatchWebhookDelivery(
   const startedAt = Date.now()
 
   try {
-    const response = await fetch(webhook.targetUrl, {
-      method: 'POST',
-      headers: {
+    const headers = applyCustomHeaders(
+      {
         'content-type': 'application/json',
         'x-lancepay-timestamp': timestamp,
         'x-lancepay-signature': signature,
       },
+      getCustomHeaders(webhook.id),
+    )
+
+    const response = await fetch(webhook.targetUrl, {
+      method: 'POST',
+      headers,
       body,
       signal: AbortSignal.timeout(10_000),
     })

--- a/app/api/routes-b/webhooks/[id]/route.ts
+++ b/app/api/routes-b/webhooks/[id]/route.ts
@@ -5,6 +5,12 @@ import { verifyAuthToken } from '@/lib/auth'
 import { validateEventTypes } from '../../_lib/webhook-events'
 import { registerRoute } from '../../_lib/openapi'
 import { generateSecretFingerprint } from '../../_lib/webhook-fingerprint'
+import {
+  clearCustomHeaders,
+  getCustomHeaders,
+  setCustomHeaders,
+  validateCustomHeaders,
+} from '../../_lib/webhook-custom-headers'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -36,7 +42,8 @@ registerRoute({
     targetUrl: z.string().url().optional(),
     description: z.string().max(100).optional(),
     eventTypes: z.array(z.string()).optional(),
-    isActive: z.boolean().optional()
+    isActive: z.boolean().optional(),
+    headers: z.record(z.string(), z.string()).nullable().optional()
   }),
   responseSchema: z.object({
     webhook: z.object({
@@ -116,6 +123,7 @@ async function GETHandler(
       subscribedEvents: webhook.subscribedEvents,
       isActive: webhook.isActive,
       secretFingerprint: generateSecretFingerprint(webhook.signingSecret),
+      headers: getCustomHeaders(webhook.id),
       createdAt: webhook.createdAt,
     },
   })
@@ -148,9 +156,24 @@ async function PATCHHandler(
   }
 
   const body = await request.json()
-  const { targetUrl, description, eventTypes, isActive } = body
+  const { targetUrl, description, eventTypes, isActive, headers } = body
 
   const updateData: any = {}
+  let nextHeaders: Record<string, string> | undefined
+  let headersChanged = false
+
+  if (headers !== undefined) {
+    headersChanged = true
+    if (headers === null) {
+      nextHeaders = {}
+    } else {
+      const headersResult = validateCustomHeaders(headers)
+      if (!headersResult.ok) {
+        return NextResponse.json({ error: headersResult.error }, { status: 400 })
+      }
+      nextHeaders = headersResult.headers
+    }
+  }
 
   if (targetUrl !== undefined) {
     if (typeof targetUrl !== 'string' || targetUrl.length > 512 || !isValidHttpsUrl(targetUrl)) {
@@ -190,26 +213,47 @@ async function PATCHHandler(
     updateData.isActive = isActive
   }
 
-  if (Object.keys(updateData).length === 0) {
+  if (Object.keys(updateData).length === 0 && !headersChanged) {
     return NextResponse.json({ error: 'No fields to update' }, { status: 400 })
   }
 
-  const updatedWebhook = await prisma.userWebhook.update({
-    where: { id },
-    data: updateData,
-    select: {
-      id: true,
-      targetUrl: true,
-      description: true,
-      subscribedEvents: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  })
+  const updatedWebhook =
+    Object.keys(updateData).length > 0
+      ? await prisma.userWebhook.update({
+          where: { id },
+          data: updateData,
+          select: {
+            id: true,
+            targetUrl: true,
+            description: true,
+            subscribedEvents: true,
+            isActive: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        })
+      : await prisma.userWebhook.findUnique({
+          where: { id },
+          select: {
+            id: true,
+            targetUrl: true,
+            description: true,
+            subscribedEvents: true,
+            isActive: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        })
+
+  if (headersChanged && nextHeaders !== undefined) {
+    setCustomHeaders(id, nextHeaders)
+  }
 
   return NextResponse.json({
-    webhook: updatedWebhook,
+    webhook: {
+      ...updatedWebhook,
+      headers: getCustomHeaders(id),
+    },
   })
 }
 
@@ -240,6 +284,7 @@ async function DELETEHandler(
   }
 
   await prisma.userWebhook.delete({ where: { id } })
+  clearCustomHeaders(id)
 
   return new NextResponse(null, { status: 204 })
 }

--- a/app/api/routes-b/webhooks/__tests__/custom-headers.test.ts
+++ b/app/api/routes-b/webhooks/__tests__/custom-headers.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import {
+  applyCustomHeaders,
+  getCustomHeaders,
+  isReservedHeader,
+  resetCustomHeaderStore,
+  setCustomHeaders,
+  validateCustomHeaders,
+} from '../../_lib/webhook-custom-headers'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    userWebhook: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    webhookDelivery: { create: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedWebhookFindUnique = vi.mocked(prisma.userWebhook.findUnique)
+const mockedWebhookCount = vi.mocked(prisma.userWebhook.count)
+const mockedWebhookCreate = vi.mocked(prisma.userWebhook.create)
+const mockedWebhookUpdate = vi.mocked(prisma.userWebhook.update)
+const mockedWebhookDelete = vi.mocked(prisma.userWebhook.delete)
+const mockedDeliveryCreate = vi.mocked(prisma.webhookDelivery.create)
+
+const fakeUser = { id: 'user-1', privyId: 'privy-1' }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  resetCustomHeaderStore()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+})
+
+describe('validateCustomHeaders', () => {
+  it('accepts an empty object or undefined', () => {
+    expect(validateCustomHeaders({})).toEqual({ ok: true, headers: {} })
+    expect(validateCustomHeaders(undefined)).toEqual({ ok: true, headers: {} })
+    expect(validateCustomHeaders(null)).toEqual({ ok: true, headers: {} })
+  })
+
+  it('rejects non-object input', () => {
+    const res = validateCustomHeaders([])
+    expect(res.ok).toBe(false)
+  })
+
+  it('rejects more than 10 entries', () => {
+    const headers: Record<string, string> = {}
+    for (let i = 0; i < 11; i += 1) headers[`X-Header-${i}`] = String(i)
+    const res = validateCustomHeaders(headers)
+    expect(res.ok).toBe(false)
+  })
+
+  it('rejects values longer than 256 characters', () => {
+    const res = validateCustomHeaders({ 'X-Big': 'a'.repeat(257) })
+    expect(res.ok).toBe(false)
+  })
+
+  it('rejects reserved headers (case-insensitive)', () => {
+    expect(validateCustomHeaders({ host: 'example.com' }).ok).toBe(false)
+    expect(validateCustomHeaders({ HOST: 'example.com' }).ok).toBe(false)
+    expect(validateCustomHeaders({ 'Content-Length': '10' }).ok).toBe(false)
+    expect(validateCustomHeaders({ 'X-LancePay-Trace': 'x' }).ok).toBe(false)
+    expect(validateCustomHeaders({ 'x-lancepay-anything': 'x' }).ok).toBe(false)
+  })
+
+  it('rejects invalid header names', () => {
+    expect(validateCustomHeaders({ 'bad header': 'x' }).ok).toBe(false)
+    expect(validateCustomHeaders({ '': 'x' }).ok).toBe(false)
+  })
+
+  it('rejects non-string values', () => {
+    expect(validateCustomHeaders({ 'X-Foo': 123 as unknown as string }).ok).toBe(false)
+  })
+
+  it('accepts a valid set of headers', () => {
+    const res = validateCustomHeaders({
+      'X-Tenant-Id': 'tenant-42',
+      Authorization: 'Bearer xyz',
+    })
+    expect(res.ok).toBe(true)
+    if (res.ok) {
+      expect(Object.keys(res.headers)).toHaveLength(2)
+    }
+  })
+
+  it('isReservedHeader works regardless of case', () => {
+    expect(isReservedHeader('Host')).toBe(true)
+    expect(isReservedHeader('content-length')).toBe(true)
+    expect(isReservedHeader('X-LancePay-Foo')).toBe(true)
+    expect(isReservedHeader('Authorization')).toBe(false)
+  })
+})
+
+describe('applyCustomHeaders', () => {
+  it('merges custom headers but preserves reserved base headers', () => {
+    const merged = applyCustomHeaders(
+      {
+        'content-type': 'application/json',
+        'x-lancepay-signature': 'sig',
+      },
+      {
+        'X-Tenant-Id': 'tenant-42',
+        // attempting to override a reserved header should be ignored
+        'X-LancePay-Signature': 'evil',
+      },
+    )
+    expect(merged['x-lancepay-signature']).toBe('sig')
+    expect(merged['X-Tenant-Id']).toBe('tenant-42')
+    expect(merged['X-LancePay-Signature']).toBeUndefined()
+  })
+})
+
+describe('POST /api/routes-b/webhooks with custom headers', () => {
+  it('creates a webhook with valid headers and persists them', async () => {
+    mockedWebhookCount.mockResolvedValue(0)
+    mockedWebhookCreate.mockResolvedValue({
+      id: 'wh-1',
+      targetUrl: 'https://example.test/webhook',
+      description: null,
+      createdAt: new Date('2026-04-29T00:00:00Z'),
+    } as never)
+
+    const { POST } = await import('../route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks', {
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({
+        targetUrl: 'https://example.test/webhook',
+        headers: { 'X-Tenant-Id': 'tenant-42' },
+      }),
+    })
+
+    const res = await POST(request)
+    const json = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(json.headers).toEqual({ 'X-Tenant-Id': 'tenant-42' })
+    expect(getCustomHeaders('wh-1')).toEqual({ 'X-Tenant-Id': 'tenant-42' })
+  })
+
+  it('rejects creation when a reserved header is supplied', async () => {
+    mockedWebhookCount.mockResolvedValue(0)
+
+    const { POST } = await import('../route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks', {
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({
+        targetUrl: 'https://example.test/webhook',
+        headers: { Host: 'attacker.test' },
+      }),
+    })
+
+    const res = await POST(request)
+    expect(res.status).toBe(400)
+    expect(mockedWebhookCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects creation when a header value is too long', async () => {
+    mockedWebhookCount.mockResolvedValue(0)
+
+    const { POST } = await import('../route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks', {
+      method: 'POST',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({
+        targetUrl: 'https://example.test/webhook',
+        headers: { 'X-Big': 'a'.repeat(257) },
+      }),
+    })
+
+    const res = await POST(request)
+    expect(res.status).toBe(400)
+    expect(mockedWebhookCreate).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/routes-b/webhooks/[id] with custom headers', () => {
+  beforeEach(() => {
+    mockedWebhookFindUnique.mockResolvedValue({
+      id: 'wh-1',
+      userId: 'user-1',
+      targetUrl: 'https://example.test/webhook',
+      description: null,
+      subscribedEvents: ['invoice.paid'],
+      isActive: true,
+      signingSecret: 's'.repeat(64),
+      createdAt: new Date('2026-04-29T00:00:00Z'),
+      updatedAt: new Date('2026-04-29T00:00:00Z'),
+    } as never)
+    mockedWebhookUpdate.mockResolvedValue({
+      id: 'wh-1',
+      targetUrl: 'https://example.test/webhook',
+      description: null,
+      subscribedEvents: ['invoice.paid'],
+      isActive: true,
+      createdAt: new Date('2026-04-29T00:00:00Z'),
+      updatedAt: new Date('2026-04-29T00:00:00Z'),
+    } as never)
+  })
+
+  it('updates headers without other fields', async () => {
+    const { PATCH } = await import('../[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks/wh-1', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ headers: { 'X-Tenant-Id': 'new-tenant' } }),
+    })
+
+    const res = await PATCH(request, { params: Promise.resolve({ id: 'wh-1' }) })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.webhook.headers).toEqual({ 'X-Tenant-Id': 'new-tenant' })
+    expect(getCustomHeaders('wh-1')).toEqual({ 'X-Tenant-Id': 'new-tenant' })
+  })
+
+  it('clears headers when null is supplied', async () => {
+    setCustomHeaders('wh-1', { 'X-Tenant-Id': 'old-tenant' })
+    const { PATCH } = await import('../[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks/wh-1', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ headers: null }),
+    })
+
+    const res = await PATCH(request, { params: Promise.resolve({ id: 'wh-1' }) })
+    expect(res.status).toBe(200)
+    expect(getCustomHeaders('wh-1')).toEqual({})
+  })
+
+  it('rejects update with reserved header', async () => {
+    const { PATCH } = await import('../[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks/wh-1', {
+      method: 'PATCH',
+      headers: { authorization: 'Bearer token' },
+      body: JSON.stringify({ headers: { 'X-LancePay-Replay': 'attacker' } }),
+    })
+
+    const res = await PATCH(request, { params: Promise.resolve({ id: 'wh-1' }) })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('dispatchWebhookDelivery applies custom headers', () => {
+  it('attaches stored custom headers without overriding reserved ones', async () => {
+    setCustomHeaders('wh-1', {
+      'X-Tenant-Id': 'tenant-42',
+      Authorization: 'Bearer downstream',
+    })
+
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchSpy)
+    mockedDeliveryCreate.mockResolvedValue({} as never)
+    vi.mocked(prisma.userWebhook.update).mockResolvedValue({} as never)
+
+    const { dispatchWebhookDelivery } = await import('../../_lib/webhook-delivery')
+
+    const result = await dispatchWebhookDelivery(
+      { id: 'wh-1', targetUrl: 'https://example.test/webhook', signingSecret: 's'.repeat(64) },
+      'invoice.paid',
+      { id: 'evt_1', amount: 100 },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const sentHeaders = (fetchSpy.mock.calls[0][1] as { headers: Record<string, string> }).headers
+    expect(sentHeaders['X-Tenant-Id']).toBe('tenant-42')
+    expect(sentHeaders['Authorization']).toBe('Bearer downstream')
+    expect(sentHeaders['x-lancepay-signature']).toBeDefined()
+    expect(sentHeaders['x-lancepay-timestamp']).toBeDefined()
+    expect(sentHeaders['content-type']).toBe('application/json')
+
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('DELETE /api/routes-b/webhooks/[id] clears custom headers', () => {
+  it('removes the headers entry on delete', async () => {
+    setCustomHeaders('wh-1', { 'X-Tenant-Id': 'tenant-42' })
+    expect(getCustomHeaders('wh-1')).toEqual({ 'X-Tenant-Id': 'tenant-42' })
+
+    mockedWebhookFindUnique.mockResolvedValue({
+      id: 'wh-1',
+      userId: 'user-1',
+    } as never)
+    mockedWebhookDelete.mockResolvedValue({} as never)
+
+    const { DELETE } = await import('../[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/webhooks/wh-1', {
+      method: 'DELETE',
+      headers: { authorization: 'Bearer token' },
+    })
+
+    const res = await DELETE(request, { params: Promise.resolve({ id: 'wh-1' }) })
+    expect(res.status).toBe(204)
+    expect(getCustomHeaders('wh-1')).toEqual({})
+  })
+})

--- a/app/api/routes-b/webhooks/route.ts
+++ b/app/api/routes-b/webhooks/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
@@ -8,6 +9,7 @@ import { validateEventTypes, getDefaultEventTypes } from '../_lib/webhook-events
 import { registerRoute } from '../_lib/openapi'
 import { generateSecretFingerprint } from '../_lib/webhook-fingerprint'
 import { generateWebhookSecret } from '../_lib/hmac'
+import { getCustomHeaders, setCustomHeaders, validateCustomHeaders } from '../_lib/webhook-custom-headers'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -39,7 +41,8 @@ registerRoute({
   requestSchema: z.object({
     targetUrl: z.string().url(),
     description: z.string().max(100).optional(),
-    eventTypes: z.array(z.string()).optional()
+    eventTypes: z.array(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional()
   }),
   responseSchema: z.object({
     id: z.string(),
@@ -106,6 +109,7 @@ async function GETHandler(request: NextRequest) {
       ...webhook,
       secretFingerprint: generateSecretFingerprint(webhook.signingSecret),
       signingSecret: undefined, // Remove raw secret
+      headers: getCustomHeaders(webhook.id),
     }))
 
     return NextResponse.json({ webhooks: webhooksWithFingerprint })
@@ -162,7 +166,7 @@ async function POSTHandler(request: NextRequest) {
     // Validate event types
     let eventTypes: string[]
     try {
-      eventTypes = body.eventTypes 
+      eventTypes = body.eventTypes
         ? validateEventTypes(body.eventTypes)
         : getDefaultEventTypes()
     } catch (error) {
@@ -170,6 +174,11 @@ async function POSTHandler(request: NextRequest) {
         { error: error instanceof Error ? error.message : 'Invalid eventTypes' },
         { status: 400 }
       )
+    }
+
+    const headersResult = validateCustomHeaders(body.headers)
+    if (!headersResult.ok) {
+      return NextResponse.json({ error: headersResult.error }, { status: 400 })
     }
 
     const existingCount = await prisma.userWebhook.count({
@@ -204,11 +213,14 @@ async function POSTHandler(request: NextRequest) {
       },
     })
 
+    setCustomHeaders(webhook.id, headersResult.headers)
+
     const responseBody = {
       id: webhook.id,
       targetUrl: webhook.targetUrl,
       description: webhook.description ?? null,
       signingSecret,
+      headers: headersResult.headers,
       createdAt: webhook.createdAt,
     }
 


### PR DESCRIPTION
## Summary
- Adds `headers: Record<string,string>` to `POST /api/routes-b/webhooks` and `PATCH /api/routes-b/webhooks/[id]` (max 10 entries, each value ≤ 256 chars)
- Validates header names with the RFC 7230 token grammar; rejects empty / oversized names
- Rejects reserved headers (`Host`, `Content-Length`, any `X-LancePay-*`) so the framework cannot be spoofed
- Exposes the stored headers on the GET endpoints; `PATCH headers: null` clears them; `DELETE` clears them too
- `dispatchWebhookDelivery` merges the stored custom headers with the framework headers and **never** lets a custom entry overwrite a reserved one
- Imports `node:crypto` explicitly in `webhooks/route.ts` so `crypto.createHash` resolves under the vitest node runtime (a latent issue surfaced by the new tests)

## Scope
All work lives in `app/api/routes-b/`:
- New helper `app/api/routes-b/_lib/webhook-custom-headers.ts` (validator, in-memory store, merge utility)
- Edits to `webhooks/route.ts`, `webhooks/[id]/route.ts`, `_lib/webhook-delivery.ts`
- Tests in `webhooks/__tests__/custom-headers.test.ts`

Storage is in-memory keyed by `webhookId` because the database schema is out of scope.

## Test plan
- [x] Validator accepts empty / valid sets, rejects > 10 entries, oversized values, reserved headers (case-insensitive), invalid names, non-string values
- [x] `applyCustomHeaders` cannot override reserved framework headers (regression test for spoofing attempt)
- [x] `POST /webhooks` persists headers and returns them; rejects reserved + oversized
- [x] `PATCH /webhooks/[id]` updates headers without other fields, clears via `null`, rejects reserved
- [x] `dispatchWebhookDelivery` attaches stored headers on every dispatch while preserving reserved ones
- [x] `DELETE /webhooks/[id]` clears the headers entry

Closes #605