### PR TITLE
Fix assigned routes-d invoice endpoints

### DIFF
--- a/app/api/routes-d/invoices/[id]/due-date/route.ts
+++ b/app/api/routes-d/invoices/[id]/due-date/route.ts
@@ -1,87 +1,95 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await params
-  // 1. Auth
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  // 2. Fetch Invoice
-  const invoice = await prisma.invoice.findUnique({ where: { id } })
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-  if (invoice.userId !== user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  // 3. Status Validation
-  if (invoice.status !== 'pending') {
-    return NextResponse.json(
-      { error: 'Due date can only be updated on pending invoices' },
-      { status: 422 }
-    )
-  }
-
-  // 4. dueDate Validation
-  let body: { dueDate?: string | null }
   try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
-
-  if (!('dueDate' in body)) {
-    return NextResponse.json({ error: 'dueDate is required' }, { status: 400 })
-  }
-
-  let newDueDate: Date | null = null
-
-  if (body.dueDate !== null) {
-    // Must be a string
-    if (typeof body.dueDate !== 'string') {
-      return NextResponse.json({ error: 'dueDate must be a string or null' }, { status: 400 })
+    const { id } = await params
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Must be a valid ISO date (YYYY-MM-DD or full ISO string)
-    const parsed = new Date(body.dueDate)
-    if (isNaN(parsed.getTime())) {
-      return NextResponse.json({ error: 'Invalid date format' }, { status: 400 })
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true },
+    })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Must be a future date (compare to start of today UTC)
-    const today = new Date()
-    today.setUTCHours(0, 0, 0, 0)
-    if (parsed <= today) {
-      return NextResponse.json({ error: 'Due date must be a future date' }, { status: 400 })
+    const invoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+      },
+    })
+    if (!invoice) {
+      return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+    }
+    if (invoice.userId !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    newDueDate = parsed
+    if (invoice.status !== 'pending') {
+      return NextResponse.json(
+        { error: 'Due date can only be updated on pending invoices' },
+        { status: 422 }
+      )
+    }
+
+    let body: { dueDate?: string | null }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (!('dueDate' in body)) {
+      return NextResponse.json({ error: 'dueDate is required' }, { status: 400 })
+    }
+
+    let newDueDate: Date | null = null
+
+    if (body.dueDate !== null) {
+      if (typeof body.dueDate !== 'string') {
+        return NextResponse.json({ error: 'dueDate must be a string or null' }, { status: 400 })
+      }
+
+      const parsed = new Date(body.dueDate)
+      if (Number.isNaN(parsed.getTime())) {
+        return NextResponse.json({ error: 'Invalid date format' }, { status: 400 })
+      }
+
+      const today = new Date()
+      today.setUTCHours(0, 0, 0, 0)
+      if (parsed <= today) {
+        return NextResponse.json({ error: 'Due date must be a future date' }, { status: 400 })
+      }
+
+      newDueDate = parsed
+    }
+
+    const updated = await prisma.invoice.update({
+      where: { id },
+      data: { dueDate: newDueDate },
+      select: {
+        id: true,
+        invoiceNumber: true,
+        dueDate: true,
+      },
+    })
+
+    return NextResponse.json(updated, { status: 200 })
+  } catch (error) {
+    logger.error({ err: error }, 'PATCH /api/routes-d/invoices/[id]/due-date error')
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
   }
-
-  // 5. Update
-  const updated = await prisma.invoice.update({
-    where: { id },
-    data: { dueDate: newDueDate },
-    select: {
-      id: true,
-      invoiceNumber: true,
-      dueDate: true,
-    },
-  })
-
-  return NextResponse.json(updated, { status: 200 })
 }

--- a/tests/api.routes-d.due-date.test.ts
+++ b/tests/api.routes-d.due-date.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const verifyAuthToken = vi.fn()
+const userFindUnique = vi.fn()
+const invoiceFindUnique = vi.fn()
+const invoiceUpdate = vi.fn()
+const loggerError = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/logger', () => ({ logger: { error: loggerError } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: userFindUnique },
+    invoice: {
+      findUnique: invoiceFindUnique,
+      update: invoiceUpdate,
+    },
+  },
+}))
+
+const BASE_URL = 'http://localhost/api/routes-d/invoices/inv_1/due-date'
+
+function makeRequest(body: unknown, headers: Record<string, string> = { authorization: 'Bearer token' }) {
+  return new NextRequest(BASE_URL, {
+    method: 'PATCH',
+    headers: { ...headers, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /api/routes-d/invoices/[id]/due-date', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when the auth token is invalid', async () => {
+    verifyAuthToken.mockResolvedValue(null)
+
+    const { PATCH } = await import('@/app/api/routes-d/invoices/[id]/due-date/route')
+    const response = await PATCH(makeRequest({ dueDate: '2099-01-01' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(userFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the invoice belongs to another user', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_2', status: 'pending' })
+
+    const { PATCH } = await import('@/app/api/routes-d/invoices/[id]/due-date/route')
+    const response = await PATCH(makeRequest({ dueDate: '2099-01-01' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
+    expect(invoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dueDate is missing', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1', status: 'pending' })
+
+    const { PATCH } = await import('@/app/api/routes-d/invoices/[id]/due-date/route')
+    const response = await PATCH(makeRequest({}), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'dueDate is required' })
+    expect(invoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('updates a pending invoice due date', async () => {
+    const dueDate = '2099-01-01T00:00:00.000Z'
+    const updated = { id: 'inv_1', invoiceNumber: 'INV-001', dueDate: new Date(dueDate) }
+
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1', status: 'pending' })
+    invoiceUpdate.mockResolvedValue(updated)
+
+    const { PATCH } = await import('@/app/api/routes-d/invoices/[id]/due-date/route')
+    const response = await PATCH(makeRequest({ dueDate }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      id: 'inv_1',
+      invoiceNumber: 'INV-001',
+      dueDate,
+    })
+    expect(invoiceUpdate).toHaveBeenCalledWith({
+      where: { id: 'inv_1' },
+      data: { dueDate: new Date(dueDate) },
+      select: {
+        id: true,
+        invoiceNumber: true,
+        dueDate: true,
+      },
+    })
+  })
+})

--- a/tests/api.routes-d.messages.test.ts
+++ b/tests/api.routes-d.messages.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const verifyAuthToken = vi.fn()
+const userFindUnique = vi.fn()
+const invoiceFindUnique = vi.fn()
+const messageFindMany = vi.fn()
+const loggerError = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/logger', () => ({ logger: { error: loggerError } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: userFindUnique },
+    invoice: { findUnique: invoiceFindUnique },
+    invoiceMessage: { findMany: messageFindMany },
+  },
+}))
+
+const BASE_URL = 'http://localhost/api/routes-d/invoices/inv_1/messages'
+
+function makeRequest(headers: Record<string, string> = { authorization: 'Bearer token' }) {
+  return new NextRequest(BASE_URL, {
+    method: 'GET',
+    headers,
+  })
+}
+
+describe('GET /api/routes-d/invoices/[id]/messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when the authorization header is missing', async () => {
+    const { GET } = await import('@/app/api/routes-d/invoices/[id]/messages/route')
+    const response = await GET(makeRequest({}), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(verifyAuthToken).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue(null)
+
+    const { GET } = await import('@/app/api/routes-d/invoices/[id]/messages/route')
+    const response = await GET(makeRequest(), {
+      params: Promise.resolve({ id: 'missing_invoice' }),
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: 'Invoice not found' })
+    expect(messageFindMany).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the invoice belongs to another user', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_2' })
+
+    const { GET } = await import('@/app/api/routes-d/invoices/[id]/messages/route')
+    const response = await GET(makeRequest(), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
+    expect(messageFindMany).not.toHaveBeenCalled()
+  })
+
+  it('lists invoice messages for the invoice owner', async () => {
+    const createdAt = new Date('2026-01-01T12:00:00.000Z')
+    const messages = [
+      {
+        id: 'msg_1',
+        senderType: 'client',
+        senderName: 'Ada',
+        content: 'Thanks, paid today.',
+        createdAt,
+      },
+    ]
+
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1' })
+    messageFindMany.mockResolvedValue(messages)
+
+    const { GET } = await import('@/app/api/routes-d/invoices/[id]/messages/route')
+    const response = await GET(makeRequest(), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      messages: [
+        {
+          ...messages[0],
+          createdAt: createdAt.toISOString(),
+        },
+      ],
+    })
+    expect(messageFindMany).toHaveBeenCalledWith({
+      where: { invoiceId: 'inv_1' },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        senderType: true,
+        senderName: true,
+        content: true,
+        createdAt: true,
+      },
+    })
+  })
+})


### PR DESCRIPTION
Closes #728
Closes #742
Closes #744


## Changes
- Hardened the routes-d invoice due-date handler with selected ownership fields and structured error logging.
- Added unit coverage for PATCH /api/routes-d/invoices/[id]/due-date.
- Added unit coverage for GET /api/routes-d/invoices/[id]/messages, including auth, not-found, forbidden, and happy path cases.

## Testing
- Not run per requester instruction.