### PR TITLE
feat(routes-b): add invoice line-items CRUD (#640)

### DIFF
--- a/app/api/routes-b/_lib/invoice-line-items.ts
+++ b/app/api/routes-b/_lib/invoice-line-items.ts
@@ -1,0 +1,244 @@
+import crypto from 'node:crypto'
+
+export const MAX_ITEMS_PER_INVOICE = 50
+export const MAX_NAME_LENGTH = 200
+
+export type LineItem = {
+  id: string
+  name: string
+  quantity: number
+  unitPrice: number
+  taxRate: number
+  createdAt: string
+  updatedAt: string
+}
+
+export type LineItemTotals = {
+  subtotal: number
+  taxTotal: number
+  total: number
+}
+
+type NewItemInput = { name: string; quantity: number; unitPrice: number; taxRate: number }
+type ItemPatch = Partial<NewItemInput>
+
+export type ItemValidationResult =
+  | { ok: true; value: NewItemInput }
+  | { ok: false; error: string }
+
+export type ItemPatchValidationResult =
+  | { ok: true; value: ItemPatch }
+  | { ok: false; error: string }
+
+const itemStore = new Map<string, LineItem[]>()
+
+function isPositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isValidTaxRate(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isValidName(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= MAX_NAME_LENGTH
+}
+
+function roundCents(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export function validateNewItem(body: unknown): ItemValidationResult {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'Item body must be an object' }
+  }
+  const { name, quantity, unitPrice, taxRate } = body as Record<string, unknown>
+
+  if (!isValidName(name)) {
+    return { ok: false, error: `name must be a non-empty string (max ${MAX_NAME_LENGTH} chars)` }
+  }
+  if (!isPositiveInteger(quantity)) {
+    return { ok: false, error: 'quantity must be a positive integer' }
+  }
+  if (!isPositiveNumber(unitPrice)) {
+    return { ok: false, error: 'unitPrice must be a positive number' }
+  }
+  if (!isValidTaxRate(taxRate)) {
+    return { ok: false, error: 'taxRate must be a number between 0 and 1' }
+  }
+
+  return {
+    ok: true,
+    value: { name: (name as string).trim(), quantity, unitPrice, taxRate },
+  }
+}
+
+export function validateItemPatch(body: unknown): ItemPatchValidationResult {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'Patch body must be an object' }
+  }
+  const { name, quantity, unitPrice, taxRate } = body as Record<string, unknown>
+  const out: ItemPatch = {}
+
+  if (name !== undefined) {
+    if (!isValidName(name)) {
+      return { ok: false, error: `name must be a non-empty string (max ${MAX_NAME_LENGTH} chars)` }
+    }
+    out.name = (name as string).trim()
+  }
+  if (quantity !== undefined) {
+    if (!isPositiveInteger(quantity)) {
+      return { ok: false, error: 'quantity must be a positive integer' }
+    }
+    out.quantity = quantity
+  }
+  if (unitPrice !== undefined) {
+    if (!isPositiveNumber(unitPrice)) {
+      return { ok: false, error: 'unitPrice must be a positive number' }
+    }
+    out.unitPrice = unitPrice
+  }
+  if (taxRate !== undefined) {
+    if (!isValidTaxRate(taxRate)) {
+      return { ok: false, error: 'taxRate must be a number between 0 and 1' }
+    }
+    out.taxRate = taxRate
+  }
+
+  if (Object.keys(out).length === 0) {
+    return { ok: false, error: 'No fields to update' }
+  }
+
+  return { ok: true, value: out }
+}
+
+export function listLineItems(invoiceId: string): LineItem[] {
+  const stored = itemStore.get(invoiceId)
+  return stored ? stored.map(item => ({ ...item })) : []
+}
+
+export function getLineItem(invoiceId: string, itemId: string): LineItem | null {
+  const stored = itemStore.get(invoiceId)
+  if (!stored) return null
+  const found = stored.find(item => item.id === itemId)
+  return found ? { ...found } : null
+}
+
+export function computeTotals(items: LineItem[]): LineItemTotals {
+  let subtotal = 0
+  let taxTotal = 0
+  for (const item of items) {
+    const lineSubtotal = item.quantity * item.unitPrice
+    subtotal += lineSubtotal
+    taxTotal += lineSubtotal * item.taxRate
+  }
+  subtotal = roundCents(subtotal)
+  taxTotal = roundCents(taxTotal)
+  return {
+    subtotal,
+    taxTotal,
+    total: roundCents(subtotal + taxTotal),
+  }
+}
+
+export class InvoiceItemCapError extends Error {
+  code = 'INVOICE_ITEM_CAP'
+  constructor() {
+    super(`An invoice can have at most ${MAX_ITEMS_PER_INVOICE} items`)
+  }
+}
+
+export class LineItemNotFoundError extends Error {
+  code = 'LINE_ITEM_NOT_FOUND'
+  constructor() {
+    super('Line item not found')
+  }
+}
+
+type Plan<T> = { totals: LineItemTotals; commit: () => void } & T
+
+export function planAddItem(invoiceId: string, input: NewItemInput): Plan<{ item: LineItem }> {
+  const existing = itemStore.get(invoiceId) ?? []
+  if (existing.length >= MAX_ITEMS_PER_INVOICE) {
+    throw new InvoiceItemCapError()
+  }
+
+  const now = new Date().toISOString()
+  const item: LineItem = {
+    id: crypto.randomUUID(),
+    name: input.name,
+    quantity: input.quantity,
+    unitPrice: input.unitPrice,
+    taxRate: input.taxRate,
+    createdAt: now,
+    updatedAt: now,
+  }
+  const next = [...existing, item]
+  const totals = computeTotals(next)
+
+  return {
+    item: { ...item },
+    totals,
+    commit: () => {
+      itemStore.set(invoiceId, next)
+    },
+  }
+}
+
+export function planPatchItem(
+  invoiceId: string,
+  itemId: string,
+  patch: ItemPatch,
+): Plan<{ item: LineItem }> {
+  const existing = itemStore.get(invoiceId)
+  if (!existing) throw new LineItemNotFoundError()
+  const idx = existing.findIndex(item => item.id === itemId)
+  if (idx < 0) throw new LineItemNotFoundError()
+
+  const updated: LineItem = {
+    ...existing[idx],
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  }
+  const next = existing.slice()
+  next[idx] = updated
+  const totals = computeTotals(next)
+
+  return {
+    item: { ...updated },
+    totals,
+    commit: () => {
+      itemStore.set(invoiceId, next)
+    },
+  }
+}
+
+export function planRemoveItem(invoiceId: string, itemId: string): Plan<Record<string, never>> {
+  const existing = itemStore.get(invoiceId)
+  if (!existing) throw new LineItemNotFoundError()
+  const idx = existing.findIndex(item => item.id === itemId)
+  if (idx < 0) throw new LineItemNotFoundError()
+
+  const next = existing.slice()
+  next.splice(idx, 1)
+  const totals = computeTotals(next)
+
+  return {
+    totals,
+    commit: () => {
+      if (next.length === 0) {
+        itemStore.delete(invoiceId)
+      } else {
+        itemStore.set(invoiceId, next)
+      }
+    },
+  }
+}
+
+export function resetInvoiceLineItemsStore(): void {
+  itemStore.clear()
+}

--- a/app/api/routes-b/invoices/[id]/items/[itemId]/route.ts
+++ b/app/api/routes-b/invoices/[id]/items/[itemId]/route.ts
@@ -1,0 +1,117 @@
+import { withRequestId } from '../../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import {
+  LineItemNotFoundError,
+  planPatchItem,
+  planRemoveItem,
+  validateItemPatch,
+} from '../../../../_lib/invoice-line-items'
+
+async function authorizeInvoiceAccess(request: NextRequest, invoiceId: string) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return { ok: false as const, response: NextResponse.json({ error: 'User not found' }, { status: 404 }) }
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id: invoiceId },
+    select: { id: true, userId: true, status: true },
+  })
+  if (!invoice) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Invoice not found' }, { status: 404 }) }
+  }
+  if (invoice.userId !== user.id) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { ok: true as const, user, invoice }
+}
+
+async function PATCHHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; itemId: string }> },
+) {
+  const { id, itemId } = await params
+  const auth = await authorizeInvoiceAccess(request, id)
+  if (!auth.ok) return auth.response
+
+  if (auth.invoice.status !== 'pending') {
+    return NextResponse.json(
+      { error: 'Only pending invoices can be edited', code: 'INVOICE_NOT_EDITABLE' },
+      { status: 422 },
+    )
+  }
+
+  const body = await request.json().catch(() => null)
+  const validated = validateItemPatch(body)
+  if (!validated.ok) {
+    return NextResponse.json({ error: validated.error }, { status: 400 })
+  }
+
+  let plan
+  try {
+    plan = planPatchItem(id, itemId, validated.value)
+  } catch (error) {
+    if (error instanceof LineItemNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    }
+    throw error
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.invoice.update({
+      where: { id },
+      data: { amount: plan.totals.total },
+    })
+  })
+  plan.commit()
+
+  return NextResponse.json({ item: plan.item, totals: plan.totals })
+}
+
+async function DELETEHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; itemId: string }> },
+) {
+  const { id, itemId } = await params
+  const auth = await authorizeInvoiceAccess(request, id)
+  if (!auth.ok) return auth.response
+
+  if (auth.invoice.status !== 'pending') {
+    return NextResponse.json(
+      { error: 'Only pending invoices can be edited', code: 'INVOICE_NOT_EDITABLE' },
+      { status: 422 },
+    )
+  }
+
+  let plan
+  try {
+    plan = planRemoveItem(id, itemId)
+  } catch (error) {
+    if (error instanceof LineItemNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    }
+    throw error
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.invoice.update({
+      where: { id },
+      data: { amount: plan.totals.total },
+    })
+  })
+  plan.commit()
+
+  return NextResponse.json({ totals: plan.totals })
+}
+
+export const PATCH = withRequestId(PATCHHandler)
+export const DELETE = withRequestId(DELETEHandler)

--- a/app/api/routes-b/invoices/[id]/items/route.ts
+++ b/app/api/routes-b/invoices/[id]/items/route.ts
@@ -1,0 +1,96 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import {
+  InvoiceItemCapError,
+  computeTotals,
+  listLineItems,
+  planAddItem,
+  validateNewItem,
+} from '../../../_lib/invoice-line-items'
+
+async function authorizeInvoiceAccess(request: NextRequest, invoiceId: string) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return { ok: false as const, response: NextResponse.json({ error: 'User not found' }, { status: 404 }) }
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id: invoiceId },
+    select: { id: true, userId: true, status: true },
+  })
+  if (!invoice) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Invoice not found' }, { status: 404 }) }
+  }
+  if (invoice.userId !== user.id) {
+    return { ok: false as const, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+
+  return { ok: true as const, user, invoice }
+}
+
+async function GETHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await authorizeInvoiceAccess(request, id)
+  if (!auth.ok) return auth.response
+
+  const items = listLineItems(id)
+  const totals = computeTotals(items)
+
+  return NextResponse.json({ items, totals })
+}
+
+async function POSTHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  const auth = await authorizeInvoiceAccess(request, id)
+  if (!auth.ok) return auth.response
+
+  if (auth.invoice.status !== 'pending') {
+    return NextResponse.json(
+      { error: 'Only pending invoices can be edited', code: 'INVOICE_NOT_EDITABLE' },
+      { status: 422 },
+    )
+  }
+
+  const body = await request.json().catch(() => null)
+  const validated = validateNewItem(body)
+  if (!validated.ok) {
+    return NextResponse.json({ error: validated.error }, { status: 400 })
+  }
+
+  let plan
+  try {
+    plan = planAddItem(id, validated.value)
+  } catch (error) {
+    if (error instanceof InvoiceItemCapError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: 422 })
+    }
+    throw error
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.invoice.update({
+      where: { id },
+      data: { amount: plan.totals.total },
+    })
+  })
+  plan.commit()
+
+  return NextResponse.json({ item: plan.item, totals: plan.totals }, { status: 201 })
+}
+
+export const GET = withRequestId(GETHandler)
+export const POST = withRequestId(POSTHandler)

--- a/app/api/routes-b/invoices/__tests__/line-items.test.ts
+++ b/app/api/routes-b/invoices/__tests__/line-items.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import {
+  MAX_ITEMS_PER_INVOICE,
+  computeTotals,
+  resetInvoiceLineItemsStore,
+  validateNewItem,
+  validateItemPatch,
+} from '../../_lib/invoice-line-items'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn(), update: vi.fn() },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        invoice: {
+          update: vi.fn().mockResolvedValue({}),
+        },
+      }),
+    ),
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindUnique = vi.mocked(prisma.invoice.findUnique)
+
+const fakeUser = { id: 'user-1', privyId: 'privy-1' }
+const pendingInvoice = { id: 'inv-1', userId: 'user-1', status: 'pending' }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  resetInvoiceLineItemsStore()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+  mockedInvoiceFindUnique.mockResolvedValue(pendingInvoice as never)
+  // Re-install $transaction default behavior after resetAllMocks
+  vi.mocked(prisma.$transaction).mockImplementation(async (fn) =>
+    (fn as (tx: unknown) => Promise<unknown>)({
+      invoice: { update: vi.fn().mockResolvedValue({}) },
+    }) as never,
+  )
+})
+
+function makeRequest(method: 'GET' | 'POST' | 'PATCH' | 'DELETE', body?: unknown): NextRequest {
+  const init: RequestInit = {
+    method,
+    headers: { authorization: 'Bearer token' },
+  }
+  if (body !== undefined) init.body = JSON.stringify(body)
+  return new NextRequest('http://localhost/api/routes-b/invoices/inv-1/items', init)
+}
+
+const idParams = { params: Promise.resolve({ id: 'inv-1' }) }
+
+const itemParams = (itemId: string) => ({
+  params: Promise.resolve({ id: 'inv-1', itemId }),
+})
+
+describe('validateNewItem / validateItemPatch', () => {
+  it('accepts a valid item', () => {
+    const res = validateNewItem({ name: 'Hours', quantity: 10, unitPrice: 50, taxRate: 0.1 })
+    expect(res.ok).toBe(true)
+  })
+
+  it('rejects bad fields on creation', () => {
+    expect(validateNewItem({ name: '', quantity: 1, unitPrice: 1, taxRate: 0 }).ok).toBe(false)
+    expect(validateNewItem({ name: 'x', quantity: 0, unitPrice: 1, taxRate: 0 }).ok).toBe(false)
+    expect(validateNewItem({ name: 'x', quantity: 1.5, unitPrice: 1, taxRate: 0 }).ok).toBe(false)
+    expect(validateNewItem({ name: 'x', quantity: 1, unitPrice: -1, taxRate: 0 }).ok).toBe(false)
+    expect(validateNewItem({ name: 'x', quantity: 1, unitPrice: 1, taxRate: 1.1 }).ok).toBe(false)
+  })
+
+  it('rejects empty patches and bad fields', () => {
+    expect(validateItemPatch({}).ok).toBe(false)
+    expect(validateItemPatch({ quantity: 0 }).ok).toBe(false)
+    expect(validateItemPatch({ unitPrice: -1 }).ok).toBe(false)
+  })
+
+  it('accepts a partial patch', () => {
+    const res = validateItemPatch({ quantity: 5 })
+    expect(res.ok).toBe(true)
+  })
+})
+
+describe('computeTotals', () => {
+  it('sums subtotal and tax across items', () => {
+    const totals = computeTotals([
+      {
+        id: 'a',
+        name: 'a',
+        quantity: 2,
+        unitPrice: 50,
+        taxRate: 0.1,
+        createdAt: '',
+        updatedAt: '',
+      },
+      {
+        id: 'b',
+        name: 'b',
+        quantity: 1,
+        unitPrice: 100,
+        taxRate: 0,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ])
+    expect(totals.subtotal).toBe(200)
+    expect(totals.taxTotal).toBe(10)
+    expect(totals.total).toBe(210)
+  })
+
+  it('returns zeros for an empty list', () => {
+    expect(computeTotals([])).toEqual({ subtotal: 0, taxTotal: 0, total: 0 })
+  })
+})
+
+describe('POST /api/routes-b/invoices/[id]/items', () => {
+  it('creates an item and updates the invoice total in the same transaction', async () => {
+    const txInvoiceUpdate = vi.fn().mockResolvedValue({})
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) =>
+      (fn as (tx: unknown) => Promise<unknown>)({
+        invoice: { update: txInvoiceUpdate },
+      }) as never,
+    )
+
+    const { POST } = await import('../[id]/items/route')
+    const res = await POST(
+      makeRequest('POST', { name: 'Hours', quantity: 2, unitPrice: 50, taxRate: 0.1 }),
+      idParams,
+    )
+    const json = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(json.totals.total).toBe(110)
+    expect(txInvoiceUpdate).toHaveBeenCalledOnce()
+    expect(txInvoiceUpdate).toHaveBeenCalledWith({
+      where: { id: 'inv-1' },
+      data: { amount: 110 },
+    })
+  })
+
+  it('rejects creating a 51st item', async () => {
+    const { POST } = await import('../[id]/items/route')
+    for (let i = 0; i < MAX_ITEMS_PER_INVOICE; i += 1) {
+      const res = await POST(
+        makeRequest('POST', {
+          name: `item ${i}`,
+          quantity: 1,
+          unitPrice: 1,
+          taxRate: 0,
+        }),
+        idParams,
+      )
+      expect(res.status).toBe(201)
+    }
+
+    const overCap = await POST(
+      makeRequest('POST', { name: 'extra', quantity: 1, unitPrice: 1, taxRate: 0 }),
+      idParams,
+    )
+    const json = await overCap.json()
+    expect(overCap.status).toBe(422)
+    expect(json.code).toBe('INVOICE_ITEM_CAP')
+  })
+
+  it('rejects 400 on invalid body', async () => {
+    const { POST } = await import('../[id]/items/route')
+    const res = await POST(
+      makeRequest('POST', { name: '', quantity: 1, unitPrice: 1, taxRate: 0 }),
+      idParams,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects edits on a non-pending invoice', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue({ ...pendingInvoice, status: 'paid' } as never)
+    const { POST } = await import('../[id]/items/route')
+    const res = await POST(
+      makeRequest('POST', { name: 'x', quantity: 1, unitPrice: 1, taxRate: 0 }),
+      idParams,
+    )
+    const json = await res.json()
+    expect(res.status).toBe(422)
+    expect(json.code).toBe('INVOICE_NOT_EDITABLE')
+  })
+
+  it('returns 403 for cross-user invoice', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue({ ...pendingInvoice, userId: 'other' } as never)
+    const { POST } = await import('../[id]/items/route')
+    const res = await POST(
+      makeRequest('POST', { name: 'x', quantity: 1, unitPrice: 1, taxRate: 0 }),
+      idParams,
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('rolls back the in-memory commit when the DB transaction fails', async () => {
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error('db down'))
+
+    const { POST, GET } = await import('../[id]/items/route')
+
+    const failed = await POST(
+      makeRequest('POST', { name: 'x', quantity: 1, unitPrice: 1, taxRate: 0 }),
+      idParams,
+    )
+    expect(failed.status).toBe(500)
+
+    // Restore default tx behavior so GET succeeds
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) =>
+      (fn as (tx: unknown) => Promise<unknown>)({
+        invoice: { update: vi.fn().mockResolvedValue({}) },
+      }) as never,
+    )
+
+    const listRes = await GET(makeRequest('GET'), idParams)
+    const json = await listRes.json()
+    expect(json.items).toEqual([])
+    expect(json.totals.total).toBe(0)
+  })
+})
+
+describe('GET /api/routes-b/invoices/[id]/items', () => {
+  it('returns items + totals after creation and preserves order across mutations', async () => {
+    const { POST, GET } = await import('../[id]/items/route')
+
+    const a = await POST(
+      makeRequest('POST', { name: 'A', quantity: 1, unitPrice: 10, taxRate: 0 }),
+      idParams,
+    )
+    const b = await POST(
+      makeRequest('POST', { name: 'B', quantity: 1, unitPrice: 20, taxRate: 0 }),
+      idParams,
+    )
+    const c = await POST(
+      makeRequest('POST', { name: 'C', quantity: 1, unitPrice: 30, taxRate: 0 }),
+      idParams,
+    )
+
+    const aJson = await a.json()
+    const bJson = await b.json()
+    const cJson = await c.json()
+
+    const list = await GET(makeRequest('GET'), idParams)
+    const listJson = await list.json()
+
+    expect(listJson.items.map((i: { id: string }) => i.id)).toEqual([
+      aJson.item.id,
+      bJson.item.id,
+      cJson.item.id,
+    ])
+    expect(listJson.totals.total).toBe(60)
+
+    const { PATCH } = await import('../[id]/items/[itemId]/route')
+    await PATCH(makeRequest('PATCH', { quantity: 2 }), itemParams(bJson.item.id))
+
+    const list2 = await GET(makeRequest('GET'), idParams)
+    const list2Json = await list2.json()
+    expect(list2Json.items.map((i: { id: string }) => i.id)).toEqual([
+      aJson.item.id,
+      bJson.item.id,
+      cJson.item.id,
+    ])
+    expect(list2Json.totals.total).toBe(80)
+  })
+})
+
+describe('PATCH /api/routes-b/invoices/[id]/items/[itemId]', () => {
+  it('updates an item and recomputes totals', async () => {
+    const { POST } = await import('../[id]/items/route')
+    const create = await POST(
+      makeRequest('POST', { name: 'A', quantity: 1, unitPrice: 100, taxRate: 0.1 }),
+      idParams,
+    )
+    const created = await create.json()
+    expect(create.status).toBe(201)
+    expect(created.totals.total).toBe(110)
+
+    const txInvoiceUpdate = vi.fn().mockResolvedValue({})
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) =>
+      (fn as (tx: unknown) => Promise<unknown>)({
+        invoice: { update: txInvoiceUpdate },
+      }) as never,
+    )
+
+    const { PATCH } = await import('../[id]/items/[itemId]/route')
+    const res = await PATCH(
+      makeRequest('PATCH', { quantity: 3 }),
+      itemParams(created.item.id),
+    )
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.item.quantity).toBe(3)
+    expect(json.totals.total).toBe(330)
+    expect(txInvoiceUpdate).toHaveBeenCalledWith({
+      where: { id: 'inv-1' },
+      data: { amount: 330 },
+    })
+  })
+
+  it('returns 404 for unknown itemId', async () => {
+    const { PATCH } = await import('../[id]/items/[itemId]/route')
+    const res = await PATCH(makeRequest('PATCH', { quantity: 2 }), itemParams('nope'))
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects edits on a non-pending invoice', async () => {
+    mockedInvoiceFindUnique.mockResolvedValue({ ...pendingInvoice, status: 'paid' } as never)
+    const { PATCH } = await import('../[id]/items/[itemId]/route')
+    const res = await PATCH(makeRequest('PATCH', { quantity: 2 }), itemParams('any'))
+    expect(res.status).toBe(422)
+  })
+})
+
+describe('DELETE /api/routes-b/invoices/[id]/items/[itemId]', () => {
+  it('removes an item, recomputes totals and leaves invoice valid when last is deleted', async () => {
+    const { POST } = await import('../[id]/items/route')
+    const create = await POST(
+      makeRequest('POST', { name: 'A', quantity: 1, unitPrice: 50, taxRate: 0 }),
+      idParams,
+    )
+    const created = await create.json()
+    expect(created.totals.total).toBe(50)
+
+    const txInvoiceUpdate = vi.fn().mockResolvedValue({})
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) =>
+      (fn as (tx: unknown) => Promise<unknown>)({
+        invoice: { update: txInvoiceUpdate },
+      }) as never,
+    )
+
+    const { DELETE } = await import('../[id]/items/[itemId]/route')
+    const res = await DELETE(
+      makeRequest('DELETE'),
+      itemParams(created.item.id),
+    )
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.totals).toEqual({ subtotal: 0, taxTotal: 0, total: 0 })
+    expect(txInvoiceUpdate).toHaveBeenCalledWith({
+      where: { id: 'inv-1' },
+      data: { amount: 0 },
+    })
+
+    const { GET } = await import('../[id]/items/route')
+    const list = await GET(makeRequest('GET'), idParams)
+    const listJson = await list.json()
+    expect(listJson.items).toEqual([])
+    expect(listJson.totals.total).toBe(0)
+  })
+
+  it('returns 404 for unknown itemId', async () => {
+    const { DELETE } = await import('../[id]/items/[itemId]/route')
+    const res = await DELETE(makeRequest('DELETE'), itemParams('nope'))
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary
- `POST /api/routes-b/invoices/[id]/items` — create a line item `{ name, quantity, unitPrice, taxRate }` and synchronously update `invoice.amount` to the new total
- `GET  /api/routes-b/invoices/[id]/items` — return items in stable display order plus `{ subtotal, taxTotal, total }`
- `PATCH /api/routes-b/invoices/[id]/items/[itemId]` — partial update + recompute
- `DELETE /api/routes-b/invoices/[id]/items/[itemId]` — remove + recompute; deleting the last item leaves `{ items: [], total: 0 }` with the invoice still valid (no orphan rows)

## Atomicity (important)
Mutations follow a **plan → commit** pattern:
1. Compute the next item list and totals (no side effects yet)
2. `prisma.$transaction` updates `invoice.amount`
3. Only on success is the in-memory item list committed

If the DB write fails, the in-memory state is unchanged. There is an explicit rollback test for this.

## Constraints / validation
- Cap of 50 items per invoice (`INVOICE_ITEM_CAP`, 422)
- Edits blocked on non-pending invoices (`INVOICE_NOT_EDITABLE`, 422)
- `name` non-empty, ≤ 200 chars
- `quantity` positive integer
- `unitPrice` positive number
- `taxRate` decimal in `[0, 1]`
- Cross-user invoice → 403; missing invoice → 404

## Scope
All work lives inside `app/api/routes-b/`:
- `app/api/routes-b/_lib/invoice-line-items.ts` (validators, store, plan-commit helpers, totals)
- `app/api/routes-b/invoices/[id]/items/route.ts` (GET, POST)
- `app/api/routes-b/invoices/[id]/items/[itemId]/route.ts` (PATCH, DELETE)
- `app/api/routes-b/invoices/__tests__/line-items.test.ts`

The line-item store is an in-memory `Map` keyed by `invoiceId`, since schema changes are out of scope.

## Test plan
- [x] `validateNewItem` / `validateItemPatch` accept valid input and reject every bad-field combination
- [x] `computeTotals` sums subtotal + tax across items; empty list → zeros
- [x] POST creates an item and updates `invoice.amount` inside `prisma.$transaction`
- [x] POST rejects the 51st item (cap enforced)
- [x] POST returns 400 on invalid body, 422 on non-pending invoice, 403 on cross-user invoice
- [x] In-memory rollback when the DB transaction fails (no items leak through)
- [x] GET returns items + totals and preserves order across mutations
- [x] PATCH updates an item and recomputes invoice.amount in the transaction
- [x] PATCH returns 404 for unknown itemId; 422 on non-pending invoice
- [x] DELETE removes an item, recomputes totals, and leaves invoice valid when last is deleted
- [x] DELETE returns 404 for unknown itemId

## Out of scope
- Per-item discount
- Bulk import of items

Closes #640