### PR TITLE
feat(routes-d): add overdue invoices endpoint

### DIFF
--- a/app/api/routes-d/invoices/overdue/__tests__/overdue.test.ts
+++ b/app/api/routes-d/invoices/overdue/__tests__/overdue.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+  default: { error: vi.fn() },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findMany)
+
+function getReq(auth = 'Bearer token'): NextRequest {
+  return new NextRequest('http://localhost/api/routes-d/invoices/overdue', {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+const THREE_DAYS_AGO = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+  mockedInvoiceFind.mockResolvedValue([])
+})
+
+describe('GET /api/routes-d/invoices/overdue', () => {
+  it('returns 401 when authorization header is missing', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(getReq(''))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 for an invalid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await GET(getReq())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when the user does not exist', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    const res = await GET(getReq())
+    expect(res.status).toBe(404)
+  })
+
+  it('returns an empty list when there are no overdue invoices', async () => {
+    const res = await GET(getReq())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.invoices).toEqual([])
+    expect(json.count).toBe(0)
+  })
+
+  it('returns overdue invoices with the correct shape', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      {
+        id: 'inv-1',
+        invoiceNumber: 'INV-001',
+        clientName: 'Acme Corp',
+        amount: 500,
+        currency: 'USDC',
+        dueDate: THREE_DAYS_AGO,
+      },
+    ] as never)
+
+    const res = await GET(getReq())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.count).toBe(1)
+    expect(json.invoices[0]).toMatchObject({
+      id: 'inv-1',
+      invoiceNumber: 'INV-001',
+      clientName: 'Acme Corp',
+      currency: 'USDC',
+    })
+  })
+
+  it('calculates daysOverdue correctly', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      {
+        id: 'inv-1',
+        invoiceNumber: 'INV-001',
+        clientName: 'Acme Corp',
+        amount: 100,
+        currency: 'USDC',
+        dueDate: THREE_DAYS_AGO,
+      },
+    ] as never)
+
+    const res = await GET(getReq())
+    const json = await res.json()
+    expect(json.invoices[0].daysOverdue).toBeGreaterThanOrEqual(2)
+    expect(json.invoices[0].daysOverdue).toBeLessThanOrEqual(4)
+  })
+
+  it('converts Decimal amounts to numbers', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      {
+        id: 'inv-2',
+        invoiceNumber: 'INV-002',
+        clientName: 'Beta Ltd',
+        amount: '250.50',
+        currency: 'USDC',
+        dueDate: THREE_DAYS_AGO,
+      },
+    ] as never)
+
+    const res = await GET(getReq())
+    const json = await res.json()
+    expect(typeof json.invoices[0].amount).toBe('number')
+    expect(json.invoices[0].amount).toBe(250.5)
+  })
+
+  it('returns multiple overdue invoices in ascending due-date order', async () => {
+    const older = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+    mockedInvoiceFind.mockResolvedValue([
+      {
+        id: 'inv-older',
+        invoiceNumber: 'INV-001',
+        clientName: 'A',
+        amount: 100,
+        currency: 'USDC',
+        dueDate: older,
+      },
+      {
+        id: 'inv-newer',
+        invoiceNumber: 'INV-002',
+        clientName: 'B',
+        amount: 200,
+        currency: 'USDC',
+        dueDate: THREE_DAYS_AGO,
+      },
+    ] as never)
+
+    const res = await GET(getReq())
+    const json = await res.json()
+    expect(json.count).toBe(2)
+    expect(json.invoices[0].id).toBe('inv-older')
+    expect(json.invoices[1].id).toBe('inv-newer')
+  })
+
+  it('returns 500 on a database error', async () => {
+    mockedInvoiceFind.mockRejectedValue(new Error('DB failure') as never)
+    const res = await GET(getReq())
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
﻿## Summary

- Adds unit tests for the existing `GET /api/routes-d/invoices/overdue` handler
- The implementation was already in place; this PR fulfils the issue's test coverage requirement

## Validation / Auth Logic

The handler already implements:
- Bearer token authentication via `verifyAuthToken()`
- User lookup by `privyId`
- Ownership scoping — queries are filtered by `userId`
- Overdue filtering: `status = 'pending'` AND `dueDate < now`

## Overdue Filtering Logic

Uses `dueDate: { lt: now, not: null }` in the Prisma query. Days overdue is calculated as `Math.floor((now - dueDate) / MS_PER_DAY)`.

## Tests Added

- 401 on missing authorization header
- 401 for invalid token
- 404 when user does not exist in database
- Empty list when no overdue invoices exist (count = 0)
- Correct invoice shape returned
- daysOverdue calculated correctly (>= 2 for a 3-day-old due date)
- Decimal amount converted to JavaScript number
- Multiple invoices returned in ascending due-date order
- 500 on database error

Fixes #750
