### PR TITLE
test(routes-d): unit tests for bank-accounts set-default (#733) & delete (#734)

### DIFF
--- a/app/api/routes-d/bank-accounts/[id]/__tests__/route.test.ts
+++ b/app/api/routes-d/bank-accounts/[id]/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    bankAccount: { findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { DELETE } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedAccountFind = vi.mocked(prisma.bankAccount.findUnique)
+const mockedTransaction = vi.mocked(prisma.$transaction)
+
+// Stand-in transaction client; $transaction is wired to invoke the handler's
+// callback with this so we can assert the reassignment + delete behavior.
+const tx = {
+  bankAccount: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}
+
+const params = { params: Promise.resolve({ id: 'ba-1' }) }
+
+function req(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/bank-accounts/ba-1', {
+    method: 'DELETE',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+const ownedDefault = { id: 'ba-1', userId: 'user-1', isDefault: true }
+const ownedNonDefault = { id: 'ba-1', userId: 'user-1', isDefault: false }
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+  mockedTransaction.mockImplementation(
+    async (cb: (client: typeof tx) => unknown) => cb(tx),
+  )
+})
+
+describe('DELETE /api/routes-d/bank-accounts/[id]', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await DELETE(req(''), params)).status).toBe(401)
+  })
+
+  it('returns 401 when the authenticated user has no account record', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await DELETE(req(), params)).status).toBe(401)
+  })
+
+  it('returns 404 when the bank account does not exist', async () => {
+    mockedAccountFind.mockResolvedValue(null as never)
+    const res = await DELETE(req(), params)
+    expect(res.status).toBe(404)
+    expect(mockedTransaction).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when the bank account belongs to another user', async () => {
+    mockedAccountFind.mockResolvedValue({
+      ...ownedNonDefault,
+      userId: 'other-user',
+    } as never)
+    const res = await DELETE(req(), params)
+    expect(res.status).toBe(403)
+    expect(mockedTransaction).not.toHaveBeenCalled()
+  })
+
+  it('deletes a non-default account without reassigning a default', async () => {
+    mockedAccountFind.mockResolvedValue(ownedNonDefault as never)
+    const res = await DELETE(req(), params)
+    expect(res.status).toBe(204)
+    expect(tx.bankAccount.findFirst).not.toHaveBeenCalled()
+    expect(tx.bankAccount.update).not.toHaveBeenCalled()
+    expect(tx.bankAccount.delete).toHaveBeenCalledWith({ where: { id: 'ba-1' } })
+  })
+
+  it('promotes the oldest remaining account when deleting the default', async () => {
+    mockedAccountFind.mockResolvedValue(ownedDefault as never)
+    tx.bankAccount.findFirst.mockResolvedValue({ id: 'ba-2' } as never)
+
+    const res = await DELETE(req(), params)
+    expect(res.status).toBe(204)
+    // Picks the oldest of the user's *other* accounts as the new default.
+    expect(tx.bankAccount.findFirst).toHaveBeenCalledWith({
+      where: { userId: 'user-1', id: { not: 'ba-1' } },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+    })
+    expect(tx.bankAccount.update).toHaveBeenCalledWith({
+      where: { id: 'ba-2' },
+      data: { isDefault: true },
+    })
+    expect(tx.bankAccount.delete).toHaveBeenCalledWith({ where: { id: 'ba-1' } })
+  })
+
+  it('deletes the default account without reassigning when it is the last one', async () => {
+    mockedAccountFind.mockResolvedValue(ownedDefault as never)
+    tx.bankAccount.findFirst.mockResolvedValue(null as never)
+
+    const res = await DELETE(req(), params)
+    expect(res.status).toBe(204)
+    expect(tx.bankAccount.update).not.toHaveBeenCalled()
+    expect(tx.bankAccount.delete).toHaveBeenCalledWith({ where: { id: 'ba-1' } })
+  })
+})

--- a/app/api/routes-d/bank-accounts/[id]/default/__tests__/route.test.ts
+++ b/app/api/routes-d/bank-accounts/[id]/default/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    bankAccount: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedAccountFind = vi.mocked(prisma.bankAccount.findUnique)
+const mockedTransaction = vi.mocked(prisma.$transaction)
+
+const params = { params: Promise.resolve({ id: 'ba-1' }) }
+
+function req(auth = 'Bearer token'): NextRequest {
+  return new NextRequest(
+    'http://localhost/api/routes-d/bank-accounts/ba-1/default',
+    {
+      method: 'PATCH',
+      headers: auth ? { authorization: auth } : {},
+    },
+  )
+}
+
+const ownedNonDefault = {
+  id: 'ba-1',
+  userId: 'user-1',
+  isDefault: false,
+  bankName: 'First Bank',
+  accountNumber: '3012345678',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('PATCH /api/routes-d/bank-accounts/[id]/default', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await PATCH(req(''), params)).status).toBe(401)
+  })
+
+  it('returns 401 when the authenticated user has no account record', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await PATCH(req(), params)).status).toBe(401)
+  })
+
+  it('returns 404 when the bank account does not exist', async () => {
+    mockedAccountFind.mockResolvedValue(null as never)
+    expect((await PATCH(req(), params)).status).toBe(404)
+  })
+
+  it('returns 403 when the bank account belongs to another user', async () => {
+    mockedAccountFind.mockResolvedValue({
+      ...ownedNonDefault,
+      userId: 'other-user',
+    } as never)
+    const res = await PATCH(req(), params)
+    expect(res.status).toBe(403)
+    expect(mockedTransaction).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: returns 200 without a write when already default', async () => {
+    mockedAccountFind.mockResolvedValue({
+      ...ownedNonDefault,
+      isDefault: true,
+    } as never)
+    const res = await PATCH(req(), params)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.isDefault).toBe(true)
+    expect(mockedTransaction).not.toHaveBeenCalled()
+  })
+
+  it('promotes the account to default, clearing any previous default, atomically', async () => {
+    mockedAccountFind.mockResolvedValue(ownedNonDefault as never)
+    mockedTransaction.mockResolvedValue([
+      { count: 1 },
+      {
+        id: 'ba-1',
+        isDefault: true,
+        bankName: 'First Bank',
+        accountNumber: '3012345678',
+      },
+    ] as never)
+
+    const res = await PATCH(req(), params)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toMatchObject({ id: 'ba-1', isDefault: true })
+    // The promotion must run inside a single transaction (clear old default + set new).
+    expect(mockedTransaction).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the unit-test coverage required by **#733** and **#734** for the routes-d bank-accounts endpoints. Both handlers already exist and are correct on `main`, but neither had any tests — these suites lock in the documented behavior (happy path + key failure modes) and follow the existing routes-d test conventions (`vitest`, mocked `@/lib/auth` and `@/lib/db`, `params` passed as a resolved `Promise`).

closes #733
closes #734

## Changes

### #733 — `PATCH /api/routes-d/bank-accounts/[id]/default`
New `app/api/routes-d/bank-accounts/[id]/default/__tests__/route.test.ts` (6 tests):
- `401` when the bearer token is missing/invalid
- `401` when the token is valid but no matching user record exists
- `404` when the bank account does not exist
- `403` when the account belongs to another user — asserts **no** write/transaction runs
- idempotent `200` with **no** transaction when the account is already the default
- promotes the account to default inside a **single `$transaction`** (clears the previous default + sets the new one) and returns the updated record

### #734 — `DELETE /api/routes-d/bank-accounts/[id]`
New `app/api/routes-d/bank-accounts/[id]/__tests__/route.test.ts` (7 tests):
- `401` (missing/invalid token, and valid token with no user record)
- `404` when the account does not exist — asserts the guard short-circuits before any transaction
- `403` when the account belongs to another user — same guard assertion
- deletes a **non-default** account without reassigning a default
- deletes the **default** account and promotes the **oldest remaining** account (`orderBy createdAt asc`, excluding the deleted id) as the new default
- deletes the **default** account without reassignment when it is the last one (returns `204`)

The DELETE tests wire `$transaction` to invoke the handler's callback against a stand-in transaction client, so the reassignment/delete calls are asserted directly.

## Test plan
- `npx vitest run app/api/routes-d/bank-accounts/[id]` → **13 passing** (6 + 7)
- `npx eslint` on both new files → clean
- No source/handler changes, so the existing `lint` and `build` CI jobs are unaffected.

## Caveats
- Honest scope note: I verified `vitest` and `eslint` locally; I did not run the full `next build` (it requires `prisma generate` + a DB/env). Since these are additional test files mirroring existing sibling tests already in the repo (e.g. `transactions/[id]/__tests__`), they don't affect the production build.
