### PR TITLE
feat(routes-d): detect duplicate bank accounts on POST

### DIFF
--- a/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
+++ b/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/db', () => ({
     user: { findUnique: vi.fn() },
     bankAccount: {
       findMany: vi.fn(),
+      findFirst: vi.fn(),
       count: vi.fn(),
       create: vi.fn(),
       updateMany: vi.fn(),
@@ -21,6 +22,7 @@ import { GET, POST } from '../route'
 const mockedVerify = vi.mocked(verifyAuthToken)
 const mockedUserFind = vi.mocked(prisma.user.findUnique)
 const mockedFindMany = vi.mocked(prisma.bankAccount.findMany)
+const mockedFindFirst = vi.mocked(prisma.bankAccount.findFirst)
 const mockedCount = vi.mocked(prisma.bankAccount.count)
 const mockedCreate = vi.mocked(prisma.bankAccount.create)
 
@@ -53,6 +55,7 @@ beforeEach(() => {
   vi.resetAllMocks()
   mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
   mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+  mockedFindFirst.mockResolvedValue(null as never)
 })
 
 describe('GET /api/routes-d/bank-accounts', () => {
@@ -114,5 +117,33 @@ describe('POST /api/routes-d/bank-accounts', () => {
     const res = await POST(postReq(validAccount))
     expect([200, 201]).toContain(res.status)
     expect(mockedCreate).toHaveBeenCalled()
+  })
+
+  it('returns 409 when bank account already exists', async () => {
+    mockedFindFirst.mockResolvedValue({ id: 'existing-b1' } as never)
+    const res = await POST(postReq(validAccount))
+    expect(res.status).toBe(409)
+    const json = await res.json()
+    expect(json.error).toMatch(/already exists/i)
+    expect(json.existingId).toBe('existing-b1')
+  })
+
+  it('does not create when a duplicate account is detected', async () => {
+    mockedFindFirst.mockResolvedValue({ id: 'existing-b1' } as never)
+    await POST(postReq(validAccount))
+    expect(mockedCreate).not.toHaveBeenCalled()
+  })
+
+  it('allows creation when no duplicate exists', async () => {
+    mockedFindFirst.mockResolvedValue(null as never)
+    mockedCount.mockResolvedValue(0 as never)
+    mockedCreate.mockResolvedValue({
+      id: 'b2',
+      ...validAccount,
+      isDefault: true,
+      createdAt: new Date(),
+    } as never)
+    const res = await POST(postReq(validAccount))
+    expect([200, 201]).toContain(res.status)
   })
 })

--- a/app/api/routes-d/bank-accounts/route.ts
+++ b/app/api/routes-d/bank-accounts/route.ts
@@ -67,18 +67,18 @@ type CreateBankAccountBody = {
   isDefault?: unknown
 }
 
-function parseRequiredString(value: unknown, field: string, maxLength: number) {
+function parseRequiredString(value: unknown, field: string, maxLength: number): string | Error {
   if (typeof value !== 'string') {
-    return `${field} is required`
+    return new Error(`${field} is required`)
   }
 
   const trimmed = value.trim()
   if (!trimmed) {
-    return `${field} is required`
+    return new Error(`${field} is required`)
   }
 
   if (trimmed.length > maxLength) {
-    return `${field} must be at most ${maxLength} characters`
+    return new Error(`${field} must be at most ${maxLength} characters`)
   }
 
   return trimmed
@@ -99,12 +99,12 @@ export async function POST(request: NextRequest) {
 
   const bankName = parseRequiredString(body.bankName, 'bankName', MAX_BANK_NAME_LENGTH)
   if (typeof bankName !== 'string') {
-    return NextResponse.json({ error: bankName }, { status: 400 })
+    return NextResponse.json({ error: bankName.message }, { status: 400 })
   }
 
   const bankCode = parseRequiredString(body.bankCode, 'bankCode', 10)
   if (typeof bankCode !== 'string') {
-    return NextResponse.json({ error: bankCode }, { status: 400 })
+    return NextResponse.json({ error: bankCode.message }, { status: 400 })
   }
 
   if (!BANK_CODE_PATTERN.test(bankCode)) {
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
 
   const accountNumber = parseRequiredString(body.accountNumber, 'accountNumber', 10)
   if (typeof accountNumber !== 'string') {
-    return NextResponse.json({ error: accountNumber }, { status: 400 })
+    return NextResponse.json({ error: accountNumber.message }, { status: 400 })
   }
 
   if (!ACCOUNT_NUMBER_PATTERN.test(accountNumber)) {
@@ -132,11 +132,25 @@ export async function POST(request: NextRequest) {
     MAX_ACCOUNT_NAME_LENGTH,
   )
   if (typeof accountName !== 'string') {
-    return NextResponse.json({ error: accountName }, { status: 400 })
+    return NextResponse.json({ error: accountName.message }, { status: 400 })
   }
 
   if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
     return NextResponse.json({ error: 'isDefault must be a boolean' }, { status: 400 })
+  }
+
+  const existing = await prisma.bankAccount.findFirst({
+    where: {
+      userId,
+      accountNumber: { equals: accountNumber, mode: 'insensitive' },
+      bankCode: { equals: bankCode, mode: 'insensitive' },
+    },
+  })
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Bank account already exists', existingId: existing.id },
+      { status: 409 },
+    )
   }
 
   const existingAccountCount = await prisma.bankAccount.count({


### PR DESCRIPTION
﻿## Summary

- Adds duplicate bank account detection to `POST /api/routes-d/bank-accounts`
- Queries `bankAccount.findFirst` scoped to `userId + accountNumber + bankCode` (case-insensitive) before creation
- Returns HTTP **409 Conflict** with `{ error, existingId }` when a matching account already exists
- Normalization is handled by the existing `parseRequiredString()` helper (trims whitespace before comparison)
- Fixes pre-existing bug in `parseRequiredString` — it returned strings for both valid values and errors, making the `typeof x !== 'string'` checks always false; changed to return `Error` on failure

## Duplicate Detection Strategy

Queries for `userId + accountNumber + bankCode` (case-insensitive) before creation. Returns 409 with `existingId` if a match is found.

## Tests Added

- 409 when bank account already exists (verifies status and existingId in body)
- No create call made when duplicate is detected
- Successful creation when no duplicate exists
- Added `findFirst: vi.fn()` to Prisma mock with default `null` return in beforeEach

Fixes #816
