### PR TITLE
feat(routes-b): GET /invoices/[id]/activity audit events endpoint

### DIFF
--- a/app/api/routes-b/invoices/[id]/activity/route.ts
+++ b/app/api/routes-b/invoices/[id]/activity/route.ts
@@ -1,0 +1,65 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+function extractIpAddress(metadata: unknown): string | null {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const value = (metadata as Record<string, unknown>).ipAddress
+    return typeof value === 'string' && value.length > 0 ? value : null
+  }
+  return null
+}
+
+async function GETHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: { id: true, userId: true },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const events = await prisma.auditEvent.findMany({
+    where: { invoiceId: invoice.id },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      eventType: true,
+      metadata: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({
+    activity: events.map((event) => ({
+      id: event.id,
+      action: event.eventType,
+      ipAddress: extractIpAddress(event.metadata),
+      createdAt: event.createdAt,
+    })),
+  })
+}
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/__tests__/activity.test.ts
+++ b/app/api/routes-b/invoices/__tests__/activity.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    auditEvent: { findMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../[id]/activity/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindUnique = vi.mocked(prisma.invoice.findUnique)
+const mockedAuditFindMany = vi.mocked(prisma.auditEvent.findMany)
+
+const fakeUser = { id: 'user-1', privyId: 'privy-1' }
+const ownedInvoice = { id: 'inv-1', userId: 'user-1' }
+const otherInvoice = { id: 'inv-1', userId: 'user-2' }
+
+function makeRequest(authHeader = 'Bearer token'): NextRequest {
+  return new NextRequest(
+    'http://localhost/api/routes-b/invoices/inv-1/activity',
+    {
+      method: 'GET',
+      headers: authHeader ? { authorization: authHeader } : {},
+    },
+  )
+}
+
+const params = { params: Promise.resolve({ id: 'inv-1' }) }
+
+describe('GET /api/routes-b/invoices/[id]/activity', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when the authorization token is missing or invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(''), params)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when the invoice belongs to a different user', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(otherInvoice as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns an empty activity array (not 404) when no audit events exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(ownedInvoice as never)
+    mockedAuditFindMany.mockResolvedValue([] as never)
+
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.activity).toEqual([])
+  })
+
+  it('returns activity ordered ascending with mapped action and ipAddress fields', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(fakeUser as never)
+    mockedInvoiceFindUnique.mockResolvedValue(ownedInvoice as never)
+    const createdEarly = new Date('2025-01-01T00:00:00.000Z')
+    const createdLate = new Date('2025-01-02T09:00:00.000Z')
+    mockedAuditFindMany.mockResolvedValue([
+      {
+        id: 'evt-1',
+        eventType: 'invoice_created',
+        metadata: { ipAddress: '192.168.1.1' },
+        createdAt: createdEarly,
+      },
+      {
+        id: 'evt-2',
+        eventType: 'invoice_viewed',
+        metadata: null,
+        createdAt: createdLate,
+      },
+    ] as never)
+
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.activity).toHaveLength(2)
+    expect(body.activity[0]).toMatchObject({
+      id: 'evt-1',
+      action: 'invoice_created',
+      ipAddress: '192.168.1.1',
+    })
+    expect(body.activity[1]).toMatchObject({
+      id: 'evt-2',
+      action: 'invoice_viewed',
+      ipAddress: null,
+    })
+
+    // Confirm the route asks Prisma for an ascending-by-createdAt query.
+    expect(mockedAuditFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { invoiceId: 'inv-1' },
+        orderBy: { createdAt: 'asc' },
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `GET /api/routes-b/invoices/[id]/activity` which returns the audit events for a single invoice ordered chronologically.
- Auth path mirrors the existing refund endpoint: 401 for missing/invalid token, 404 for missing invoice, 403 for invoices owned by another user, 200 with an empty `activity` array when no events have been recorded yet.

### Schema mapping note
The live `AuditEvent` model in `prisma/schema.prisma` keys events by `invoiceId` and stores the action under `eventType`, with no dedicated `ipAddress` column. The issue spec used `resourceType`/`resourceId`/`action`/`ipAddress`. To honour the documented public contract while matching the actual schema, the route:

- queries `where: { invoiceId: invoice.id }` (the indexed FK)
- maps `eventType → action`
- pulls `ipAddress` out of the JSON `metadata` column when present, otherwise returns `null`

This keeps the response stable for consumers and avoids inventing schema changes outside the requested folder.

## Closes
- closes #405

## Test plan
- [x] `npx vitest run app/api/routes-b/invoices/__tests__/activity.test.ts` — 5/5 passing (401 unauthenticated, 404 missing invoice, 403 wrong owner, 200 empty array, 200 with mapped fields and ascending order).
