### PR TITLE
feat(routes-b): add trust-score history endpoint (#619)

### DIFF
--- a/app/api/routes-b/_lib/trust-score-history.ts
+++ b/app/api/routes-b/_lib/trust-score-history.ts
@@ -1,0 +1,68 @@
+export type TrustScoreSnapshot = {
+  date: string
+  score: number
+}
+
+export const MAX_RETENTION_DAYS = 365
+export const ALLOWED_RANGE_DAYS = [30, 90, 365] as const
+export type AllowedRangeDays = typeof ALLOWED_RANGE_DAYS[number]
+
+const userHistory = new Map<string, TrustScoreSnapshot[]>()
+
+function isoDay(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function compareDateAsc(a: TrustScoreSnapshot, b: TrustScoreSnapshot): number {
+  return a.date.localeCompare(b.date)
+}
+
+export function recordTrustScoreSnapshot(
+  userId: string,
+  score: number,
+  now: Date = new Date(),
+): void {
+  const day = isoDay(now)
+  const existing = userHistory.get(userId) ?? []
+  const idx = existing.findIndex(snap => snap.date === day)
+
+  if (idx >= 0) {
+    existing[idx] = { date: day, score }
+  } else {
+    existing.push({ date: day, score })
+    existing.sort(compareDateAsc)
+  }
+
+  while (existing.length > MAX_RETENTION_DAYS) {
+    existing.shift()
+  }
+
+  userHistory.set(userId, existing)
+}
+
+export function getTrustScoreHistory(
+  userId: string,
+  days: number,
+  now: Date = new Date(),
+): TrustScoreSnapshot[] {
+  if (!Number.isFinite(days) || days <= 0) return []
+  const stored = userHistory.get(userId)
+  if (!stored || stored.length === 0) return []
+
+  const cutoff = new Date(now)
+  cutoff.setUTCHours(0, 0, 0, 0)
+  cutoff.setUTCDate(cutoff.getUTCDate() - (days - 1))
+  const cutoffIso = isoDay(cutoff)
+
+  return stored
+    .filter(snap => snap.date >= cutoffIso)
+    .map(snap => ({ ...snap }))
+}
+
+export function isAllowedRange(value: unknown): value is AllowedRangeDays {
+  return ALLOWED_RANGE_DAYS.includes(value as AllowedRangeDays)
+}
+
+export function resetTrustScoreHistoryStore(): void {
+  userHistory.clear()
+}

--- a/app/api/routes-b/trust-score/__tests__/history.test.ts
+++ b/app/api/routes-b/trust-score/__tests__/history.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import {
+  ALLOWED_RANGE_DAYS,
+  MAX_RETENTION_DAYS,
+  getTrustScoreHistory,
+  isAllowedRange,
+  recordTrustScoreSnapshot,
+  resetTrustScoreHistoryStore,
+} from '../../_lib/trust-score-history'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    apiKey: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  resetTrustScoreHistoryStore()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFindUnique.mockResolvedValue({ id: 'user-1', role: 'user' } as never)
+})
+
+describe('trust-score history store', () => {
+  it('returns an empty array before any snapshot is recorded', () => {
+    expect(getTrustScoreHistory('user-1', 30)).toEqual([])
+  })
+
+  it('records a snapshot per day and replaces same-day entries with the latest score', () => {
+    const day1 = new Date('2026-04-29T00:00:00Z')
+    recordTrustScoreSnapshot('user-1', 60, day1)
+    // recompute later the same day overwrites the day's score
+    recordTrustScoreSnapshot('user-1', 65, new Date('2026-04-29T22:00:00Z'))
+
+    const history = getTrustScoreHistory('user-1', 30, day1)
+    expect(history).toEqual([{ date: '2026-04-29', score: 65 }])
+  })
+
+  it('builds up history across multiple days in ascending order', () => {
+    recordTrustScoreSnapshot('user-1', 50, new Date('2026-04-27T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 55, new Date('2026-04-28T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 60, new Date('2026-04-29T00:00:00Z'))
+
+    const history = getTrustScoreHistory('user-1', 30, new Date('2026-04-29T00:00:00Z'))
+    expect(history).toEqual([
+      { date: '2026-04-27', score: 50 },
+      { date: '2026-04-28', score: 55 },
+      { date: '2026-04-29', score: 60 },
+    ])
+  })
+
+  it('caps retention at 365 days, dropping the oldest entries first', () => {
+    const start = new Date('2025-04-29T00:00:00Z')
+    for (let i = 0; i < MAX_RETENTION_DAYS + 5; i += 1) {
+      const day = new Date(start)
+      day.setUTCDate(start.getUTCDate() + i)
+      recordTrustScoreSnapshot('user-1', 50 + (i % 50), day)
+    }
+
+    const lastDay = new Date(start)
+    lastDay.setUTCDate(start.getUTCDate() + MAX_RETENTION_DAYS + 4)
+
+    const history = getTrustScoreHistory('user-1', 365, lastDay)
+    expect(history).toHaveLength(MAX_RETENTION_DAYS)
+    // oldest 5 days were dropped
+    expect(history[0].date).toBe('2025-05-04')
+  })
+
+  it('range filter returns only entries within the requested window', () => {
+    recordTrustScoreSnapshot('user-1', 40, new Date('2026-01-01T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 50, new Date('2026-04-01T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 60, new Date('2026-04-29T00:00:00Z'))
+
+    const last30 = getTrustScoreHistory('user-1', 30, new Date('2026-04-29T00:00:00Z'))
+    expect(last30.map(s => s.date)).toEqual(['2026-04-01', '2026-04-29'])
+
+    const last90 = getTrustScoreHistory('user-1', 90, new Date('2026-04-29T00:00:00Z'))
+    expect(last90.map(s => s.date)).toEqual(['2026-04-01', '2026-04-29'])
+
+    const last365 = getTrustScoreHistory('user-1', 365, new Date('2026-04-29T00:00:00Z'))
+    expect(last365.map(s => s.date)).toEqual(['2026-01-01', '2026-04-01', '2026-04-29'])
+  })
+
+  it('does not leak history across users', () => {
+    recordTrustScoreSnapshot('user-a', 40, new Date('2026-04-29T00:00:00Z'))
+    expect(getTrustScoreHistory('user-b', 30)).toEqual([])
+  })
+
+  it('isAllowedRange only accepts 30, 90, or 365', () => {
+    expect(ALLOWED_RANGE_DAYS).toEqual([30, 90, 365])
+    expect(isAllowedRange(30)).toBe(true)
+    expect(isAllowedRange(90)).toBe(true)
+    expect(isAllowedRange(365)).toBe(true)
+    expect(isAllowedRange(60)).toBe(false)
+    expect(isAllowedRange('30')).toBe(false)
+  })
+})
+
+describe('GET /api/routes-b/trust-score/history', () => {
+  it('returns an empty history for a fresh user', async () => {
+    const { GET } = await import('../history/route')
+    const request = new NextRequest('http://localhost/api/routes-b/trust-score/history', {
+      headers: { authorization: 'Bearer token' },
+    })
+
+    const res = await GET(request)
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.history).toEqual([])
+    expect(json.days).toBe(30)
+  })
+
+  it('returns recorded snapshots in ascending date order', async () => {
+    recordTrustScoreSnapshot('user-1', 50, new Date('2026-04-27T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 55, new Date('2026-04-28T00:00:00Z'))
+    recordTrustScoreSnapshot('user-1', 60, new Date('2026-04-29T00:00:00Z'))
+
+    const { GET } = await import('../history/route')
+    const request = new NextRequest('http://localhost/api/routes-b/trust-score/history', {
+      headers: { authorization: 'Bearer token' },
+    })
+
+    const res = await GET(request)
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.history.map((s: { date: string }) => s.date)).toEqual([
+      '2026-04-27',
+      '2026-04-28',
+      '2026-04-29',
+    ])
+  })
+
+  it('rejects an out-of-range days value', async () => {
+    const { GET } = await import('../history/route')
+    const request = new NextRequest('http://localhost/api/routes-b/trust-score/history?days=60', {
+      headers: { authorization: 'Bearer token' },
+    })
+
+    const res = await GET(request)
+    const json = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(json.code).toBe('INVALID_RANGE')
+  })
+
+  it('honors the allowed days values', async () => {
+    const { GET } = await import('../history/route')
+    for (const days of ALLOWED_RANGE_DAYS) {
+      const request = new NextRequest(
+        `http://localhost/api/routes-b/trust-score/history?days=${days}`,
+        { headers: { authorization: 'Bearer token' } },
+      )
+      const res = await GET(request)
+      expect(res.status).toBe(200)
+      const json = await res.json()
+      expect(json.days).toBe(days)
+    }
+  })
+
+  it('returns 403 without a valid token (parity with /trust-score)', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+
+    const { GET } = await import('../history/route')
+    const request = new NextRequest('http://localhost/api/routes-b/trust-score/history', {})
+
+    const res = await GET(request)
+    expect(res.status).toBe(403)
+  })
+})

--- a/app/api/routes-b/trust-score/history/route.ts
+++ b/app/api/routes-b/trust-score/history/route.ts
@@ -1,0 +1,43 @@
+import { withRequestId } from '../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { requireScope, RoutesBForbiddenError } from '../../_lib/authz'
+import {
+  ALLOWED_RANGE_DAYS,
+  getTrustScoreHistory,
+  isAllowedRange,
+} from '../../_lib/trust-score-history'
+
+const DEFAULT_DAYS = 30
+
+async function GETHandler(request: NextRequest) {
+  try {
+    const auth = await requireScope(request, 'routes-b:read')
+
+    const raw = request.nextUrl.searchParams.get('days')
+    let days: number = DEFAULT_DAYS
+    if (raw !== null) {
+      const parsed = Number.parseInt(raw, 10)
+      if (!isAllowedRange(parsed)) {
+        return NextResponse.json(
+          {
+            error: `days must be one of ${ALLOWED_RANGE_DAYS.join(', ')}`,
+            code: 'INVALID_RANGE',
+          },
+          { status: 400 },
+        )
+      }
+      days = parsed
+    }
+
+    const history = getTrustScoreHistory(auth.userId, days)
+
+    return NextResponse.json({ days, history })
+  } catch (error) {
+    if (error instanceof RoutesBForbiddenError) {
+      return NextResponse.json({ error: 'Forbidden', code: error.code }, { status: 403 })
+    }
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+}
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/trust-score/route.ts
+++ b/app/api/routes-b/trust-score/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { requireScope, RoutesBForbiddenError } from '../_lib/authz'
 import { getCacheValue, setCacheValue } from '../_lib/cache'
+import { recordTrustScoreSnapshot } from '../_lib/trust-score-history'
 
 const TRUST_SCORE_COOLDOWN_MS = 30_000
 
@@ -60,6 +61,8 @@ async function recomputeTrustScore(userId: string): Promise<TrustScorePayload> {
       lastUpdatedAt: true,
     },
   })
+
+  recordTrustScoreSnapshot(userId, trustScore.score)
 
   return {
     trustScore: {


### PR DESCRIPTION
## Summary
- Adds `GET /api/routes-b/trust-score/history?days=30|90|365` returning `{ days, history: [{ date, score }] }` in ascending date order
- Per-user in-memory ring buffer holds the last 365 daily snapshots, bounding memory across recompute frequency
- Same-day recomputes overwrite the day's score (latest wins) so history is one entry per UTC day
- Snapshot is recorded inside `recomputeTrustScore` after each successful upsert, so the endpoint and the history stay in lock-step
- `days` defaults to 30 and rejects anything outside `{30, 90, 365}` with `INVALID_RANGE` so we don't expose buckets we never advertised

## Scope
All changes live inside `app/api/routes-b/`:
- `app/api/routes-b/_lib/trust-score-history.ts` (store + validators)
- `app/api/routes-b/trust-score/history/route.ts` (new endpoint)
- `app/api/routes-b/trust-score/route.ts` (snapshot hook in the recompute path)
- `app/api/routes-b/trust-score/__tests__/history.test.ts` (tests)

## Behavior / acceptance
- Memory is bounded by the per-user 365-entry cap (oldest dropped first)
- History is returned in ascending date order
- 403 without a valid bearer token, matching `/trust-score`'s contract

## Test plan
- [x] Empty history before any snapshot
- [x] Same-day recompute overwrites the day's score (latest wins)
- [x] Builds up across multiple days in ascending order
- [x] 365-day retention cap drops oldest entries first
- [x] `days=30 / 90 / 365` filters return only entries within the window
- [x] No history leaks across users
- [x] `isAllowedRange` accepts only `30 / 90 / 365`
- [x] Endpoint rejects out-of-range `days` with `INVALID_RANGE`
- [x] Endpoint returns 403 without a valid token

## Out of scope
- Persistent (database-backed) history — issue explicitly defers this
- Component-level history — separate issue

Closes #619