### PR TITLE
feat: resolve issues #772, #773, #785, #786 — routes-b shared logger/request-id + routes-d analytics

### DIFF
--- a/app/api/routes-b/_shared/__tests__/logger.test.ts
+++ b/app/api/routes-b/_shared/__tests__/logger.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockChild } = vi.hoisted(() => {
+  const mockChild = vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })
+  return { mockChild }
+})
+
+vi.mock('@/lib/logger', () => ({
+  logger: { child: mockChild },
+  default: { child: mockChild },
+}))
+
+import { createRouteLogger, logger } from '../logger'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createRouteLogger', () => {
+  it('creates a child logger with namespace routes-b', () => {
+    createRouteLogger({ route: '/api/routes-b/contacts' })
+    expect(mockChild).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: 'routes-b', route: '/api/routes-b/contacts' }),
+    )
+  })
+
+  it('propagates extra context fields to the child logger', () => {
+    createRouteLogger({ route: '/api/routes-b/invoices', userId: 'user-42' })
+    expect(mockChild).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-42' }),
+    )
+  })
+
+  it('returns a logger object with error and info methods', () => {
+    const childLogger = createRouteLogger({ route: '/api/routes-b/branding' })
+    expect(typeof childLogger.error).toBe('function')
+    expect(typeof childLogger.info).toBe('function')
+  })
+
+  it('calls child on the base logger instance once per call', () => {
+    createRouteLogger({ route: '/api/routes-b/wallet' })
+    expect(mockChild).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-exports the base logger as logger', () => {
+    expect(logger).toBeDefined()
+    expect(typeof logger.child).toBe('function')
+  })
+})

--- a/app/api/routes-b/_shared/__tests__/with-request-id.test.ts
+++ b/app/api/routes-b/_shared/__tests__/with-request-id.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { withRequestId, getRequestId } from '../with-request-id'
+
+describe('_shared/with-request-id re-export', () => {
+  it('exports withRequestId as a function', () => {
+    expect(typeof withRequestId).toBe('function')
+  })
+
+  it('exports getRequestId as a function', () => {
+    expect(typeof getRequestId).toBe('function')
+  })
+
+  it('withRequestId wraps a handler and echoes X-Request-Id in the response', async () => {
+    const handler = async () => new Response(JSON.stringify({ ok: true }), { status: 200 })
+    const wrapped = withRequestId(handler)
+
+    const req = new Request('http://localhost/api/routes-b/test', {
+      headers: { authorization: 'Bearer tok' },
+    })
+
+    const res = await wrapped(req as any)
+    expect(res.headers.get('X-Request-Id')).toBeTruthy()
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts an incoming x-request-id UUID and echoes it back', async () => {
+    const incomingId = '018f4d2a-1c3b-7000-8000-000000000abc'
+    const handler = async () => new Response('{}', { status: 200 })
+    const wrapped = withRequestId(handler)
+
+    const req = new Request('http://localhost/api/routes-b/test', {
+      headers: { 'x-request-id': incomingId },
+    })
+
+    const res = await wrapped(req as any)
+    expect(res.headers.get('X-Request-Id')).toBe(incomingId)
+  })
+
+  it('getRequestId returns null outside a request context', () => {
+    expect(getRequestId()).toBeNull()
+  })
+
+  it('getRequestId returns the request ID inside a handler invocation', async () => {
+    let capturedId: string | null = null
+
+    const handler = async () => {
+      capturedId = getRequestId()
+      return new Response('{}', { status: 200 })
+    }
+
+    const wrapped = withRequestId(handler)
+    await wrapped(new Request('http://localhost/') as any)
+
+    expect(capturedId).not.toBeNull()
+    expect(typeof capturedId).toBe('string')
+  })
+})

--- a/app/api/routes-b/_shared/logger.ts
+++ b/app/api/routes-b/_shared/logger.ts
@@ -1,0 +1,17 @@
+import { logger as baseLogger } from '@/lib/logger'
+
+export type RouteLogContext = {
+  route: string
+  [key: string]: unknown
+}
+
+/**
+ * Returns a Pino child logger pre-bound with routes-b namespace and route context.
+ * Request-id is automatically injected by the withRequestId middleware patch.
+ * Never pass sensitive fields (tokens, account numbers) as context keys.
+ */
+export function createRouteLogger(context: RouteLogContext) {
+  return baseLogger.child({ namespace: 'routes-b', ...context })
+}
+
+export { baseLogger as logger }

--- a/app/api/routes-b/_shared/with-request-id.ts
+++ b/app/api/routes-b/_shared/with-request-id.ts
@@ -1,0 +1,6 @@
+/**
+ * Canonical _shared entry-point for the request-id correlation middleware.
+ * Implementation lives in _lib/with-request-id to keep it co-located with
+ * the schema-version utilities it depends on.
+ */
+export { withRequestId, getRequestId } from '../_lib/with-request-id'

--- a/app/api/routes-b/branding/route.ts
+++ b/app/api/routes-b/branding/route.ts
@@ -3,8 +3,10 @@ import { withBodyLimit } from '../_lib/with-body-limit'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { logger } from '@/lib/logger'
+import { createRouteLogger } from '../_shared/logger'
 import { registerRoute } from '../_lib/openapi'
+
+const log = createRouteLogger({ route: '/api/routes-b/branding' })
 import { hasTableColumn } from '../_lib/table-columns'
 import { brandingSchema, type BrandingPayload } from './schema'
 import { errorResponse } from '../_lib/errors'
@@ -182,7 +184,7 @@ async function writeBranding(request: NextRequest) {
       },
     })
   } catch (error) {
-    logger.error({ err: error }, 'branding update error')
+    log.error({ err: error }, 'branding update error')
     return errorResponse('INTERNAL', 'Failed to update branding settings', {}, 500)
   }
 }

--- a/app/api/routes-b/contacts/route.ts
+++ b/app/api/routes-b/contacts/route.ts
@@ -2,8 +2,10 @@ import { withRequestId } from '../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
-import { logger } from '@/lib/logger'
+import { createRouteLogger } from '../_shared/logger'
 import { listContacts } from '../_lib/contacts'
+
+const log = createRouteLogger({ route: '/api/routes-b/contacts' })
 
 async function GETHandler(request: NextRequest) {
   try {
@@ -38,7 +40,7 @@ async function GETHandler(request: NextRequest) {
 
     return NextResponse.json({ contacts })
   } catch (error) {
-    logger.error({ err: error }, 'Routes B contacts GET error')
+    log.error({ err: error }, 'Routes B contacts GET error')
     return NextResponse.json({ error: 'Failed to get contacts' }, { status: 500 })
   }
 }

--- a/app/api/routes-d/analytics/top-months/__tests__/route.test.ts
+++ b/app/api/routes-d/analytics/top-months/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { child: vi.fn().mockReturnValue({ error: vi.fn(), info: vi.fn() }) },
+  default: { child: vi.fn().mockReturnValue({ error: vi.fn(), info: vi.fn() }) },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findMany)
+
+function makeRequest(params: Record<string, string> = {}, auth = 'Bearer token'): NextRequest {
+  const url = new URL('http://localhost/api/routes-d/analytics/top-months')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new NextRequest(url.toString(), {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1', timezone: null } as never)
+  mockedInvoiceFind.mockResolvedValue([])
+})
+
+describe('GET /api/routes-d/analytics/top-months', () => {
+  it('returns 401 when no auth header is provided', async () => {
+    const req = new NextRequest('http://localhost/api/routes-d/analytics/top-months', {
+      method: 'GET',
+    })
+    expect((await GET(req)).status).toBe(401)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(makeRequest())).status).toBe(401)
+  })
+
+  it('returns 404 when user is not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(makeRequest())).status).toBe(404)
+  })
+
+  it('returns 200 with empty topMonths when no paid invoices exist', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.topMonths).toEqual([])
+    expect(json.tz).toBe('UTC')
+  })
+
+  it('returns 400 for an invalid timezone', async () => {
+    const res = await GET(makeRequest({ tz: 'Not/AZone' }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.fields).toHaveProperty('tz')
+  })
+
+  it('correctly ranks months by earnings and returns top 3 by default', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      { amount: 100, paidAt: new Date('2024-01-15T10:00:00Z') },
+      { amount: 500, paidAt: new Date('2024-03-10T10:00:00Z') },
+      { amount: 300, paidAt: new Date('2024-02-20T10:00:00Z') },
+      { amount: 200, paidAt: new Date('2024-03-25T10:00:00Z') },
+      { amount: 50,  paidAt: new Date('2024-04-01T10:00:00Z') },
+    ] as never)
+
+    const res = await GET(makeRequest({ tz: 'UTC' }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    // March = 700, Feb = 300, Jan = 100 → top 3
+    expect(json.topMonths[0].month).toBe('2024-03')
+    expect(json.topMonths[0].earned).toBe(700)
+    expect(json.topMonths[1].month).toBe('2024-02')
+    expect(json.topMonths[2].month).toBe('2024-01')
+    expect(json.topMonths.length).toBe(3)
+  })
+
+  it('respects the limit query parameter', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      { amount: 100, paidAt: new Date('2024-01-15T10:00:00Z') },
+      { amount: 200, paidAt: new Date('2024-02-15T10:00:00Z') },
+      { amount: 300, paidAt: new Date('2024-03-15T10:00:00Z') },
+    ] as never)
+
+    const res = await GET(makeRequest({ limit: '1' }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.topMonths.length).toBe(1)
+  })
+
+  it('uses user.timezone when no ?tz= param is provided', async () => {
+    mockedUserFind.mockResolvedValue({ id: 'user-1', timezone: 'Africa/Lagos' } as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.tz).toBe('Africa/Lagos')
+  })
+
+  it('skips invoices with null paidAt', async () => {
+    mockedInvoiceFind.mockResolvedValue([
+      { amount: 100, paidAt: null },
+      { amount: 200, paidAt: new Date('2024-01-15T10:00:00Z') },
+    ] as never)
+
+    const res = await GET(makeRequest({ tz: 'UTC' }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.topMonths.length).toBe(1)
+    expect(json.topMonths[0].earned).toBe(200)
+  })
+
+  it('returns 500 on unexpected database error', async () => {
+    mockedInvoiceFind.mockRejectedValue(new Error('DB failure') as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/routes-d/analytics/top-months/route.ts
+++ b/app/api/routes-d/analytics/top-months/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { createRouteLogger } from '../../_shared/logger'
+
+const log = createRouteLogger({ route: '/api/routes-d/analytics/top-months' })
+
+// ── GET /api/routes-d/analytics/top-months — top earning months ──────────────
+
+function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true, timezone: true },
+    })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { searchParams } = new URL(request.url)
+    const rawTz = searchParams.get('tz') ?? user.timezone ?? 'UTC'
+
+    if (!isValidTimezone(rawTz)) {
+      return NextResponse.json(
+        {
+          error: 'Invalid timezone',
+          fields: { tz: `"${rawTz}" is not a valid IANA timezone name` },
+        },
+        { status: 400 },
+      )
+    }
+
+    const limitParam = Number(searchParams.get('limit') ?? 3)
+    const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 12) : 3
+
+    const paid = await prisma.invoice.findMany({
+      where: { userId: user.id, status: 'paid' },
+      select: { amount: true, paidAt: true },
+    })
+
+    const monthly: Record<string, number> = {}
+
+    for (const inv of paid) {
+      if (!inv.paidAt) continue
+
+      const key = inv.paidAt
+        .toLocaleDateString('en-CA', { timeZone: rawTz })
+        .slice(0, 7)
+
+      monthly[key] = (monthly[key] ?? 0) + Number(inv.amount)
+    }
+
+    const topMonths = Object.entries(monthly)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([month, earned]) => ({
+        month,
+        earned: Number(earned.toFixed(2)),
+      }))
+
+    return NextResponse.json({ topMonths, tz: rawTz })
+  } catch (error) {
+    log.error({ err: error }, 'Top months analytics GET error')
+    return NextResponse.json({ error: 'Failed to get top months analytics' }, { status: 500 })
+  }
+}

--- a/app/api/routes-d/analytics/withdrawals/__tests__/route.test.ts
+++ b/app/api/routes-d/analytics/withdrawals/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    transaction: { aggregate: vi.fn(), count: vi.fn() },
+  },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { child: vi.fn().mockReturnValue({ error: vi.fn(), info: vi.fn() }) },
+  default: { child: vi.fn().mockReturnValue({ error: vi.fn(), info: vi.fn() }) },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedAggregate = vi.mocked(prisma.transaction.aggregate)
+const mockedCount = vi.mocked(prisma.transaction.count)
+
+function makeRequest(params: Record<string, string> = {}, auth = 'Bearer token'): NextRequest {
+  const url = new URL('http://localhost/api/routes-d/analytics/withdrawals')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new NextRequest(url.toString(), {
+    method: 'GET',
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+  mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+  mockedAggregate
+    .mockResolvedValueOnce({ _count: { id: 10 }, _sum: { amount: 5000 } } as never)
+    .mockResolvedValueOnce({ _count: { id: 8 }, _sum: { amount: 4500 } } as never)
+  mockedCount.mockResolvedValueOnce(1 as never).mockResolvedValueOnce(1 as never)
+})
+
+describe('GET /api/routes-d/analytics/withdrawals', () => {
+  it('returns 401 when no auth header is provided', async () => {
+    const req = new NextRequest('http://localhost/api/routes-d/analytics/withdrawals', {
+      method: 'GET',
+    })
+    expect((await GET(req)).status).toBe(401)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    expect((await GET(makeRequest())).status).toBe(401)
+  })
+
+  it('returns 404 when user is not found', async () => {
+    mockedUserFind.mockResolvedValue(null as never)
+    expect((await GET(makeRequest())).status).toBe(404)
+  })
+
+  it('returns 200 with correct withdrawal summary on happy path', async () => {
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+
+    const json = await res.json()
+    expect(json.withdrawals.totalCount).toBe(10)
+    expect(json.withdrawals.totalAmount).toBe(5000)
+    expect(json.withdrawals.completedCount).toBe(8)
+    expect(json.withdrawals.completedAmount).toBe(4500)
+    expect(json.withdrawals.pendingCount).toBe(1)
+    expect(json.withdrawals.failedCount).toBe(1)
+    expect(json.withdrawals.currency).toBe('USDC')
+  })
+
+  it('accepts optional from/to date range params', async () => {
+    const res = await GET(makeRequest({ from: '2024-01-01', to: '2024-01-31' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 400 for invalid from date', async () => {
+    const res = await GET(makeRequest({ from: 'not-a-date' }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/invalid from date/i)
+  })
+
+  it('returns 400 for invalid to date', async () => {
+    const res = await GET(makeRequest({ to: 'bad-date' }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/invalid to date/i)
+  })
+
+  it('returns 400 when from is after to', async () => {
+    const res = await GET(makeRequest({ from: '2024-02-01', to: '2024-01-01' }))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatch(/from must be before/i)
+  })
+
+  it('handles zero amounts gracefully', async () => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+    mockedAggregate
+      .mockResolvedValueOnce({ _count: { id: 0 }, _sum: { amount: null } } as never)
+      .mockResolvedValueOnce({ _count: { id: 0 }, _sum: { amount: null } } as never)
+    mockedCount.mockResolvedValue(0 as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.withdrawals.totalAmount).toBe(0)
+    expect(json.withdrawals.completedAmount).toBe(0)
+  })
+
+  it('returns 500 on unexpected database error', async () => {
+    mockedAggregate.mockReset()
+    mockedAggregate.mockRejectedValue(new Error('DB failure') as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/routes-d/analytics/withdrawals/route.ts
+++ b/app/api/routes-d/analytics/withdrawals/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { createRouteLogger } from '../../_shared/logger'
+
+const log = createRouteLogger({ route: '/api/routes-d/analytics/withdrawals' })
+
+// ── GET /api/routes-d/analytics/withdrawals — withdrawal analytics ───────────
+
+export async function GET(request: NextRequest) {
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+
+    const { searchParams } = new URL(request.url)
+
+    const fromParam = searchParams.get('from')
+    const toParam = searchParams.get('to')
+
+    const from = fromParam ? new Date(fromParam) : null
+    const to = toParam ? new Date(toParam) : null
+
+    if (fromParam && isNaN(from!.getTime())) {
+      return NextResponse.json({ error: 'Invalid from date' }, { status: 400 })
+    }
+    if (toParam && isNaN(to!.getTime())) {
+      return NextResponse.json({ error: 'Invalid to date' }, { status: 400 })
+    }
+    if (from && to && from > to) {
+      return NextResponse.json({ error: 'from must be before or equal to to' }, { status: 400 })
+    }
+
+    const baseWhere = {
+      userId: user.id,
+      type: 'withdrawal',
+      ...(from || to
+        ? {
+            createdAt: {
+              ...(from ? { gte: from } : {}),
+              ...(to ? { lte: to } : {}),
+            },
+          }
+        : {}),
+    }
+
+    const [total, completed, pendingCount, failedCount] = await Promise.all([
+      prisma.transaction.aggregate({
+        where: baseWhere,
+        _count: { id: true },
+        _sum: { amount: true },
+      }),
+      prisma.transaction.aggregate({
+        where: { ...baseWhere, status: 'completed' },
+        _count: { id: true },
+        _sum: { amount: true },
+      }),
+      prisma.transaction.count({ where: { ...baseWhere, status: 'pending' } }),
+      prisma.transaction.count({ where: { ...baseWhere, status: 'failed' } }),
+    ])
+
+    return NextResponse.json({
+      withdrawals: {
+        totalCount: total._count.id,
+        totalAmount: Number(total._sum.amount ?? 0),
+        completedCount: completed._count.id,
+        completedAmount: Number(completed._sum.amount ?? 0),
+        pendingCount,
+        failedCount,
+        currency: 'USDC',
+      },
+    })
+  } catch (error) {
+    log.error({ err: error }, 'Withdrawal analytics GET error')
+    return NextResponse.json({ error: 'Failed to get withdrawal analytics' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

Closes #772
Closes #773
Closes #785 
Closes #786

This PR resolves all four open issues assigned to me in a single cohesive change.

### [routes-b] #785 — Structured logging wrapper (`_shared/logger.ts`)
- Introduces `createRouteLogger(context)` returning a Pino child logger pre-bound with `namespace: 'routes-b'` and a `route` context field
- Request-id is automatically injected by the existing `withRequestId` middleware patch on the base logger
- Adopted in `contacts/route.ts` and `branding/route.ts` (both already had `logger.error` calls) — replaces bare `@/lib/logger` imports with the scoped helper
- 5 unit tests in `_shared/__tests__/logger.test.ts`

### [routes-b] #786 — Request-id correlation header (`_shared/with-request-id.ts`)
- Provides a canonical `_shared` re-export for `withRequestId` and `getRequestId`; implementation stays in `_lib/with-request-id.ts` (co-located with schema-version utilities it depends on)
- 6 unit tests verifying X-Request-Id header echo, in-context access, and null outside context

### [routes-d] #773 — `GET /api/routes-d/analytics/withdrawals`
- New handler at `app/api/routes-d/analytics/withdrawals/route.ts`
- Aggregates withdrawal stats: `totalCount`, `totalAmount`, `completedCount`, `completedAmount`, `pendingCount`, `failedCount`, `currency`
- Optional `?from=` / `?to=` ISO date range filtering with validation (400 on invalid/reversed dates)
- Auth + ownership check; structured error envelope; uses `createRouteLogger`
- 10 unit tests covering happy path, date-range params, zero amounts, and 500

### [routes-d] #772 — `GET /api/routes-d/analytics/top-months`
- New handler at `app/api/routes-d/analytics/top-months/route.ts`
- Returns top earning months ranked by paid-invoice amounts with IANA `?tz=` timezone support
- Falls back to `user.timezone` then UTC; validates timezone and returns 400 with `fields.tz` on invalid input
- Optional `?limit=` param (default 3, max 12); skips invoices with `null paidAt`
- 10 unit tests covering rankings, timezone, limit, null-paidAt, and 500

## Test plan

- [ ] All 31 new tests pass: `npx vitest run app/api/routes-b/_shared/__tests__ app/api/routes-d/analytics/withdrawals/__tests__ app/api/routes-d/analytics/top-months/__tests__`
- [ ] No existing test regressions — only changed files are `contacts/route.ts` and `branding/route.ts` (import swap only, behaviour unchanged)
- [ ] New endpoints return 401 without auth, 404 for unknown user, 400 for invalid params, 200 with correct payload on happy path
- [ ] `createRouteLogger` creates a child logger namespaced `routes-b`; `withRequestId` echoes `X-Request-Id` on all responses
