### PR TITLE
test(routes-d): add unit tests for contacts, tags, invoice summary & payment-status

### DIFF
--- a/app/api/routes-d/contacts/__tests__/contacts.test.ts
+++ b/app/api/routes-d/contacts/__tests__/contacts.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    contact: { findMany: vi.fn(), create: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const contactDelegate = prisma.contact as unknown as {
+  findMany: ReturnType<typeof vi.fn>
+  create: ReturnType<typeof vi.fn>
+}
+
+const BASE_URL = 'http://localhost/api/routes-d/contacts'
+
+function makeGet(search?: string, authHeader: string | null = 'Bearer token') {
+  const url = search ? `${BASE_URL}?search=${encodeURIComponent(search)}` : BASE_URL
+  return new NextRequest(url, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+function makePost(body: unknown, authHeader: string | null = 'Bearer token') {
+  return new NextRequest(BASE_URL, {
+    method: 'POST',
+    headers: authHeader ? { authorization: authHeader } : {},
+    body: JSON.stringify(body),
+  })
+}
+
+describe('GET /api/routes-d/contacts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when the auth token is missing', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeGet(undefined, null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(contactDelegate.findMany).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when the token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeGet())
+    expect(res.status).toBe(401)
+    expect(contactDelegate.findMany).not.toHaveBeenCalled()
+  })
+
+  it('lists the authenticated user contacts with nullable fields normalised', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    contactDelegate.findMany.mockResolvedValue([
+      {
+        id: 'c-1',
+        name: 'Ada',
+        email: 'ada@example.com',
+        company: 'ACME',
+        notes: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ])
+
+    const res = await GET(makeGet())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.contacts).toHaveLength(1)
+    expect(body.contacts[0]).toMatchObject({
+      id: 'c-1',
+      name: 'Ada',
+      email: 'ada@example.com',
+      company: 'ACME',
+      notes: null,
+    })
+    expect(contactDelegate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'user_1' }) }),
+    )
+  })
+
+  it('applies a case-insensitive search filter on name and email', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    contactDelegate.findMany.mockResolvedValue([])
+
+    await GET(makeGet('ada'))
+    expect(contactDelegate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: 'user_1',
+          OR: [
+            { name: { contains: 'ada', mode: 'insensitive' } },
+            { email: { contains: 'ada', mode: 'insensitive' } },
+          ],
+        },
+      }),
+    )
+  })
+})
+
+describe('POST /api/routes-d/contacts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await POST(makePost({ name: 'Ada', email: 'ada@example.com' }, null))
+    expect(res.status).toBe(401)
+    expect(contactDelegate.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the name is missing', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    const res = await POST(makePost({ email: 'ada@example.com' }))
+    expect(res.status).toBe(400)
+    expect(contactDelegate.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the email is invalid', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    const res = await POST(makePost({ name: 'Ada', email: 'not-an-email' }))
+    expect(res.status).toBe(400)
+    expect(contactDelegate.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when notes exceed the maximum length', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    const res = await POST(
+      makePost({ name: 'Ada', email: 'ada@example.com', notes: 'x'.repeat(501) }),
+    )
+    expect(res.status).toBe(400)
+    expect(contactDelegate.create).not.toHaveBeenCalled()
+  })
+
+  it('creates a contact and returns 201 with normalised fields', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    contactDelegate.create.mockResolvedValue({
+      id: 'c-1',
+      name: 'Ada',
+      email: 'ada@example.com',
+      company: null,
+      notes: null,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    })
+
+    const res = await POST(makePost({ name: 'Ada', email: 'Ada@Example.com' }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body).toMatchObject({ id: 'c-1', email: 'ada@example.com', company: null, notes: null })
+    expect(contactDelegate.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: 'user_1', name: 'Ada', email: 'ada@example.com' }),
+      }),
+    )
+  })
+
+  it('returns 409 when a contact with the same email already exists', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    contactDelegate.create.mockRejectedValue({ code: 'P2002' })
+
+    const res = await POST(makePost({ name: 'Ada', email: 'ada@example.com' }))
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({
+      error: 'A contact with this email already exists',
+    })
+  })
+})

--- a/app/api/routes-d/contacts/route.ts
+++ b/app/api/routes-d/contacts/route.ts
@@ -28,7 +28,9 @@ async function getAuthenticatedUser(request: NextRequest) {
 }
 
 function normalizeOptionalString(value: unknown, maxLength: number): string | null | undefined {
-  if (value === undefined) return undefined
+  // An omitted optional field is treated as "no value" (null), not invalid input.
+  // `undefined` is reserved for values that fail validation (wrong type or too long).
+  if (value === undefined) return null
   if (value === null) return null
   if (typeof value !== 'string') return undefined
 

--- a/app/api/routes-d/invoices/[id]/payment-status/__tests__/payment-status.test.ts
+++ b/app/api/routes-d/invoices/[id]/payment-status/__tests__/payment-status.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedLoggerError = vi.mocked(logger.error)
+const invoiceDelegate = prisma.invoice as unknown as { findUnique: ReturnType<typeof vi.fn> }
+
+const URL = 'http://localhost/api/routes-d/invoices/inv-1/payment-status'
+
+function makeRequest(authHeader: string | null = null) {
+  return new NextRequest(URL, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+function withParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+const invoice = {
+  id: 'inv-1',
+  invoiceNumber: 'INV-001',
+  status: 'paid',
+  amount: '250.00',
+  currency: 'USD',
+  paidAt: new Date('2026-02-01T00:00:00Z'),
+  dueDate: new Date('2026-01-15T00:00:00Z'),
+}
+
+describe('GET /api/routes-d/invoices/[id]/payment-status', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 404 when no invoice matches the id or invoice number', async () => {
+    invoiceDelegate.findUnique.mockResolvedValue(null)
+    const res = await GET(makeRequest(), withParams('missing'))
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Invoice not found' })
+  })
+
+  it('returns the payment status looked up by id without requiring auth', async () => {
+    invoiceDelegate.findUnique.mockResolvedValueOnce(invoice)
+    const res = await GET(makeRequest(), withParams('inv-1'))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      invoiceNumber: 'INV-001',
+      status: 'paid',
+      amount: 250,
+      currency: 'USD',
+      paidAt: '2026-02-01T00:00:00.000Z',
+      dueDate: '2026-01-15T00:00:00.000Z',
+    })
+    expect(mockedVerify).not.toHaveBeenCalled()
+  })
+
+  it('falls back to looking up the invoice by invoice number', async () => {
+    invoiceDelegate.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce(invoice)
+    const res = await GET(makeRequest(), withParams('INV-001'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.invoiceNumber).toBe('INV-001')
+    expect(invoiceDelegate.findUnique).toHaveBeenNthCalledWith(1, { where: { id: 'INV-001' } })
+    expect(invoiceDelegate.findUnique).toHaveBeenNthCalledWith(2, {
+      where: { invoiceNumber: 'INV-001' },
+    })
+  })
+
+  it('verifies the token when an authorization header is present', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    invoiceDelegate.findUnique.mockResolvedValueOnce(invoice)
+    const res = await GET(makeRequest('Bearer token'), withParams('inv-1'))
+    expect(res.status).toBe(200)
+    expect(mockedVerify).toHaveBeenCalledWith('token')
+  })
+
+  it('returns 500 and logs when the lookup throws', async () => {
+    invoiceDelegate.findUnique.mockRejectedValue(new Error('db down'))
+    const res = await GET(makeRequest(), withParams('inv-1'))
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to get payment status' })
+    expect(mockedLoggerError).toHaveBeenCalled()
+  })
+})

--- a/app/api/routes-d/invoices/summary/__tests__/summary.test.ts
+++ b/app/api/routes-d/invoices/summary/__tests__/summary.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { aggregate: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const invoiceDelegate = prisma.invoice as unknown as { aggregate: ReturnType<typeof vi.fn> }
+
+const URL = 'http://localhost/api/routes-d/invoices/summary'
+
+function makeRequest(authHeader: string | null = 'Bearer token') {
+  return new NextRequest(URL, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('GET /api/routes-d/invoices/summary', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when the auth token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(mockedUserFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user does not exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'User not found' })
+    expect(invoiceDelegate.aggregate).not.toHaveBeenCalled()
+  })
+
+  it('returns a six-month aggregation scoped to the authenticated user', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    invoiceDelegate.aggregate.mockResolvedValue({ _count: { id: 2 }, _sum: { amount: '150.00' } })
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.summary).toHaveLength(6)
+    expect(body.summary[0]).toMatchObject({
+      issued: 2,
+      paid: 2,
+      totalIssued: 150,
+      totalPaid: 150,
+    })
+    expect(body.summary[0].month).toMatch(/^\d{4}-\d{2}$/)
+    // 2 aggregate calls (issued + paid) per month over six months
+    expect(invoiceDelegate.aggregate).toHaveBeenCalledTimes(12)
+    expect(invoiceDelegate.aggregate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ userId: 'user_1' }) }),
+    )
+  })
+
+  it('coerces null sums to zero', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    invoiceDelegate.aggregate.mockResolvedValue({ _count: { id: 0 }, _sum: { amount: null } })
+
+    const res = await GET(makeRequest())
+    const body = await res.json()
+    expect(body.summary[0]).toMatchObject({
+      issued: 0,
+      paid: 0,
+      totalIssued: 0,
+      totalPaid: 0,
+    })
+  })
+})

--- a/app/api/routes-d/tags/__tests__/tags.test.ts
+++ b/app/api/routes-d/tags/__tests__/tags.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    tag: { findMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const tagDelegate = prisma.tag as unknown as { findMany: ReturnType<typeof vi.fn> }
+
+const URL = 'http://localhost/api/routes-d/tags'
+
+function makeRequest(authHeader: string | null = 'Bearer token') {
+  return new NextRequest(URL, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('GET /api/routes-d/tags', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when the auth token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(makeRequest(null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(mockedUserFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user does not exist', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'User not found' })
+    expect(tagDelegate.findMany).not.toHaveBeenCalled()
+  })
+
+  it('returns the tags with their invoice counts for the authenticated user', async () => {
+    mockedVerify.mockResolvedValue({ userId: 'privy_1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user_1' } as never)
+    tagDelegate.findMany.mockResolvedValue([
+      {
+        id: 't-1',
+        name: 'Urgent',
+        color: '#ff0000',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        _count: { invoiceTags: 3 },
+      },
+    ])
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.tags).toEqual([
+      {
+        id: 't-1',
+        name: 'Urgent',
+        color: '#ff0000',
+        invoiceCount: 3,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ])
+    expect(tagDelegate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'user_1' },
+        orderBy: { name: 'asc' },
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The four `routes-d` handlers below were already implemented on `main` but had **no unit tests**, leaving the "Unit tests pass in CI" acceptance criterion unmet. This PR adds happy-path + key failure-mode tests for each, following the existing vitest conventions (`vi.mock` of `@/lib/auth` and `@/lib/db`, handlers invoked directly).

### Tests added
- **`GET,POST /api/routes-d/contacts`** (#738) — GET: auth, case-insensitive search filter, nullable-field normalisation; POST: auth, name/email/notes validation, `201` happy path, `P2002` → `409` duplicate.
- **`GET /api/routes-d/invoices/[id]/payment-status`** (#745) — lookup by `id` and fallback by `invoiceNumber`, optional auth, `404` not found, `500` error envelope.
- **`GET /api/routes-d/invoices/summary`** (#751) — auth, missing user `404`, six-month aggregation shape, null-sum coercion to `0`.
- **`GET /api/routes-d/tags`** (#759) — auth, missing user `404`, tag → invoice-count mapping.

### Bug fix (in scope for #738)
Writing the contacts tests surfaced a bug: `normalizeOptionalString` returned `undefined` both when an optional field was **absent** and when it was **invalid**, and the POST handler rejects `undefined` with `400`. As a result, creating a contact with only `name` + `email` (the documented happy path) returned `400`, even though `company`/`notes` are optional (`String?`) in the Prisma schema. Fixed by treating an absent value as `null`, reserving `undefined` for genuinely invalid input.

## Test plan
- [x] `npx vitest run` on all four new test files — **22 passed**
- [x] Existing `contacts/__tests__/contact-by-id.test.ts` still green (11 passed)
- [x] `npx tsc --noEmit` — no type errors in the changed files

Closes #738
Closes #745
Closes #751
Closes #759