### PR TITLE
Fix routes-d invoice tag attach

### DIFF
--- a/app/api/routes-d/invoices/[id]/tags/route.ts
+++ b/app/api/routes-d/invoices/[id]/tags/route.ts
@@ -14,32 +14,50 @@ export async function POST(
     if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
     const claims = await verifyAuthToken(authToken)
-    if (!claims) return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+    if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true },
+    })
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
     const { id } = await params
-    const body = await request.json()
-
-    if (!body.tagId) {
-      return NextResponse.json({ error: 'tagId is required' }, { status: 400 })
+    let body: { tagId?: unknown }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
     }
 
-    // Verify invoice exists and belongs to this user
-    const invoice = await prisma.invoice.findUnique({ where: { id } })
+    if (typeof body.tagId !== 'string' || body.tagId.trim() === '') {
+      return NextResponse.json({ error: 'tagId is required' }, { status: 400 })
+    }
+    const tagId = body.tagId.trim()
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    })
     if (!invoice) return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
     if (invoice.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
-    // Verify tag exists and belongs to this user
-    const tag = await prisma.tag.findUnique({ where: { id: body.tagId } })
+    const tag = await prisma.tag.findUnique({
+      where: { id: tagId },
+      select: {
+        id: true,
+        name: true,
+        color: true,
+        userId: true,
+      },
+    })
     if (!tag) return NextResponse.json({ error: 'Tag not found' }, { status: 404 })
     if (tag.userId !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
     let isNew = true
 
     try {
-      await prisma.invoiceTag.create({ data: { invoiceId: id, tagId: body.tagId } })
+      await prisma.invoiceTag.create({ data: { invoiceId: id, tagId } })
     } catch (err: unknown) {
       const isPrismaUniqueError =
         typeof err === 'object' && err !== null && 'code' in err &&

--- a/tests/api.routes-d.invoice-tags.test.ts
+++ b/tests/api.routes-d.invoice-tags.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const verifyAuthToken = vi.fn()
+const userFindUnique = vi.fn()
+const invoiceFindUnique = vi.fn()
+const tagFindUnique = vi.fn()
+const invoiceTagCreate = vi.fn()
+const loggerError = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/logger', () => ({ logger: { error: loggerError } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: userFindUnique },
+    invoice: { findUnique: invoiceFindUnique },
+    tag: { findUnique: tagFindUnique },
+    invoiceTag: { create: invoiceTagCreate },
+  },
+}))
+
+const URL = 'http://localhost/api/routes-d/invoices/inv_1/tags'
+
+function makeRequest(body: unknown, headers: Record<string, string> = { authorization: 'Bearer token' }) {
+  return new NextRequest(URL, {
+    method: 'POST',
+    headers: { ...headers, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/routes-d/invoices/[id]/tags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when the authorization header is missing', async () => {
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({ tagId: 'tag_1' }, {}), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(verifyAuthToken).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when tagId is missing', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({}), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'tagId is required' })
+    expect(invoiceFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the invoice belongs to another user', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_2' })
+
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({ tagId: 'tag_1' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
+    expect(tagFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the tag belongs to another user', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1' })
+    tagFindUnique.mockResolvedValue({ id: 'tag_1', name: 'Urgent', color: '#111111', userId: 'user_2' })
+
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({ tagId: 'tag_1' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
+    expect(invoiceTagCreate).not.toHaveBeenCalled()
+  })
+
+  it('attaches a tag to an owned invoice', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1' })
+    tagFindUnique.mockResolvedValue({ id: 'tag_1', name: 'Urgent', color: '#111111', userId: 'user_1' })
+    invoiceTagCreate.mockResolvedValue({ invoiceId: 'inv_1', tagId: 'tag_1' })
+
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({ tagId: ' tag_1 ' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toEqual({
+      invoiceId: 'inv_1',
+      tagId: 'tag_1',
+      tagName: 'Urgent',
+      tagColor: '#111111',
+    })
+    expect(invoiceTagCreate).toHaveBeenCalledWith({
+      data: { invoiceId: 'inv_1', tagId: 'tag_1' },
+    })
+  })
+
+  it('is idempotent when the tag is already attached', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceFindUnique.mockResolvedValue({ id: 'inv_1', userId: 'user_1' })
+    tagFindUnique.mockResolvedValue({ id: 'tag_1', name: 'Urgent', color: '#111111', userId: 'user_1' })
+    invoiceTagCreate.mockRejectedValue({ code: 'P2002' })
+
+    const { POST } = await import('@/app/api/routes-d/invoices/[id]/tags/route')
+    const response = await POST(makeRequest({ tagId: 'tag_1' }), {
+      params: Promise.resolve({ id: 'inv_1' }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      invoiceId: 'inv_1',
+      tagId: 'tag_1',
+      tagName: 'Urgent',
+      tagColor: '#111111',
+    })
+  })
+})


### PR DESCRIPTION
Closes #749

## Changes
- Hardens POST /api/routes-d/invoices/[id]/tags with normalized tagId validation, selected ownership fields, invalid JSON handling, and consistent auth errors.
- Keeps duplicate tag attachment idempotent.
- Adds unit coverage for auth, validation, ownership checks, successful attach, and duplicate attach behavior.

## Testing
- Not run per requester instruction.