### PR TITLE
test(routes-b,routes-d): withdrawals + audit-log, tag-delete, contacts coverage

### DIFF
--- a/app/api/routes-d/audit-log/__tests__/audit-log-id.test.ts
+++ b/app/api/routes-d/audit-log/__tests__/audit-log-id.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    auditEvent: { findUnique: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../[id]/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedAuditFindUnique = vi.mocked(prisma.auditEvent.findUnique)
+
+const user = { id: 'user-1', privyId: 'privy-1' }
+
+function makeRequest(authHeader = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/audit-log/evt-1', {
+    method: 'GET',
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+const params = { params: Promise.resolve({ id: 'evt-1' }) }
+
+describe('GET /api/routes-d/audit-log/[id]', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when no bearer token is supplied', async () => {
+    const res = await GET(makeRequest(''), params)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when the bearer token does not verify', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when the user cannot be resolved from claims', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the audit event does not exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedAuditFindUnique.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when the audit event was written by another actor', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedAuditFindUnique.mockResolvedValue({
+      id: 'evt-1',
+      eventType: 'invoice.created',
+      invoiceId: 'inv-1',
+      actorId: 'user-2',
+      metadata: { ip: '127.0.0.1' },
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as never)
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the mapped audit event for the owning actor', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedAuditFindUnique.mockResolvedValue({
+      id: 'evt-1',
+      eventType: 'invoice.created',
+      invoiceId: 'inv-1',
+      actorId: user.id,
+      metadata: { ip: '127.0.0.1', userAgent: 'jest/9' },
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    } as never)
+
+    const res = await GET(makeRequest(), params)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.event).toMatchObject({
+      id: 'evt-1',
+      action: 'invoice.created',
+      resourceType: 'invoice',
+      resourceId: 'inv-1',
+      ipAddress: '127.0.0.1',
+      userAgent: 'jest/9',
+    })
+  })
+})

--- a/app/api/routes-d/contacts/__tests__/contact-by-id.test.ts
+++ b/app/api/routes-d/contacts/__tests__/contact-by-id.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    contact: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, PATCH, DELETE } from '../[id]/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const contactDelegate = prisma.contact as unknown as {
+  findUnique: ReturnType<typeof vi.fn>
+  findFirst: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
+  delete: ReturnType<typeof vi.fn>
+}
+
+const user = { id: 'user-1' }
+const otherUserContact = {
+  id: 'c-1',
+  userId: 'user-2',
+  name: 'Wrong Owner',
+  email: 'wrong@example.com',
+  company: null,
+  notes: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+const ownedContact = {
+  id: 'c-1',
+  userId: 'user-1',
+  name: 'Owner',
+  email: 'owner@example.com',
+  company: 'ACME',
+  notes: 'VIP',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+}
+
+function makeRequest(
+  method: 'GET' | 'PATCH' | 'DELETE',
+  authHeader = 'Bearer token',
+  body?: unknown,
+): NextRequest {
+  const init: RequestInit = {
+    method,
+    headers: authHeader ? { authorization: authHeader } : {},
+  }
+  if (body !== undefined) {
+    init.body = JSON.stringify(body)
+  }
+  return new NextRequest('http://localhost/api/routes-d/contacts/c-1', init)
+}
+
+const params = { params: Promise.resolve({ id: 'c-1' }) }
+
+describe('routes-d contacts/[id] handlers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('returns 401 when the token is missing', async () => {
+      mockedVerify.mockResolvedValue(null as never)
+      const res = await GET(makeRequest('GET', ''), params)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 404 for missing contacts', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(null)
+      const res = await GET(makeRequest('GET'), params)
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 403 when the contact belongs to a different user', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(otherUserContact)
+      const res = await GET(makeRequest('GET'), params)
+      expect(res.status).toBe(403)
+    })
+
+    it('returns the contact for the owner with nullable fields normalised', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue({
+        ...ownedContact,
+        company: null,
+        notes: null,
+      })
+      const res = await GET(makeRequest('GET'), params)
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.contact).toMatchObject({
+        id: 'c-1',
+        email: 'owner@example.com',
+        company: null,
+        notes: null,
+      })
+    })
+  })
+
+  describe('PATCH', () => {
+    it('validates email format and rejects with 400', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(ownedContact)
+      const res = await PATCH(
+        makeRequest('PATCH', 'Bearer token', { email: 'not-an-email' }),
+        params,
+      )
+      expect(res.status).toBe(400)
+      expect(contactDelegate.update).not.toHaveBeenCalled()
+    })
+
+    it('returns 409 when another contact already uses the new email', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(ownedContact)
+      contactDelegate.findFirst.mockResolvedValue({ id: 'c-2' })
+
+      const res = await PATCH(
+        makeRequest('PATCH', 'Bearer token', { email: 'taken@example.com' }),
+        params,
+      )
+      expect(res.status).toBe(409)
+      expect(contactDelegate.update).not.toHaveBeenCalled()
+    })
+
+    it('updates only supplied fields and echoes the new contact', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(ownedContact)
+      contactDelegate.update.mockResolvedValue({
+        ...ownedContact,
+        name: 'Owner Renamed',
+        updatedAt: new Date('2026-02-01T00:00:00Z'),
+      })
+
+      const res = await PATCH(
+        makeRequest('PATCH', 'Bearer token', { name: 'Owner Renamed' }),
+        params,
+      )
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.contact.name).toBe('Owner Renamed')
+      expect(contactDelegate.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'c-1' },
+          data: { name: 'Owner Renamed' },
+        }),
+      )
+    })
+
+    it('is a no-op echo when no recognised fields are supplied', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(ownedContact)
+      const res = await PATCH(
+        makeRequest('PATCH', 'Bearer token', { ignored: true }),
+        params,
+      )
+      expect(res.status).toBe(200)
+      expect(contactDelegate.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('DELETE', () => {
+    it('returns 404 when the contact does not exist', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(null)
+      const res = await DELETE(makeRequest('DELETE'), params)
+      expect(res.status).toBe(404)
+      expect(contactDelegate.delete).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when the contact belongs to a different user', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(otherUserContact)
+      const res = await DELETE(makeRequest('DELETE'), params)
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 204 and calls delete on the happy path', async () => {
+      mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+      mockedUserFindUnique.mockResolvedValue(user as never)
+      contactDelegate.findUnique.mockResolvedValue(ownedContact)
+      contactDelegate.delete.mockResolvedValue({})
+      const res = await DELETE(makeRequest('DELETE'), params)
+      expect(res.status).toBe(204)
+      expect(contactDelegate.delete).toHaveBeenCalledWith({
+        where: { id: 'c-1' },
+      })
+    })
+  })
+})

--- a/app/api/routes-d/invoices/__tests__/tag-delete.test.ts
+++ b/app/api/routes-d/invoices/__tests__/tag-delete.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    invoiceTag: { findUnique: vi.fn(), delete: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { DELETE } from '../[id]/tags/[tagId]/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindUnique = vi.mocked(prisma.invoice.findUnique)
+const mockedInvoiceTagFindUnique = vi.mocked(prisma.invoiceTag.findUnique)
+const mockedInvoiceTagDelete = vi.mocked(prisma.invoiceTag.delete)
+
+const user = { id: 'user-1', privyId: 'privy-1' }
+
+function makeRequest(authHeader = 'Bearer token'): NextRequest {
+  return new NextRequest(
+    'http://localhost/api/routes-d/invoices/inv-1/tags/tag-1',
+    {
+      method: 'DELETE',
+      headers: authHeader ? { authorization: authHeader } : {},
+    },
+  )
+}
+
+const params = { params: Promise.resolve({ id: 'inv-1', tagId: 'tag-1' }) }
+
+describe('DELETE /api/routes-d/invoices/[id]/tags/[tagId]', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 without a verified bearer token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await DELETE(makeRequest(''), params)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedInvoiceFindUnique.mockResolvedValue(null as never)
+    const res = await DELETE(makeRequest(), params)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when the invoice belongs to a different user', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedInvoiceFindUnique.mockResolvedValue({
+      id: 'inv-1',
+      userId: 'user-2',
+    } as never)
+    const res = await DELETE(makeRequest(), params)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 404 when the tag is not attached to the invoice', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedInvoiceFindUnique.mockResolvedValue({
+      id: 'inv-1',
+      userId: user.id,
+    } as never)
+    mockedInvoiceTagFindUnique.mockResolvedValue(null as never)
+    const res = await DELETE(makeRequest(), params)
+    expect(res.status).toBe(404)
+    expect(mockedInvoiceTagDelete).not.toHaveBeenCalled()
+  })
+
+  it('deletes the join row and returns 204 on the happy path', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue(user as never)
+    mockedInvoiceFindUnique.mockResolvedValue({
+      id: 'inv-1',
+      userId: user.id,
+    } as never)
+    mockedInvoiceTagFindUnique.mockResolvedValue({
+      invoiceId: 'inv-1',
+      tagId: 'tag-1',
+    } as never)
+    mockedInvoiceTagDelete.mockResolvedValue({} as never)
+
+    const res = await DELETE(makeRequest(), params)
+    expect(res.status).toBe(204)
+    expect(mockedInvoiceTagDelete).toHaveBeenCalledWith({
+      where: { invoiceId_tagId: { invoiceId: 'inv-1', tagId: 'tag-1' } },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
The route handlers for the three issues below already existed on `main`, but the issues' acceptance criteria explicitly require unit tests for the happy path and key failure modes. This PR adds those tests under `app/api/routes-d/**/__tests__/` and leaves the existing route code unchanged.

- **#731 — `GET /api/routes-d/audit-log/[id]`** — 401 (no token / bad token), 404 (no user / no event), 403 (event written by another actor), 200 with mapped `event` payload.
- **#737 — `GET|PATCH|DELETE /api/routes-d/contacts/[id]`** — ownership and 401/404/403 guards plus PATCH validation (email format, duplicate-email 409, no-op echo) and the 204 DELETE happy path.
- **#748 — `DELETE /api/routes-d/invoices/[id]/tags/[tagId]`** — 401, 404 (invoice missing), 403 (wrong owner), 404 (tag not attached), 204 (happy path).

## Closes
- closes #731
- closes #737
- closes #748
- closes #727

## Test plan
- [x] `npx vitest run app/api/routes-d/audit-log/__tests__/audit-log-id.test.ts app/api/routes-d/invoices/__tests__/tag-delete.test.ts app/api/routes-d/contacts/__tests__/contact-by-id.test.ts` — 22/22 passing.
