### PR TITLE
Fix routes d

### DIFF
--- a/app/api/routes-d/notifications/__tests__/route.test.ts
+++ b/app/api/routes-d/notifications/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, notification: { findMany: vi.fn(), count: vi.fn() } },
+}))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedNotifFindMany = vi.mocked(prisma.notification.findMany)
+const mockedNotifCount = vi.mocked(prisma.notification.count)
+
+function reqGET(query = '', auth = 'Bearer token'): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-d/notifications${query}`, {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/notifications', () => {
+  it('returns 401 without token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(reqGET(''))).status).toBe(401)
+  })
+
+  it('returns 404 if user not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(reqGET())).status).toBe(404)
+  })
+
+  it('returns notifications and unread count', async () => {
+    mockedNotifFindMany.mockResolvedValue([{ id: '1', title: 'Test' }] as never)
+    mockedNotifCount.mockResolvedValue(1 as never)
+
+    const res = await GET(reqGET())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.notifications).toHaveLength(1)
+    expect(json.unreadCount).toBe(1)
+  })
+
+  it('filters by unread=true', async () => {
+    mockedNotifFindMany.mockResolvedValue([{ id: '1', title: 'Test', isRead: false }] as never)
+    mockedNotifCount.mockResolvedValue(1 as never)
+
+    const res = await GET(reqGET('?unread=true'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.notifications).toHaveLength(1)
+    expect(json.unreadCount).toBe(1)
+    expect(mockedNotifFindMany).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user-1', isRead: false } }))
+  })
+})

--- a/app/api/routes-d/reminder-settings/__tests__/route.test.ts
+++ b/app/api/routes-d/reminder-settings/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, reminderSettings: { findUnique: vi.fn(), upsert: vi.fn() } },
+}))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedSettingsFind = vi.mocked(prisma.reminderSettings.findUnique)
+const mockedSettingsUpsert = vi.mocked(prisma.reminderSettings.upsert)
+
+function reqGET(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/reminder-settings', {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+function reqPATCH(body: any, auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/reminder-settings', {
+    method: 'PATCH',
+    headers: auth ? { authorization: auth, 'content-type': 'application/json' } : { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/reminder-settings', () => {
+  it('returns 401 without token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(reqGET(''))).status).toBe(401)
+  })
+
+  it('returns 401 if user not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(reqGET())).status).toBe(401)
+  })
+
+  it('returns settings if found', async () => {
+    mockedSettingsFind.mockResolvedValue({ id: '1', onDueEnabled: true, beforeDueDays: [3], afterDueDays: [7] } as never)
+    const res = await GET(reqGET())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.settings.onDueEnabled).toBe(true)
+  })
+
+  it('returns null settings if not found', async () => {
+    mockedSettingsFind.mockResolvedValue(null as never)
+    const res = await GET(reqGET())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.settings).toBeNull()
+  })
+})
+
+describe('PATCH /api/routes-d/reminder-settings', () => {
+  it('returns 401 without token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await PATCH(reqPATCH({}))).status).toBe(401)
+  })
+
+  it('validates sendDaysBefore limit', async () => {
+    expect((await PATCH(reqPATCH({ sendDaysBefore: 50 }))).status).toBe(400)
+  })
+
+  it('validates sendDaysAfter limit', async () => {
+    expect((await PATCH(reqPATCH({ sendDaysAfter: 100 }))).status).toBe(400)
+  })
+
+  it('upserts settings successfully', async () => {
+    mockedSettingsUpsert.mockResolvedValue({ onDueEnabled: false, beforeDueDays: [2], afterDueDays: [5] } as never)
+    const res = await PATCH(reqPATCH({ sendOnDueDate: false, sendDaysBefore: 2, sendDaysAfter: 5 }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.settings.sendOnDueDate).toBe(false)
+    expect(json.settings.sendDaysBefore).toBe(2)
+    expect(json.settings.sendDaysAfter).toBe(5)
+  })
+})

--- a/app/api/routes-d/search/__tests__/route.test.ts
+++ b/app/api/routes-d/search/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, invoice: { findMany: vi.fn() } },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFindMany = vi.mocked(prisma.invoice.findMany)
+
+function reqGET(query = '', auth = 'Bearer token'): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-d/search${query}`, {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/search', () => {
+  it('returns 401 without token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(reqGET('?q=test', ''))).status).toBe(401)
+  })
+
+  it('returns 404 if user not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(reqGET('?q=test'))).status).toBe(404)
+  })
+
+  it('returns 400 if q is missing or too short', async () => {
+    expect((await GET(reqGET('?q=t'))).status).toBe(400)
+    expect((await GET(reqGET(''))).status).toBe(400)
+  })
+
+  it('returns both invoices and contacts when no type specified', async () => {
+    mockedInvoiceFindMany.mockResolvedValueOnce([{ id: 'inv-1', invoiceNumber: '001' }] as never)
+    mockedInvoiceFindMany.mockResolvedValueOnce([{ clientName: 'John', clientEmail: 'john@example.com' }] as never)
+
+    const res = await GET(reqGET('?q=john'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.results.invoices).toHaveLength(1)
+    expect(json.results.contacts).toHaveLength(1)
+    expect(json.totalResults).toBe(2)
+  })
+
+  it('returns only invoices when type=invoices', async () => {
+    mockedInvoiceFindMany.mockResolvedValueOnce([{ id: 'inv-1', invoiceNumber: '001' }] as never)
+
+    const res = await GET(reqGET('?q=john&type=invoices'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.results.invoices).toHaveLength(1)
+    expect(json.results.contacts).toHaveLength(0)
+    expect(json.totalResults).toBe(1)
+  })
+
+  it('returns only contacts when type=contacts', async () => {
+    mockedInvoiceFindMany.mockResolvedValueOnce([{ clientName: 'John', clientEmail: 'john@example.com' }] as never)
+
+    const res = await GET(reqGET('?q=john&type=contacts'))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.results.invoices).toHaveLength(0)
+    expect(json.results.contacts).toHaveLength(1)
+    expect(json.totalResults).toBe(1)
+  })
+})

--- a/app/api/routes-d/transactions/__tests__/route.test.ts
+++ b/app/api/routes-d/transactions/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: { user: { findUnique: vi.fn() }, transaction: { findMany: vi.fn(), count: vi.fn() } },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedTxFindMany = vi.mocked(prisma.transaction.findMany)
+const mockedTxCount = vi.mocked(prisma.transaction.count)
+
+function req(auth = 'Bearer token', query = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-d/transactions${query}`, {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+const tx = {
+  id: 'tx-1', type: 'withdrawal', status: 'completed', amount: 100, currency: 'USDC',
+  txHash: 'hash', invoice: { invoiceNumber: 'INV-01' }, userId: 'user-1', createdAt: new Date()
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+})
+
+describe('GET /api/routes-d/transactions', () => {
+  it('returns 401 without a valid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(req(''))).status).toBe(401)
+  })
+
+  it('returns 401 when the user is not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(req())).status).toBe(401)
+  })
+
+  it('returns 400 for invalid type', async () => {
+    expect((await GET(req('Bearer token', '?type=invalid'))).status).toBe(400)
+  })
+
+  it('returns 400 for invalid status', async () => {
+    expect((await GET(req('Bearer token', '?status=invalid'))).status).toBe(400)
+  })
+
+  it('returns the transactions for the user', async () => {
+    mockedTxFindMany.mockResolvedValue([tx] as never)
+    mockedTxCount.mockResolvedValue(1 as never)
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.transactions).toHaveLength(1)
+    expect(json.transactions[0].id).toBe('tx-1')
+    expect(json.pagination.total).toBe(1)
+  })
+})


### PR DESCRIPTION
## PR Description

This PR implements the requested unit tests for the following `/api/routes-d` endpoints:

- `GET /api/routes-d/transactions`
- `GET`, `PATCH /api/routes-d/reminder-settings`
- `GET /api/routes-d/search`
- `GET /api/routes-d/notifications`

All endpoints handle requests and validation efficiently. Unit tests have been provided to cover happy paths and common failure scenarios such as missing tokens, invalid parameters, and unauthorized access.

Closes #762
Closes #757
Closes #758
Closes #754
