### PR TITLE
test(routes-d): exchange-rate, profile avatar, invoice remind, bank-accounts coverage

### DIFF
--- a/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
+++ b/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    bankAccount: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedFindMany = vi.mocked(prisma.bankAccount.findMany)
+const mockedCount = vi.mocked(prisma.bankAccount.count)
+const mockedCreate = vi.mocked(prisma.bankAccount.create)
+
+function getReq(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/bank-accounts', {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+function postReq(body: unknown, auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/bank-accounts', {
+    method: 'POST',
+    headers: {
+      ...(auth ? { authorization: auth } : {}),
+      'content-type': 'application/json',
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+const validAccount = {
+  bankName: 'First Bank',
+  bankCode: '011',
+  accountNumber: '3012345678',
+  accountName: 'Jane Doe',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/bank-accounts', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(getReq(''))).status).toBe(401)
+  })
+
+  it('lists accounts with the account number masked', async () => {
+    mockedFindMany.mockResolvedValue([
+      {
+        id: 'b1',
+        bankName: 'First Bank',
+        bankCode: '011',
+        accountNumber: '3012345678',
+        accountName: 'Jane Doe',
+        isDefault: true,
+        createdAt: new Date(),
+      },
+    ] as never)
+    const res = await GET(getReq())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.bankAccounts[0].accountNumber).toBe('******5678')
+  })
+})
+
+describe('POST /api/routes-d/bank-accounts', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await POST(postReq(validAccount, ''))).status).toBe(401)
+  })
+
+  it('returns 400 on invalid JSON', async () => {
+    expect((await POST(postReq('not json'))).status).toBe(400)
+  })
+
+  it('returns 400 when bankName is missing', async () => {
+    const { bankName: _omit, ...rest } = validAccount
+    expect((await POST(postReq(rest))).status).toBe(400)
+  })
+
+  it('returns 400 for a malformed bank code', async () => {
+    expect((await POST(postReq({ ...validAccount, bankCode: 'AB' }))).status).toBe(400)
+  })
+
+  it('returns 400 for a malformed account number', async () => {
+    expect((await POST(postReq({ ...validAccount, accountNumber: '123' }))).status).toBe(400)
+  })
+
+  it('creates a bank account for a valid payload', async () => {
+    mockedCount.mockResolvedValue(0 as never)
+    mockedCreate.mockResolvedValue({
+      id: 'b1',
+      ...validAccount,
+      isDefault: true,
+      createdAt: new Date(),
+    } as never)
+    const res = await POST(postReq(validAccount))
+    expect([200, 201]).toContain(res.status)
+    expect(mockedCreate).toHaveBeenCalled()
+  })
+})

--- a/app/api/routes-d/exchange-rate/__tests__/exchange-rate.test.ts
+++ b/app/api/routes-d/exchange-rate/__tests__/exchange-rate.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/exchange-rate', () => ({ getUsdToNgnRate: vi.fn() }))
+
+import { getUsdToNgnRate } from '@/lib/exchange-rate'
+import { GET } from '../route'
+
+const mockedRate = vi.mocked(getUsdToNgnRate)
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('GET /api/routes-d/exchange-rate', () => {
+  it('returns the USDC->NGN rate envelope', async () => {
+    mockedRate.mockResolvedValue({
+      rate: 1600,
+      lastUpdated: '2026-05-26T00:00:00.000Z',
+    } as never)
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.rate).toEqual({
+      from: 'USDC',
+      to: 'NGN',
+      value: 1600,
+      fetchedAt: '2026-05-26T00:00:00.000Z',
+    })
+  })
+
+  it('returns 503 when the rate source falls back', async () => {
+    mockedRate.mockResolvedValue({ fallback: true } as never)
+    expect((await GET()).status).toBe(503)
+  })
+})

--- a/app/api/routes-d/invoices/[id]/remind/__tests__/remind.test.ts
+++ b/app/api/routes-d/invoices/[id]/remind/__tests__/remind.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+  },
+}))
+vi.mock('@/lib/email', () => ({ sendEmail: vi.fn() }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { sendEmail } from '@/lib/email'
+import { POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+const mockedSend = vi.mocked(sendEmail)
+
+const params = { params: Promise.resolve({ id: 'inv-1' }) }
+
+function req(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/invoices/inv-1/remind', {
+    method: 'POST',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+const pendingInvoice = {
+  userId: 'user-1',
+  status: 'pending',
+  clientEmail: 'client@example.com',
+  invoiceNumber: 'INV-001',
+  amount: 100,
+  currency: 'USD',
+  dueDate: null,
+  paymentLink: 'https://pay/inv-1',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('POST /api/routes-d/invoices/[id]/remind', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await POST(req(''), params)).status).toBe(401)
+  })
+
+  it('returns 404 when the user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await POST(req(), params)).status).toBe(404)
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null as never)
+    expect((await POST(req(), params)).status).toBe(404)
+  })
+
+  it('returns 403 when the invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({ ...pendingInvoice, userId: 'other' } as never)
+    expect((await POST(req(), params)).status).toBe(403)
+  })
+
+  it('returns 422 when the invoice is not pending', async () => {
+    mockedInvoiceFind.mockResolvedValue({ ...pendingInvoice, status: 'paid' } as never)
+    expect((await POST(req(), params)).status).toBe(422)
+  })
+
+  it('sends the reminder for a pending invoice', async () => {
+    mockedInvoiceFind.mockResolvedValue(pendingInvoice as never)
+    mockedSend.mockResolvedValue(undefined as never)
+    const res = await POST(req(), params)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ sent: true, clientEmail: 'client@example.com' })
+    expect(mockedSend).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'client@example.com' }),
+    )
+  })
+})

--- a/app/api/routes-d/profile/avatar/__tests__/avatar.test.ts
+++ b/app/api/routes-d/profile/avatar/__tests__/avatar.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({ prisma: { user: { update: vi.fn() } } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUpdate = vi.mocked(prisma.user.update)
+
+function req(body: unknown, auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/profile/avatar', {
+    method: 'PATCH',
+    headers: {
+      ...(auth ? { authorization: auth } : {}),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+})
+
+describe('PATCH /api/routes-d/profile/avatar', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await PATCH(req({ avatarUrl: 'https://x/a.png' }, ''))).status).toBe(401)
+  })
+
+  it('returns 400 when avatarUrl is missing', async () => {
+    expect((await PATCH(req({}))).status).toBe(400)
+  })
+
+  it('returns 400 for a non-string avatarUrl', async () => {
+    expect((await PATCH(req({ avatarUrl: 123 }))).status).toBe(400)
+  })
+
+  it('returns 400 for a non-HTTPS URL', async () => {
+    expect((await PATCH(req({ avatarUrl: 'http://x/a.png' }))).status).toBe(400)
+  })
+
+  it('returns 400 when avatarUrl exceeds 512 chars', async () => {
+    const long = `https://x/${'a'.repeat(520)}.png`
+    expect((await PATCH(req({ avatarUrl: long }))).status).toBe(400)
+  })
+
+  it('updates the avatar for a valid HTTPS URL', async () => {
+    mockedUpdate.mockResolvedValue({ avatarUrl: 'https://cdn/a.png' } as never)
+    const res = await PATCH(req({ avatarUrl: 'https://cdn/a.png' }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ avatarUrl: 'https://cdn/a.png' })
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { privyId: 'privy-1' },
+        data: { avatarUrl: 'https://cdn/a.png' },
+      }),
+    )
+  })
+
+  it('allows clearing the avatar with null', async () => {
+    mockedUpdate.mockResolvedValue({ avatarUrl: null } as never)
+    const res = await PATCH(req({ avatarUrl: null }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ avatarUrl: null })
+  })
+})


### PR DESCRIPTION
## Summary
The four route handlers below already exist on `main`; their issues' acceptance criteria require unit tests for the happy path and key failure modes. This PR adds those tests and leaves the route code unchanged.

closes #770
closes #755
closes #747
closes #735

- **#770 exchange-rate** `GET` — 200 rate envelope (USDC→NGN) + 503 on fallback.
- **#755 profile/avatar** `PATCH` — 401, 400 (missing / non-string / non-HTTPS / >512), 200 update, null clear; asserts the update targets the authed user.
- **#747 invoices/[id]/remind** `POST` — 401 / 404 (no user, no invoice) / 403 / 422 (non-pending) / 200 sends the reminder email.
- **#735 bank-accounts** `GET,POST` — masked account listing; create validation (401 / 400 invalid-json, missing/malformed fields / 201).

All tests follow the existing routes-d vitest convention (mocked `@/lib/auth`, `@/lib/db`, `@/lib/email`).
