### PR TITLE
feat(routes-d): add invoice amount update endpoint

### DIFF
--- a/app/api/routes-d/invoices/[id]/amount/__tests__/route.test.ts
+++ b/app/api/routes-d/invoices/[id]/amount/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+const mockedInvoiceUpdate = vi.mocked(prisma.invoice.update)
+
+const INVOICE_ID = 'inv-abc'
+const USER_ID = 'user-1'
+
+const fakeInvoice = {
+  id: INVOICE_ID,
+  userId: USER_ID,
+  status: 'pending',
+}
+
+const fakeUpdated = {
+  id: INVOICE_ID,
+  invoiceNumber: 'INV-001',
+  amount: 750,
+  currency: 'USD',
+  updatedAt: new Date(),
+}
+
+function makePatch(body: unknown, auth = 'Bearer token'): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-d/invoices/${INVOICE_ID}/amount`,
+    {
+      method: 'PATCH',
+      headers: {
+        ...(auth ? { authorization: auth } : {}),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    },
+  )
+}
+
+const params = Promise.resolve({ id: INVOICE_ID })
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: USER_ID } as never)
+  mockedInvoiceFind.mockResolvedValue(fakeInvoice as never)
+  mockedInvoiceUpdate.mockResolvedValue(fakeUpdated as never)
+})
+
+describe('PATCH /api/routes-d/invoices/[id]/amount', () => {
+  it('returns 401 without authorization header', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await PATCH(makePatch({ amount: 500 }, ''), { params })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with invalid token', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await PATCH(makePatch({ amount: 500 }, 'Bearer bad'), { params })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    const res = await PATCH(makePatch({ amount: 500 }), { params })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null as never)
+    const res = await PATCH(makePatch({ amount: 500 }), { params })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toBe('Invoice not found')
+  })
+
+  it('returns 403 when invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({ ...fakeInvoice, userId: 'other-user' } as never)
+    const res = await PATCH(makePatch({ amount: 500 }), { params })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.error).toBe('Forbidden')
+  })
+
+  it('returns 422 for a paid invoice', async () => {
+    mockedInvoiceFind.mockResolvedValue({ ...fakeInvoice, status: 'paid' } as never)
+    const res = await PATCH(makePatch({ amount: 500 }), { params })
+    expect(res.status).toBe(422)
+    const json = await res.json()
+    expect(json.error).toMatch(/pending/i)
+  })
+
+  it('returns 422 for a cancelled invoice', async () => {
+    mockedInvoiceFind.mockResolvedValue({ ...fakeInvoice, status: 'cancelled' } as never)
+    const res = await PATCH(makePatch({ amount: 500 }), { params })
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 400 when amount field is missing', async () => {
+    const res = await PATCH(makePatch({}), { params })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/amount is required/i)
+  })
+
+  it('returns 400 for a zero amount', async () => {
+    const res = await PATCH(makePatch({ amount: 0 }), { params })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/positive/i)
+  })
+
+  it('returns 400 for a negative amount', async () => {
+    const res = await PATCH(makePatch({ amount: -100 }), { params })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/positive/i)
+  })
+
+  it('returns 400 for a non-numeric amount', async () => {
+    const res = await PATCH(makePatch({ amount: 'abc' }), { params })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/positive/i)
+  })
+
+  it('returns 400 for NaN amount', async () => {
+    const res = await PATCH(makePatch({ amount: NaN }), { params })
+    expect(res.status).toBe(400)
+  })
+
+  it('updates the invoice amount and returns the updated invoice', async () => {
+    const res = await PATCH(makePatch({ amount: 750 }), { params })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.id).toBe(INVOICE_ID)
+    expect(json.amount).toBe(750)
+    expect(mockedInvoiceUpdate).toHaveBeenCalledWith({
+      where: { id: INVOICE_ID },
+      data: { amount: 750 },
+      select: expect.any(Object),
+    })
+  })
+
+  it('amount is serialized as a number in the response', async () => {
+    const res = await PATCH(makePatch({ amount: 750 }), { params })
+    const json = await res.json()
+    expect(typeof json.amount).toBe('number')
+  })
+})

--- a/app/api/routes-d/invoices/[id]/amount/route.ts
+++ b/app/api/routes-d/invoices/[id]/amount/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true },
+    })
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: { id: true, userId: true, status: true },
+    })
+    if (!invoice) {
+      return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
+    }
+    if (invoice.userId !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    if (invoice.status !== 'pending') {
+      return NextResponse.json(
+        { error: 'Amount can only be updated on pending invoices' },
+        { status: 422 },
+      )
+    }
+
+    let body: { amount?: unknown }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (!('amount' in body)) {
+      return NextResponse.json({ error: 'amount is required' }, { status: 400 })
+    }
+
+    const rawAmount = body.amount
+    if (typeof rawAmount !== 'number' || !Number.isFinite(rawAmount) || rawAmount <= 0) {
+      return NextResponse.json(
+        { error: 'amount must be a positive number' },
+        { status: 400 },
+      )
+    }
+
+    const updated = await prisma.invoice.update({
+      where: { id },
+      data: { amount: rawAmount },
+      select: {
+        id: true,
+        invoiceNumber: true,
+        amount: true,
+        currency: true,
+        updatedAt: true,
+      },
+    })
+
+    return NextResponse.json(
+      { ...updated, amount: Number(updated.amount) },
+      { status: 200 },
+    )
+  } catch (error) {
+    logger.error({ err: error }, 'PATCH /api/routes-d/invoices/[id]/amount error')
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

Implements `PATCH /api/routes-d/invoices/[id]/amount` for updating the amount on a pending invoice.

### Amount validation logic
- `amount` field is required; returns `400` if missing
- Must be a finite positive number; returns `400` for zero, negative, NaN, non-numeric values

### Ownership / Auth handling
- Requires a valid Bearer token; returns `401` if missing or invalid
- Resolves the Privy user; returns `401` if user not found
- Fetches the invoice by `id`; returns `404` if not found
- Compares `invoice.userId !== user.id`; returns `403` if mismatched

### Invoice update behavior
- Returns `422` if the invoice is not in `pending` status (e.g. `paid`, `cancelled`)
- Updates `amount` on the invoice and returns the updated record with amount serialized as a number
- Response shape: `{ id, invoiceNumber, amount, currency, updatedAt }`

### Tests added
`app/api/routes-d/invoices/[id]/amount/__tests__/route.test.ts` covers:
- `401` — missing/invalid token; user not found
- `404` — invoice not found
- `403` — ownership violation
- `422` — paid invoice; cancelled invoice
- `400` — missing amount; zero; negative; non-numeric; NaN
- `200` — successful update with correct DB call and amount as number

Fixes #774