### PR TITLE
feat(routes-b): invoice activity, branding GET, and invoice cancel endpoints

### DIFF
--- a/app/api/routes-b/branding/route.ts
+++ b/app/api/routes-b/branding/route.ts
@@ -182,3 +182,28 @@ async function PATCHHandler(request: NextRequest) {
 export const PATCH = withRequestId(
   withBodyLimit(PATCHHandler, { limitBytes: 1024 * 1024 })
 )
+
+// GET /api/routes-b/branding — return the authenticated user's branding
+// settings, or { branding: null } (200, not 404) when none has been set up.
+async function GETHandler(request: NextRequest) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const branding = await prisma.brandingSettings.findUnique({
+    where: { userId: user.id },
+    select: {
+      id: true,
+      logoUrl: true,
+      primaryColor: true,
+      footerText: true,
+      signatureUrl: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({ branding: branding ?? null })
+}
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/activity/route.ts
+++ b/app/api/routes-b/invoices/[id]/activity/route.ts
@@ -1,0 +1,67 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+// The AuditEvent model stores `ipAddress` (when known) inside the `metadata`
+// JSON column rather than as a dedicated field, so we surface it from there.
+function extractIpAddress(metadata: unknown): string | null {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const value = (metadata as Record<string, unknown>).ipAddress
+    return typeof value === 'string' && value.length > 0 ? value : null
+  }
+  return null
+}
+
+async function GETHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: { id: true, userId: true },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const events = await prisma.auditEvent.findMany({
+    where: { invoiceId: invoice.id },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      eventType: true,
+      metadata: true,
+      createdAt: true,
+    },
+  })
+
+  return NextResponse.json({
+    activity: events.map((event) => ({
+      id: event.id,
+      action: event.eventType,
+      ipAddress: extractIpAddress(event.metadata),
+      createdAt: event.createdAt,
+    })),
+  })
+}
+
+export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/[id]/cancel/route.ts
+++ b/app/api/routes-b/invoices/[id]/cancel/route.ts
@@ -1,0 +1,85 @@
+import { withRequestId } from '../../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+const MAX_REASON_LENGTH = 200
+
+async function POSTHandler(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  const claims = await verifyAuthToken(authToken || '')
+  if (!claims) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  // Optional body: { reason?: string } (<= 200 chars). Tolerate an empty body.
+  let reason: string | undefined
+  let body: unknown = {}
+  try {
+    body = await request.json()
+  } catch {
+    body = {}
+  }
+  if (body && typeof body === 'object' && 'reason' in body) {
+    const rawReason = (body as Record<string, unknown>).reason
+    if (rawReason !== undefined && rawReason !== null) {
+      if (typeof rawReason !== 'string' || rawReason.length > MAX_REASON_LENGTH) {
+        return NextResponse.json(
+          { error: `reason must be a string of at most ${MAX_REASON_LENGTH} characters` },
+          { status: 400 },
+        )
+      }
+      reason = rawReason
+    }
+  }
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: { id: true, userId: true, status: true },
+  })
+
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+  }
+
+  if (invoice.userId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (invoice.status !== 'pending') {
+    return NextResponse.json(
+      { error: 'Only pending invoices can be cancelled' },
+      { status: 422 },
+    )
+  }
+
+  const updated = await prisma.invoice.update({
+    where: { id },
+    data: {
+      status: 'cancelled',
+      cancelledAt: new Date(),
+      ...(reason !== undefined ? { cancellationReason: reason } : {}),
+    },
+    select: {
+      id: true,
+      invoiceNumber: true,
+      status: true,
+      cancelledAt: true,
+      cancellationReason: true,
+    },
+  })
+
+  return NextResponse.json(updated)
+}
+
+export const POST = withRequestId(POSTHandler)


### PR DESCRIPTION
## Summary

Implements three routes-b endpoints, consolidating the work previously split out in #828 (which this supersedes — closing it in favour of this combined PR).

- **`GET /api/routes-b/invoices/[id]/activity`** — invoice audit events, chronological. Closes #405
- **`GET /api/routes-b/branding`** — user branding settings, `{ branding: null }` (200) when unset. Added alongside the existing PATCH. Closes #412
- **`POST /api/routes-b/invoices/[id]/cancel`** — cancel a pending invoice, optional `reason` (≤200 chars), 422 for non-pending. Closes #423

All use the routes-b auth pattern (`verifyAuthToken` + user lookup), are wrapped with `withRequestId`, and enforce ownership (401/403/404).

## Schema note (important for review)

The `AuditEvent` model has **no** `resourceType`/`resourceId`/`action`/`ipAddress` columns (it has `invoiceId`, `eventType`, `metadata`, …). Issue #405's example query/response assumed columns that don't exist, so the activity endpoint queries by `invoiceId`, maps `action ← eventType`, and surfaces `ipAddress` from the `metadata` JSON.

## Note on #426

`GET /api/routes-b/bank-accounts` (#426) is **already implemented in `main`** with the exact behaviour the issue describes (default-first ordering, correct fields), so this PR intentionally does not touch it. #426 can be closed as already-done.
