### PR TITLE
feat: implement API improvements for issues #777, #793, #782, #792

### DIFF
--- a/app/api/routes-b/audit-log/__tests__/date-range-actor-filters.test.ts
+++ b/app/api/routes-b/audit-log/__tests__/date-range-actor-filters.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    auditEvent: { findMany: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('../_lib/audit-severity', () => ({
+  getSeverity: vi.fn(() => 'info'),
+  buildSeverityFilter: vi.fn(() => ({})),
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedFindMany = vi.mocked(prisma.auditEvent.findMany)
+const mockedCount = vi.mocked(prisma.auditEvent.count)
+
+function makeRequest(query = '') {
+  return new NextRequest(`http://localhost/api/routes-b/audit-log${query}`, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/routes-b/audit-log date-range and actor filters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-28T12:00:00.000Z'))
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user-1' } as never)
+    mockedFindMany.mockResolvedValue([] as never)
+    mockedCount.mockResolvedValue(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses default 90-day range when no dates provided', async () => {
+    await GET(makeRequest())
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          actorId: 'user-1',
+          createdAt: {
+            gte: new Date('2026-01-28T12:00:00.000Z'), // 90 days before
+            lte: new Date('2026-04-28T12:00:00.000Z'), // now
+          },
+        }),
+      }),
+    )
+  })
+
+  it('applies custom date range', async () => {
+    await GET(makeRequest('?from=2026-04-01T00:00:00.000Z&to=2026-04-02T00:00:00.000Z'))
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date('2026-04-01T00:00:00.000Z'),
+            lte: new Date('2026-04-02T00:00:00.000Z'),
+          },
+        }),
+      }),
+    )
+  })
+
+  it('rejects invalid date ranges', async () => {
+    const res = await GET(makeRequest('?from=2026-04-03T00:00:00.000Z&to=2026-04-02T00:00:00.000Z'))
+
+    expect(res.status).toBe(400)
+    expect(mockedFindMany).not.toHaveBeenCalled()
+  })
+
+  it('rejects date ranges exceeding 365 days', async () => {
+    const res = await GET(makeRequest('?from=2025-04-01T00:00:00.000Z&to=2026-04-28T00:00:00.000Z'))
+
+    expect(res.status).toBe(400)
+    expect(mockedFindMany).not.toHaveBeenCalled()
+  })
+
+  it('applies actor filter', async () => {
+    await GET(makeRequest('?actor=user-2'))
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ 
+          actorId: 'user-2' // Should use provided actor instead of current user
+        }),
+      }),
+    )
+  })
+
+  it('combines date range and actor filters', async () => {
+    await GET(makeRequest('?from=2026-04-01T00:00:00.000Z&to=2026-04-02T00:00:00.000Z&actor=user-2'))
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          actorId: 'user-2',
+          createdAt: {
+            gte: new Date('2026-04-01T00:00:00.000Z'),
+            lte: new Date('2026-04-02T00:00:00.000Z'),
+          },
+        }),
+      }),
+    )
+  })
+
+  it('handles invalid date format', async () => {
+    const res = await GET(makeRequest('?from=invalid-date'))
+
+    expect(res.status).toBe(400)
+    expect(mockedFindMany).not.toHaveBeenCalled()
+  })
+
+  it('trims whitespace from actor parameter', async () => {
+    await GET(makeRequest('?actor=%20user-2%20')) // URL encoded spaces
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ actorId: 'user-2' }),
+      }),
+    )
+  })
+
+  it('ignores empty actor parameter', async () => {
+    await GET(makeRequest('?actor='))
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ actorId: 'user-1' }), // Falls back to current user
+      }),
+    )
+  })
+})

--- a/app/api/routes-b/audit-log/route.ts
+++ b/app/api/routes-b/audit-log/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { buildActionFilter } from '../_lib/audit-action-filter' // Issue #621
 import { getSeverity, buildSeverityFilter } from '../_lib/audit-severity'
+import { parseAuditFilters } from '../_lib/audit-filters'
 
 async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
@@ -27,11 +28,21 @@ async function GETHandler(request: NextRequest) {
     return NextResponse.json({ error: actionFilter.error }, { status: 400 })
   }
 
+  // Date range and actor filters
+  const auditFilters = parseAuditFilters(searchParams)
+  if (!auditFilters.ok) {
+    return NextResponse.json({ error: auditFilters.error }, { status: 400 })
+  }
+
   const severity = searchParams.get('severity')
   const severityFilter = buildSeverityFilter(severity)
 
   const where = {
-    actorId: user.id,
+    actorId: auditFilters.value.actor ? auditFilters.value.actor : user.id,
+    createdAt: {
+      gte: auditFilters.value.from,
+      lte: auditFilters.value.to,
+    },
     ...actionFilter.clause,
     ...severityFilter,
   }

--- a/app/api/routes-b/branding/__tests__/validation.test.ts
+++ b/app/api/routes-b/branding/__tests__/validation.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { PATCH } from '../route'
+
+const verifyAuthToken = vi.fn()
+const findUnique = vi.fn()
+const upsert = vi.fn()
+const hasTableColumn = vi.fn()
+const executeRaw = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique },
+    brandingSettings: { upsert },
+    $executeRaw: executeRaw,
+  },
+}))
+vi.mock('../_lib/table-columns', () => ({
+  hasTableColumn,
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+const BASE_URL = 'http://localhost/api/routes-b/branding'
+
+function makeRequest(body?: unknown) {
+  return new NextRequest(BASE_URL, {
+    method: 'PATCH',
+    headers: { 
+      authorization: 'Bearer token',
+      'content-type': 'application/json',
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+}
+
+describe('PATCH /api/routes-b/branding validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    hasTableColumn.mockResolvedValue(false) // Disable optional columns by default
+    upsert.mockResolvedValue({
+      id: 'brand_1',
+      userId: 'user_1',
+      logoUrl: null,
+      primaryColor: null,
+      footerText: null,
+      signatureUrl: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    verifyAuthToken.mockResolvedValue(null)
+    const res = await PATCH(makeRequest({}))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 422 for invalid JSON', async () => {
+    const res = await PATCH(new NextRequest(BASE_URL, {
+      method: 'PATCH',
+      headers: { 
+        authorization: 'Bearer token',
+        'content-type': 'application/json',
+      },
+      body: 'invalid json',
+    }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.code).toBe('BAD_REQUEST')
+    expect(data.error.fields.body).toBe('Invalid JSON')
+  })
+
+  it('validates hex color format', async () => {
+    const res = await PATCH(makeRequest({ primaryColor: 'invalid-color' }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.code).toBe('BAD_REQUEST')
+    expect(data.error.fields.primaryColor).toContain('Must be a valid 6-digit hex color')
+  })
+
+  it('accepts valid hex colors', async () => {
+    const res = await PATCH(makeRequest({ primaryColor: '#FF5733' }))
+    
+    expect(res.status).toBe(200)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { userId: 'user_1' },
+      update: { primaryColor: '#FF5733' },
+      create: { userId: 'user_1', primaryColor: '#FF5733' },
+    })
+  })
+
+  it('validates HTTPS URLs for logoUrl', async () => {
+    const res = await PATCH(makeRequest({ logoUrl: 'http://example.com/logo.png' }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.fields.logoUrl).toContain('Must use https')
+  })
+
+  it('accepts valid HTTPS URLs', async () => {
+    const res = await PATCH(makeRequest({ logoUrl: 'https://example.com/logo.png' }))
+    
+    expect(res.status).toBe(200)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { userId: 'user_1' },
+      update: { logoUrl: 'https://example.com/logo.png' },
+      create: { userId: 'user_1', logoUrl: 'https://example.com/logo.png' },
+    })
+  })
+
+  it('accepts null values for optional fields', async () => {
+    const res = await PATCH(makeRequest({ logoUrl: null, footerText: null }))
+    
+    expect(res.status).toBe(200)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { userId: 'user_1' },
+      update: { logoUrl: null, footerText: null },
+      create: { userId: 'user_1', logoUrl: null, footerText: null },
+    })
+  })
+
+  it('validates footer text length', async () => {
+    const longText = 'a'.repeat(201)
+    const res = await PATCH(makeRequest({ footerText: longText }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.fields.footerText).toContain('Must be 200 characters or fewer')
+  })
+
+  it('validates domain format for customDomain', async () => {
+    hasTableColumn.mockImplementation((table, column) => column === 'customDomain')
+    
+    const res = await PATCH(makeRequest({ customDomain: 'invalid..domain' }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.fields.customDomain).toContain('Must be a valid domain name')
+  })
+
+  it('accepts valid domain names', async () => {
+    hasTableColumn.mockImplementation((table, column) => column === 'customDomain')
+    
+    const res = await PATCH(makeRequest({ customDomain: 'example.com' }))
+    
+    expect(res.status).toBe(200)
+    expect(executeRaw).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE "BrandingSettings"'),
+      'example.com',
+      'user_1'
+    )
+  })
+
+  it('strips unknown fields from request', async () => {
+    const res = await PATCH(makeRequest({ 
+      primaryColor: '#FF5733',
+      unknownField: 'should be stripped',
+    }))
+    
+    expect(res.status).toBe(200)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { userId: 'user_1' },
+      update: { primaryColor: '#FF5733' },
+      create: { userId: 'user_1', primaryColor: '#FF5733' },
+    })
+  })
+
+  it('handles multiple validation errors', async () => {
+    const res = await PATCH(makeRequest({ 
+      primaryColor: 'invalid',
+      logoUrl: 'http://insecure.com',
+      footerText: 'a'.repeat(201),
+    }))
+    
+    expect(res.status).toBe(422)
+    const data = await res.json()
+    expect(data.error.fields.primaryColor).toBeDefined()
+    expect(data.error.fields.logoUrl).toBeDefined()
+    expect(data.error.fields.footerText).toBeDefined()
+  })
+
+  it('returns 500 on database error', async () => {
+    upsert.mockRejectedValue(new Error('Database error'))
+    
+    const res = await PATCH(makeRequest({ primaryColor: '#FF5733' }))
+    
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error.code).toBe('INTERNAL')
+  })
+})

--- a/app/api/routes-b/branding/route.ts
+++ b/app/api/routes-b/branding/route.ts
@@ -7,6 +7,7 @@ import { logger } from '@/lib/logger'
 import { registerRoute } from '../_lib/openapi'
 import { hasTableColumn } from '../_lib/table-columns'
 import { brandingSchema, type BrandingPayload } from './schema'
+import { errorResponse } from '../_lib/errors'
 import { z } from 'zod'
 
 // Register OpenAPI documentation
@@ -111,27 +112,28 @@ async function writeBranding(request: NextRequest) {
   try {
     const user = await getAuthenticatedUser(request)
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      return errorResponse('UNAUTHORIZED', 'Unauthorized', {}, 401)
     }
 
     let body: unknown
     try {
       body = await request.json()
     } catch {
-      return NextResponse.json(
-        { error: 'Invalid request body', fields: { body: 'Invalid JSON' } },
-        { status: 422 }
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid request body',
+        { fields: { body: 'Invalid JSON' } },
+        422
       )
     }
 
     const parsed = brandingSchema.safeParse(body)
     if (!parsed.success) {
-      return NextResponse.json(
-        {
-          error: 'Invalid branding payload',
-          fields: formatFieldErrors(parsed.error),
-        },
-        { status: 422 }
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid branding payload',
+        { fields: formatFieldErrors(parsed.error) },
+        422
       )
     }
 
@@ -168,10 +170,7 @@ async function writeBranding(request: NextRequest) {
     })
   } catch (error) {
     logger.error({ err: error }, 'branding update error')
-    return NextResponse.json(
-      { error: 'Failed to update branding settings' },
-      { status: 500 }
-    )
+    return errorResponse('INTERNAL', 'Failed to update branding settings', {}, 500)
   }
 }
 
@@ -188,7 +187,7 @@ export const PATCH = withRequestId(
 async function GETHandler(request: NextRequest) {
   const user = await getAuthenticatedUser(request)
   if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return errorResponse('UNAUTHORIZED', 'Unauthorized', {}, 401)
   }
 
   const branding = await prisma.brandingSettings.findUnique({

--- a/app/api/routes-b/transactions/export/__tests__/streaming.test.ts
+++ b/app/api/routes-b/transactions/export/__tests__/streaming.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+const verifyAuthToken = vi.fn()
+const findUnique = vi.fn()
+const findMany = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique },
+    transaction: { findMany },
+  },
+}))
+
+const BASE_URL = 'http://localhost/api/routes-b/transactions/export'
+
+function makeRequest(query = '') {
+  return new NextRequest(`${BASE_URL}${query}`, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/routes-b/transactions/export streaming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    verifyAuthToken.mockResolvedValue(null)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404 when user not found', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue(null)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+  })
+
+  it('returns CSV stream with correct headers', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([
+      {
+        id: 'tx_1',
+        type: 'payment',
+        status: 'completed',
+        amount: '100.50',
+        currency: 'USD',
+        createdAt: new Date('2026-05-01T10:00:00Z'),
+        invoice: { description: 'Test invoice' },
+      },
+    ])
+
+    const res = await GET(makeRequest())
+    
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/csv')
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="transactions.csv"')
+    
+    // Verify the response is a ReadableStream
+    expect(res.body).toBeInstanceOf(ReadableStream)
+  })
+
+  it('validates date parameters', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+
+    const res = await GET(makeRequest('?from=invalid-date'))
+    
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error.code).toBe('BAD_REQUEST')
+    expect(data.error.fields.from).toBe('Must be a valid ISO date string')
+  })
+
+  it('applies date range filters to query', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([])
+
+    await GET(makeRequest('?from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z'))
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user_1',
+        createdAt: {
+          gte: new Date('2026-01-01T00:00:00Z'),
+          lte: new Date('2026-12-31T23:59:59Z'),
+        },
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 500, // Default batch size
+      include: {
+        invoice: {
+          select: {
+            description: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('handles missing invoice description gracefully', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([
+      {
+        id: 'tx_1',
+        type: 'withdrawal',
+        status: 'pending',
+        amount: '50.00',
+        currency: 'USD',
+        createdAt: new Date('2026-05-01T10:00:00Z'),
+        invoice: null, // No associated invoice
+      },
+    ])
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    
+    // The CSV stream should handle null invoice gracefully
+    expect(res.body).toBeInstanceOf(ReadableStream)
+  })
+
+  it('validates to date parameter', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+
+    const res = await GET(makeRequest('?to=not-a-date'))
+    
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error.code).toBe('BAD_REQUEST')
+    expect(data.error.fields.to).toBe('Must be a valid ISO date string')
+  })
+
+  it('queries without date filters when none provided', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([])
+
+    await GET(makeRequest())
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userId: 'user_1' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 500,
+      include: {
+        invoice: {
+          select: {
+            description: true,
+          },
+        },
+      },
+    })
+  })
+
+  it('uses cursor-based pagination for streaming', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    
+    // Mock multiple calls to simulate streaming batches
+    findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'tx_1',
+          type: 'payment',
+          status: 'completed',
+          amount: '100.00',
+          currency: 'USD',
+          createdAt: new Date('2026-05-01T10:00:00Z'),
+          invoice: { description: 'First batch' },
+        },
+      ])
+      .mockResolvedValueOnce([]) // Empty second batch to end stream
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    expect(res.body).toBeInstanceOf(ReadableStream)
+  })
+})

--- a/app/api/routes-b/transactions/export/route.ts
+++ b/app/api/routes-b/transactions/export/route.ts
@@ -3,24 +3,25 @@ import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { createCsvStream } from '../../_lib/csv-stream'
+import { errorResponse } from '../../_lib/errors'
 import type { Prisma } from '@prisma/client'
 
 async function GETHandler(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
   if (!authToken) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return errorResponse('UNAUTHORIZED', 'Unauthorized', {}, 401)
   }
 
   const claims = await verifyAuthToken(authToken)
   if (!claims) {
-    return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+    return errorResponse('UNAUTHORIZED', 'Invalid token', {}, 401)
   }
 
   const user = await prisma.user.findUnique({
     where: { privyId: claims.userId },
   })
   if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    return errorResponse('NOT_FOUND', 'User not found', {}, 404)
   }
 
   const { searchParams } = new URL(request.url)
@@ -34,14 +35,14 @@ async function GETHandler(request: NextRequest) {
     if (from) {
       const fromDate = new Date(from)
       if (isNaN(fromDate.getTime())) {
-        return NextResponse.json({ error: 'Invalid from date' }, { status: 400 })
+        return errorResponse('BAD_REQUEST', 'Invalid from date', { fields: { from: 'Must be a valid ISO date string' } }, 400)
       }
       where.createdAt.gte = fromDate
     }
     if (to) {
       const toDate = new Date(to)
       if (isNaN(toDate.getTime())) {
-        return NextResponse.json({ error: 'Invalid to date' }, { status: 400 })
+        return errorResponse('BAD_REQUEST', 'Invalid to date', { fields: { to: 'Must be a valid ISO date string' } }, 400)
       }
       where.createdAt.lte = toDate
     }

--- a/app/api/routes-d/invoices/pending/__tests__/route.test.ts
+++ b/app/api/routes-d/invoices/pending/__tests__/route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+const verifyAuthToken = vi.fn()
+const findUnique = vi.fn()
+const findMany = vi.fn()
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique },
+    invoice: { findMany },
+  },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+const BASE_URL = 'http://localhost/api/routes-d/invoices/pending'
+
+function makeRequest(query = '') {
+  return new NextRequest(`${BASE_URL}${query}`, {
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/routes-d/invoices/pending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    verifyAuthToken.mockResolvedValue(null)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when user not found', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue(null)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns pending invoices with default pagination', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([
+      {
+        id: 'inv_1',
+        invoiceNumber: 'INV-001',
+        clientName: 'John Doe',
+        clientEmail: 'john@example.com',
+        amount: '100.00',
+        currency: 'USD',
+        dueDate: new Date('2026-06-01'),
+        createdAt: new Date('2026-05-01'),
+      },
+    ])
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+
+    const data = await res.json()
+    expect(data.data).toHaveLength(1)
+    expect(data.data[0].amount).toBe(100)
+    expect(data.nextCursor).toBeNull()
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userId: 'user_1', status: 'pending' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 21,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        createdAt: true,
+      },
+    })
+  })
+
+  it('applies cursor pagination', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([])
+
+    await GET(makeRequest('?cursor=inv_123'))
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userId: 'user_1', status: 'pending', id: { lt: 'inv_123' } },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: 21,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        createdAt: true,
+      },
+    })
+  })
+
+  it('respects limit parameter with max constraint', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockResolvedValue([])
+
+    await GET(makeRequest('?limit=100'))
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 51 }) // 50 + 1 for hasNext check
+    )
+  })
+
+  it('handles next cursor when more results available', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    
+    // Return 21 items (limit + 1) to simulate more results
+    const invoices = Array.from({ length: 21 }, (_, i) => ({
+      id: `inv_${i}`,
+      invoiceNumber: `INV-${i.toString().padStart(3, '0')}`,
+      clientName: 'John Doe',
+      clientEmail: 'john@example.com',
+      amount: '100.00',
+      currency: 'USD',
+      dueDate: new Date('2026-06-01'),
+      createdAt: new Date('2026-05-01'),
+    }))
+    findMany.mockResolvedValue(invoices)
+
+    const res = await GET(makeRequest())
+    const data = await res.json()
+    
+    expect(data.data).toHaveLength(20) // Should return only limit items
+    expect(data.nextCursor).toBe('inv_19') // Last item's ID
+  })
+
+  it('returns 500 on database error', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    findUnique.mockResolvedValue({ id: 'user_1' })
+    findMany.mockRejectedValue(new Error('Database error'))
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/routes-d/invoices/pending/route.ts
+++ b/app/api/routes-d/invoices/pending/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
+
+const MAX_LIMIT = 50
+const DEFAULT_LIMIT = 20
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) return null
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) return null
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+
+  return user ?? null
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAuthenticatedUser(request)
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const cursor = searchParams.get('cursor') ?? undefined
+    const limitParam = searchParams.get('limit')
+
+    const limit = Math.min(
+      limitParam ? Math.max(1, parseInt(limitParam, 10) || DEFAULT_LIMIT) : DEFAULT_LIMIT,
+      MAX_LIMIT,
+    )
+
+    const invoices = await prisma.invoice.findMany({
+      where: {
+        userId: user.id,
+        status: 'pending',
+        ...(cursor ? { id: { lt: cursor } } : {}),
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        createdAt: true,
+      },
+    })
+
+    const hasNext = invoices.length > limit
+    const page = hasNext ? invoices.slice(0, limit) : invoices
+    const nextCursor = hasNext ? page[page.length - 1]?.id ?? null : null
+
+    return NextResponse.json({
+      data: page.map((i) => ({ ...i, amount: Number(i.amount) })),
+      nextCursor,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/routes-d/invoices/pending error')
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
- Close #777: Add GET /api/routes-d/invoices/pending endpoint with cursor pagination
- Close #793: Add date-range and actor filters to /api/routes-b/audit-log
- Close #782: Improve Zod validation in /api/routes-b/branding PATCH with consistent error handling
- Close #792: Enhance CSV streaming in /api/routes-b/transactions/export with better error responses

All endpoints include comprehensive unit tests and follow existing project conventions.