### PR TITLE
test(routes-d): notifications mark-all-read, profile, transaction get & export coverage

### DIFF
--- a/app/api/routes-d/notifications/mark-all-read/__tests__/route.test.ts
+++ b/app/api/routes-d/notifications/mark-all-read/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    notification: { updateMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedUpdateMany = vi.mocked(prisma.notification.updateMany)
+
+function req(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/notifications/mark-all-read', {
+    method: 'POST',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('POST /api/routes-d/notifications/mark-all-read', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await POST(req(''))).status).toBe(401)
+  })
+
+  it('returns 404 when the user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await POST(req())).status).toBe(404)
+  })
+
+  it('marks the user\'s unread notifications read and returns the count', async () => {
+    mockedUpdateMany.mockResolvedValue({ count: 3 } as never)
+    const res = await POST(req())
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, updatedCount: 3 })
+    expect(mockedUpdateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1', isRead: false },
+      data: { isRead: true },
+    })
+  })
+})

--- a/app/api/routes-d/profile/__tests__/route.test.ts
+++ b/app/api/routes-d/profile/__tests__/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn(), update: vi.fn() } },
+}))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedUserUpdate = vi.mocked(prisma.user.update)
+
+function req(method: string, auth = 'Bearer token', body?: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/profile', {
+    method,
+    headers: {
+      ...(auth ? { authorization: auth } : {}),
+      'content-type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+const user = { id: 'user-1', privyId: 'privy-1', email: 'a@b.c', name: 'Jane', role: 'user', createdAt: new Date() }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+})
+
+describe('GET /api/routes-d/profile', () => {
+  it('returns 401 without a token', async () => {
+    expect((await GET(req('GET', ''))).status).toBe(401)
+  })
+
+  it('returns 404 when the user is not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(req('GET'))).status).toBe(404)
+  })
+
+  it('returns the profile with wallet and bank-account count', async () => {
+    mockedUserFind.mockResolvedValue({
+      ...user,
+      wallet: { address: 'GABC' },
+      _count: { bankAccounts: 2 },
+    } as never)
+    const res = await GET(req('GET'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.profile.id).toBe('user-1')
+    expect(json.profile.wallet).toEqual({ address: 'GABC' })
+    expect(json.profile.bankAccountCount).toBe(2)
+  })
+})
+
+describe('PATCH /api/routes-d/profile', () => {
+  beforeEach(() => mockedUserFind.mockResolvedValue(user as never))
+
+  it('returns 401 without a token', async () => {
+    expect((await PATCH(req('PATCH', '', { name: 'X' }))).status).toBe(401)
+  })
+
+  it('rejects an empty name', async () => {
+    expect((await PATCH(req('PATCH', 'Bearer token', { name: '  ' }))).status).toBe(400)
+  })
+
+  it('rejects an invalid timezone', async () => {
+    expect((await PATCH(req('PATCH', 'Bearer token', { timezone: 'Not/AZone' }))).status).toBe(400)
+  })
+
+  it('updates name and timezone', async () => {
+    mockedUserUpdate.mockResolvedValue({ id: 'user-1', name: 'Jane Doe', timezone: 'Africa/Lagos' } as never)
+    const res = await PATCH(req('PATCH', 'Bearer token', { name: 'Jane Doe', timezone: 'Africa/Lagos' }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 'user-1', name: 'Jane Doe', timezone: 'Africa/Lagos' })
+  })
+})

--- a/app/api/routes-d/transactions/[id]/__tests__/route.test.ts
+++ b/app/api/routes-d/transactions/[id]/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, transaction: { findUnique: vi.fn() } },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedTxFind = vi.mocked(prisma.transaction.findUnique)
+
+const params = { params: Promise.resolve({ id: 'tx-1' }) }
+
+function req(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/transactions/tx-1', {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+const tx = {
+  id: 'tx-1', type: 'withdrawal', status: 'completed', amount: 100, currency: 'USDC',
+  txHash: 'hash', invoiceId: null, userId: 'user-1', createdAt: new Date(), completedAt: new Date(),
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/transactions/[id]', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(req(''), params)).status).toBe(401)
+  })
+
+  it('returns 404 when the user is not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(req(), params)).status).toBe(404)
+  })
+
+  it('returns 404 when the transaction does not exist', async () => {
+    mockedTxFind.mockResolvedValue(null as never)
+    expect((await GET(req(), params)).status).toBe(404)
+  })
+
+  it('returns 403 when the transaction belongs to another user', async () => {
+    mockedTxFind.mockResolvedValue({ ...tx, userId: 'other' } as never)
+    expect((await GET(req(), params)).status).toBe(403)
+  })
+
+  it('returns the transaction for its owner', async () => {
+    mockedTxFind.mockResolvedValue(tx as never)
+    const res = await GET(req(), params)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.transaction.id).toBe('tx-1')
+    expect(json.transaction.amount).toBe(100)
+    expect(json.transaction.stellarTxHash).toBe('hash')
+  })
+})

--- a/app/api/routes-d/transactions/export/__tests__/route.test.ts
+++ b/app/api/routes-d/transactions/export/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, transaction: { findMany: vi.fn() } },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedTxFindMany = vi.mocked(prisma.transaction.findMany)
+
+function req(qs = '?from=2026-01-01&to=2026-12-31', auth = 'Bearer token'): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-d/transactions/export${qs}`, {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/transactions/export', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(req('', ''))).status).toBe(401)
+  })
+
+  it('returns 400 when from/to are missing', async () => {
+    expect((await GET(req(''))).status).toBe(400)
+  })
+
+  it('returns 400 for invalid dates', async () => {
+    expect((await GET(req('?from=nope&to=also-nope'))).status).toBe(400)
+  })
+
+  it('streams a CSV of the user\'s transactions in range', async () => {
+    mockedTxFindMany.mockResolvedValue([
+      { id: 'tx-1', type: 'deposit', status: 'completed', amount: 50, currency: 'USDC', createdAt: new Date('2026-02-01T00:00:00Z') },
+    ] as never)
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/csv')
+    const body = await res.text()
+    expect(body.split('\n')[0]).toBe('id,type,status,amount,currency,createdAt')
+    expect(body).toContain('tx-1,deposit,completed,50.00,USDC')
+  })
+})


### PR DESCRIPTION
## Summary
The four route handlers below already exist on `main`; their issues' acceptance criteria require unit tests for the happy path and key failure modes. This PR adds those tests and leaves the route code unchanged.

closes #753
closes #756
closes #760
closes #761

- **#753 notifications/mark-all-read** `POST` — 401, 404 (no user), and a successful bulk mark returning `updatedCount`; asserts the `updateMany` targets the user's unread notifications.
- **#756 profile** `GET,PATCH` — GET: 401 / 404 / 200 (profile incl. wallet + bank-account count); PATCH: 401, 400 (empty name, invalid IANA timezone), 200 update.
- **#760 transactions/[id]** `GET` — 401 / 404 (no user) / 404 (no tx) / 403 (other user) / 200 owner.
- **#761 transactions/export** `GET` — 401 / 400 (missing or invalid `from`/`to`) / 200 CSV (asserts header row + content + `text/csv`).

All follow the existing routes-d vitest convention (mocked `@/lib/auth`, `@/lib/db`, `@/lib/logger`).
