### PR TITLE
feat(routes-d): introduce shared structured logger

### DIFF
--- a/app/api/routes-d/_shared/__tests__/logger.test.ts
+++ b/app/api/routes-d/_shared/__tests__/logger.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockChild } = vi.hoisted(() => {
+  const mockChild = vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })
+  return { mockChild }
+})
+
+vi.mock('@/lib/logger', () => ({
+  logger: { child: mockChild },
+  default: { child: mockChild },
+}))
+
+import { createRouteLogger, logger } from '../logger'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createRouteLogger', () => {
+  it('creates a child logger with namespace routes-d', () => {
+    createRouteLogger({ route: '/bank-accounts' })
+    expect(mockChild).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'routes-d', route: '/bank-accounts' }),
+    )
+  })
+
+  it('propagates extra context fields to the child logger', () => {
+    createRouteLogger({ route: '/dashboard', userId: 'user-42' })
+    expect(mockChild).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-42' }),
+    )
+  })
+
+  it('returns a logger object with error and info methods', () => {
+    const childLogger = createRouteLogger({ route: '/test' })
+    expect(typeof childLogger.error).toBe('function')
+    expect(typeof childLogger.info).toBe('function')
+  })
+
+  it('calls child on the base logger instance', () => {
+    createRouteLogger({ route: '/wallet' })
+    expect(mockChild).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-exports the base logger as logger', () => {
+    expect(logger).toBeDefined()
+    expect(typeof logger.child).toBe('function')
+  })
+})

--- a/app/api/routes-d/_shared/logger.ts
+++ b/app/api/routes-d/_shared/logger.ts
@@ -1,0 +1,16 @@
+import { logger as baseLogger } from '@/lib/logger'
+
+export type RouteLogContext = {
+  route: string
+  [key: string]: unknown
+}
+
+/**
+ * Returns a Pino child logger pre-bound with routes-d namespace and route context.
+ * Never pass sensitive fields (tokens, account numbers) as context keys.
+ */
+export function createRouteLogger(context: RouteLogContext) {
+  return baseLogger.child({ namespace: 'routes-d', ...context })
+}
+
+export { baseLogger as logger }

--- a/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
+++ b/app/api/routes-d/bank-accounts/__tests__/bank-accounts.test.ts
@@ -13,6 +13,10 @@ vi.mock('@/lib/db', () => ({
     },
   },
 }))
+vi.mock('../_shared/logger', () => ({
+  createRouteLogger: vi.fn().mockReturnValue({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+  logger: { error: vi.fn() },
+}))
 
 import { verifyAuthToken } from '@/lib/auth'
 import { prisma } from '@/lib/db'

--- a/app/api/routes-d/bank-accounts/route.ts
+++ b/app/api/routes-d/bank-accounts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { createRouteLogger } from '../_shared/logger'
 
 const MAX_BANK_NAME_LENGTH = 100
 const MAX_ACCOUNT_NAME_LENGTH = 100
@@ -32,31 +33,38 @@ function maskAccountNumber(accountNumber: string) {
 }
 
 export async function GET(request: NextRequest) {
+  const routeLogger = createRouteLogger({ route: '/api/routes-d/bank-accounts' })
+
   const userId = await getAuthenticatedUserId(request)
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const bankAccounts = await prisma.bankAccount.findMany({
-    where: { userId },
-    orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
-    select: {
-      id: true,
-      bankName: true,
-      bankCode: true,
-      accountNumber: true,
-      accountName: true,
-      isDefault: true,
-      createdAt: true,
-    },
-  })
+  try {
+    const bankAccounts = await prisma.bankAccount.findMany({
+      where: { userId },
+      orderBy: [{ isDefault: 'desc' }, { createdAt: 'asc' }],
+      select: {
+        id: true,
+        bankName: true,
+        bankCode: true,
+        accountNumber: true,
+        accountName: true,
+        isDefault: true,
+        createdAt: true,
+      },
+    })
 
-  return NextResponse.json({
-    bankAccounts: bankAccounts.map((bankAccount: (typeof bankAccounts)[number]) => ({
-      ...bankAccount,
-      accountNumber: maskAccountNumber(bankAccount.accountNumber),
-    })),
-  })
+    return NextResponse.json({
+      bankAccounts: bankAccounts.map((bankAccount: (typeof bankAccounts)[number]) => ({
+        ...bankAccount,
+        accountNumber: maskAccountNumber(bankAccount.accountNumber),
+      })),
+    })
+  } catch (error) {
+    routeLogger.error({ err: error }, 'Failed to list bank accounts')
+    return NextResponse.json({ error: 'Failed to list bank accounts' }, { status: 500 })
+  }
 }
 
 type CreateBankAccountBody = {
@@ -67,24 +75,26 @@ type CreateBankAccountBody = {
   isDefault?: unknown
 }
 
-function parseRequiredString(value: unknown, field: string, maxLength: number) {
+function parseRequiredString(value: unknown, field: string, maxLength: number): string | Error {
   if (typeof value !== 'string') {
-    return `${field} is required`
+    return new Error(`${field} is required`)
   }
 
   const trimmed = value.trim()
   if (!trimmed) {
-    return `${field} is required`
+    return new Error(`${field} is required`)
   }
 
   if (trimmed.length > maxLength) {
-    return `${field} must be at most ${maxLength} characters`
+    return new Error(`${field} must be at most ${maxLength} characters`)
   }
 
   return trimmed
 }
 
 export async function POST(request: NextRequest) {
+  const routeLogger = createRouteLogger({ route: '/api/routes-d/bank-accounts' })
+
   const userId = await getAuthenticatedUserId(request)
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -99,12 +109,12 @@ export async function POST(request: NextRequest) {
 
   const bankName = parseRequiredString(body.bankName, 'bankName', MAX_BANK_NAME_LENGTH)
   if (typeof bankName !== 'string') {
-    return NextResponse.json({ error: bankName }, { status: 400 })
+    return NextResponse.json({ error: bankName.message }, { status: 400 })
   }
 
   const bankCode = parseRequiredString(body.bankCode, 'bankCode', 10)
   if (typeof bankCode !== 'string') {
-    return NextResponse.json({ error: bankCode }, { status: 400 })
+    return NextResponse.json({ error: bankCode.message }, { status: 400 })
   }
 
   if (!BANK_CODE_PATTERN.test(bankCode)) {
@@ -116,7 +126,7 @@ export async function POST(request: NextRequest) {
 
   const accountNumber = parseRequiredString(body.accountNumber, 'accountNumber', 10)
   if (typeof accountNumber !== 'string') {
-    return NextResponse.json({ error: accountNumber }, { status: 400 })
+    return NextResponse.json({ error: accountNumber.message }, { status: 400 })
   }
 
   if (!ACCOUNT_NUMBER_PATTERN.test(accountNumber)) {
@@ -132,57 +142,62 @@ export async function POST(request: NextRequest) {
     MAX_ACCOUNT_NAME_LENGTH,
   )
   if (typeof accountName !== 'string') {
-    return NextResponse.json({ error: accountName }, { status: 400 })
+    return NextResponse.json({ error: accountName.message }, { status: 400 })
   }
 
   if (body.isDefault !== undefined && typeof body.isDefault !== 'boolean') {
     return NextResponse.json({ error: 'isDefault must be a boolean' }, { status: 400 })
   }
 
-  const existingAccountCount = await prisma.bankAccount.count({
-    where: { userId },
-  })
-
-  const isFirstAccount = existingAccountCount === 0
-  const shouldBeDefault = isFirstAccount || body.isDefault === true
-
-  if (body.isDefault === true) {
-    await prisma.bankAccount.updateMany({
-      where: { userId, isDefault: true },
-      data: { isDefault: false },
+  try {
+    const existingAccountCount = await prisma.bankAccount.count({
+      where: { userId },
     })
+
+    const isFirstAccount = existingAccountCount === 0
+    const shouldBeDefault = isFirstAccount || body.isDefault === true
+
+    if (body.isDefault === true) {
+      await prisma.bankAccount.updateMany({
+        where: { userId, isDefault: true },
+        data: { isDefault: false },
+      })
+    }
+
+    const bankAccount = await prisma.bankAccount.create({
+      data: {
+        userId,
+        bankName,
+        bankCode,
+        accountNumber,
+        accountName,
+        isDefault: shouldBeDefault,
+      },
+      select: {
+        id: true,
+        bankName: true,
+        bankCode: true,
+        accountNumber: true,
+        accountName: true,
+        isDefault: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json(
+      {
+        id: bankAccount.id,
+        bankName: bankAccount.bankName,
+        bankCode: bankAccount.bankCode,
+        accountNumber: bankAccount.accountNumber,
+        accountName: bankAccount.accountName,
+        isDefault: bankAccount.isDefault,
+        createdAt: bankAccount.createdAt,
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    routeLogger.error({ err: error }, 'Failed to create bank account')
+    return NextResponse.json({ error: 'Failed to create bank account' }, { status: 500 })
   }
-
-  const bankAccount = await prisma.bankAccount.create({
-    data: {
-      userId,
-      bankName,
-      bankCode,
-      accountNumber,
-      accountName,
-      isDefault: shouldBeDefault,
-    },
-    select: {
-      id: true,
-      bankName: true,
-      bankCode: true,
-      accountNumber: true,
-      accountName: true,
-      isDefault: true,
-      createdAt: true,
-    },
-  })
-
-  return NextResponse.json(
-    {
-      id: bankAccount.id,
-      bankName: bankAccount.bankName,
-      bankCode: bankAccount.bankCode,
-      accountNumber: bankAccount.accountNumber,
-      accountName: bankAccount.accountName,
-      isDefault: bankAccount.isDefault,
-      createdAt: bankAccount.createdAt,
-    },
-    { status: 201 },
-  )
 }

--- a/app/api/routes-d/dashboard/route.ts
+++ b/app/api/routes-d/dashboard/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { createRouteLogger } from '../_shared/logger'
 
 const INVOICE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'] as const
 type InvoiceStatus = (typeof INVOICE_STATUSES)[number]
@@ -23,11 +24,14 @@ async function getAuthenticatedUserId(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const routeLogger = createRouteLogger({ route: '/api/routes-d/dashboard' })
+
   const userId = await getAuthenticatedUserId(request)
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  try {
   const startOfThisMonth = new Date()
   startOfThisMonth.setUTCDate(1)
   startOfThisMonth.setUTCHours(0, 0, 0, 0)
@@ -114,4 +118,8 @@ export async function GET(request: NextRequest) {
       })),
     },
   })
+  } catch (error) {
+    routeLogger.error({ err: error }, 'Dashboard GET error')
+    return NextResponse.json({ error: 'Failed to load dashboard' }, { status: 500 })
+  }
 }


### PR DESCRIPTION
﻿## Summary

- Creates `app/api/routes-d/_shared/logger.ts` with a `createRouteLogger(context)` helper
- Integrates the logger into `bank-accounts/route.ts` and `dashboard/route.ts` (high-traffic handlers) with structured try-catch error logging
- `invoices/overdue/route.ts` already uses `@/lib/logger` directly and was left unchanged

## Logger Architecture

`createRouteLogger` wraps the existing `@/lib/logger` (Pino instance) via `.child()` and pre-binds `{ namespace: 'routes-d', route }` context. No new runtime dependency introduced.

```ts
export function createRouteLogger(context: { route: string; [key: string]: unknown }) {
  return baseLogger.child({ namespace: 'routes-d', ...context })
}
```

## Context Handling

- Each handler creates a route-scoped child logger at the top of the function
- Errors are logged as `{ err: error }` — no tokens, account numbers, or other sensitive fields included

## Handlers Updated

- `bank-accounts/route.ts` — GET and POST DB operations wrapped in try-catch with structured error logging
- `dashboard/route.ts` — Promise.all aggregation block wrapped in try-catch with structured error logging

## Tests Added

- `createRouteLogger` binds `namespace: 'routes-d'` and route name to child logger
- Extra context fields propagate to the child logger
- Returns a child logger object with `error` and `info` methods
- Uses `vi.hoisted` to avoid Vitest mock-hoisting reference errors

Fixes #810
