### PR TITLE
Feat/routes d 817 806 825

### DIFF
--- a/app/api/routes-d/_lib/csv-stream.ts
+++ b/app/api/routes-d/_lib/csv-stream.ts
@@ -1,0 +1,66 @@
+const encoder = new TextEncoder()
+
+export type CsvValue = string | number | boolean | Date | null | undefined
+
+export type CsvColumn<T> = {
+  header: string
+  value: (row: T) => CsvValue
+}
+
+export type CsvBatchFetcher<T> = (cursor: string | null, batchSize: number) => Promise<T[]>
+
+export const CSV_BATCH_SIZE = 500
+
+export function escapeCsvCell(value: CsvValue): string {
+  const text = value instanceof Date ? value.toISOString() : String(value ?? '')
+
+  if (/[",\n\r]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`
+  }
+
+  return text
+}
+
+export function createCsvStream<T extends { id: string }>(
+  columns: CsvColumn<T>[],
+  fetchBatch: CsvBatchFetcher<T>,
+  batchSize = CSV_BATCH_SIZE,
+): ReadableStream<Uint8Array> {
+  let cursor: string | null = null
+  let sentHeader = false
+  let done = false
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (!sentHeader) {
+        sentHeader = true
+        controller.enqueue(encoder.encode(`${columns.map(column => escapeCsvCell(column.header)).join(',')}\n`))
+        return
+      }
+
+      if (done) {
+        controller.close()
+        return
+      }
+
+      const rows = await fetchBatch(cursor, batchSize)
+
+      if (rows.length === 0) {
+        done = true
+        controller.close()
+        return
+      }
+
+      cursor = rows[rows.length - 1].id
+      const csvRows = rows
+        .map(row => columns.map(column => escapeCsvCell(column.value(row))).join(','))
+        .join('\n')
+
+      controller.enqueue(encoder.encode(`${csvRows}\n`))
+
+      if (rows.length < batchSize) {
+        done = true
+      }
+    },
+  })
+}

--- a/app/api/routes-d/_lib/rate-limit.ts
+++ b/app/api/routes-d/_lib/rate-limit.ts
@@ -1,0 +1,40 @@
+type Bucket = {
+  tokens: number
+  resetAt: number
+}
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfter: number }
+
+const buckets = new Map<string, Bucket>()
+
+export function checkRateLimit(
+  key: string,
+  options: { limit: number; windowMs: number },
+  now = Date.now(),
+): RateLimitResult {
+  const existing = buckets.get(key)
+
+  if (!existing || now >= existing.resetAt) {
+    buckets.set(key, {
+      tokens: options.limit - 1,
+      resetAt: now + options.windowMs,
+    })
+    return { allowed: true }
+  }
+
+  if (existing.tokens <= 0) {
+    return {
+      allowed: false,
+      retryAfter: Math.max(1, Math.ceil((existing.resetAt - now) / 1000)),
+    }
+  }
+
+  existing.tokens -= 1
+  return { allowed: true }
+}
+
+export function resetRateLimitBuckets() {
+  buckets.clear()
+}

--- a/app/api/routes-d/notifications/[id]/read/__tests__/rate-limit.test.ts
+++ b/app/api/routes-d/notifications/[id]/read/__tests__/rate-limit.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { resetRateLimitBuckets } from '../../../../_lib/rate-limit'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    notification: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedNotifFind = vi.mocked(prisma.notification.findUnique)
+const mockedNotifUpdate = vi.mocked(prisma.notification.update)
+
+const NOTIF_ID = 'notif-abc'
+const USER_ID = 'user-1'
+
+const fakeNotification = {
+  id: NOTIF_ID,
+  userId: USER_ID,
+  type: 'invoice_paid',
+  title: 'Invoice Paid',
+  message: 'Your invoice has been paid',
+  isRead: false,
+  createdAt: new Date(),
+}
+
+function makePatch(auth = 'Bearer token'): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/routes-d/notifications/${NOTIF_ID}/read`,
+    {
+      method: 'PATCH',
+      headers: auth ? { authorization: auth } : {},
+    },
+  )
+}
+
+const params = Promise.resolve({ id: NOTIF_ID })
+
+describe('PATCH /api/routes-d/notifications/[id]/read rate limit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    resetRateLimitBuckets()
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({ id: USER_ID } as never)
+    mockedNotifFind.mockResolvedValue(fakeNotification as never)
+    mockedNotifUpdate.mockResolvedValue({ ...fakeNotification, isRead: true } as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('allows requests under the limit', async () => {
+    for (let i = 0; i < 29; i += 1) {
+      const res = await PATCH(makePatch(), { params })
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('allows the request at the limit', async () => {
+    for (let i = 0; i < 30; i += 1) {
+      const res = await PATCH(makePatch(), { params })
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('rejects requests over the limit with Retry-After', async () => {
+    for (let i = 0; i < 30; i += 1) {
+      await PATCH(makePatch(), { params })
+    }
+
+    const res = await PATCH(makePatch(), { params })
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('60')
+    expect(mockedNotifUpdate).toHaveBeenCalledTimes(30)
+  })
+
+  it('recovers after the window resets', async () => {
+    for (let i = 0; i < 30; i += 1) {
+      await PATCH(makePatch(), { params })
+    }
+
+    vi.setSystemTime(new Date('2026-01-01T00:01:01.000Z'))
+
+    const res = await PATCH(makePatch(), { params })
+
+    expect(res.status).toBe(200)
+  })
+})

--- a/app/api/routes-d/notifications/[id]/read/route.ts
+++ b/app/api/routes-d/notifications/[id]/read/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { verifyAuthToken } from '@/lib/auth'
 import { prisma } from '@/lib/db'
+import { checkRateLimit } from '../../../_lib/rate-limit'
 
 /**
  * PATCH /api/routes-d/notifications/[id]/read
@@ -23,6 +24,21 @@ export async function PATCH(
   })
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
+  }
+
+  const rateLimit = checkRateLimit(`notifications:read:${user.id}`, {
+    limit: 30,
+    windowMs: 60_000,
+  })
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: { 'Retry-After': String(rateLimit.retryAfter) },
+      },
+    )
   }
 
   const { id } = await params

--- a/app/api/routes-d/transactions/export/__tests__/route.test.ts
+++ b/app/api/routes-d/transactions/export/__tests__/route.test.ts
@@ -21,6 +21,19 @@ function req(qs = '?from=2026-01-01&to=2026-12-31', auth = 'Bearer token'): Next
   })
 }
 
+async function readStreamBody(res: Response): Promise<string> {
+  if (!res.body) return ''
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let text = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    text += decoder.decode(value, { stream: true })
+  }
+  return text
+}
+
 beforeEach(() => {
   vi.resetAllMocks()
   mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
@@ -45,11 +58,74 @@ describe('GET /api/routes-d/transactions/export', () => {
     mockedTxFindMany.mockResolvedValue([
       { id: 'tx-1', type: 'deposit', status: 'completed', amount: 50, currency: 'USDC', createdAt: new Date('2026-02-01T00:00:00Z') },
     ] as never)
+
     const res = await GET(req())
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('text/csv')
-    const body = await res.text()
+    expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="transactions.csv"')
+    expect(res.body).toBeInstanceOf(ReadableStream)
+
+    const body = await readStreamBody(res)
     expect(body.split('\n')[0]).toBe('id,type,status,amount,currency,createdAt')
     expect(body).toContain('tx-1,deposit,completed,50.00,USDC')
+  })
+
+  it('applies date range filters and uses cursor-based pagination', async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
+      id: `tx-${i}`,
+      type: 'deposit',
+      status: 'completed',
+      amount: 50,
+      currency: 'USDC',
+      createdAt: new Date('2026-02-01T00:00:00Z'),
+    }))
+    mockedTxFindMany
+      .mockResolvedValueOnce(fullBatch as never)
+      .mockResolvedValueOnce([] as never)
+
+    const res = await GET(req('?from=2026-01-01T00:00:00Z&to=2026-06-30T23:59:59Z'))
+    expect(res.status).toBe(200)
+    await readStreamBody(res)
+
+    expect(mockedTxFindMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        userId: 'user-1',
+        createdAt: {
+          gte: new Date('2026-01-01T00:00:00Z'),
+          lte: new Date('2026-06-30T23:59:59Z'),
+        },
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: 500,
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        amount: true,
+        currency: true,
+        createdAt: true,
+      },
+    })
+    expect(mockedTxFindMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        userId: 'user-1',
+        createdAt: {
+          gte: new Date('2026-01-01T00:00:00Z'),
+          lte: new Date('2026-06-30T23:59:59Z'),
+        },
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: 500,
+      cursor: { id: 'tx-499' },
+      skip: 1,
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        amount: true,
+        currency: true,
+        createdAt: true,
+      },
+    })
   })
 })

--- a/app/api/routes-d/transactions/export/route.ts
+++ b/app/api/routes-d/transactions/export/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { verifyAuthToken } from "@/lib/auth";
+import { createCsvStream } from "../../_lib/csv-stream";
 
 function isValidIsoDate(value: string): boolean {
   const d = new Date(value);
   return !isNaN(d.getTime());
 }
+
+type TransactionRow = {
+  id: string;
+  type: string;
+  status: string;
+  amount: unknown;
+  currency: string;
+  createdAt: Date;
+};
 
 export async function GET(request: NextRequest) {
   const authToken = request.headers
@@ -44,37 +54,38 @@ export async function GET(request: NextRequest) {
   const fromDate = new Date(from);
   const toDate = new Date(to);
 
-  const transactions = await prisma.transaction.findMany({
-    where: {
-      userId: user.id,
-      createdAt: { gte: fromDate, lte: toDate },
-    },
-    orderBy: { createdAt: "asc" },
-    select: {
-      id: true,
-      type: true,
-      status: true,
-      amount: true,
-      currency: true,
-      createdAt: true,
-    },
-  });
+  const where = {
+    userId: user.id,
+    createdAt: { gte: fromDate, lte: toDate },
+  };
 
-  const header = "id,type,status,amount,currency,createdAt";
-  const rows = transactions.map((t) => {
-    return [
-      t.id,
-      t.type,
-      t.status,
-      Number(t.amount).toFixed(2),
-      t.currency,
-      t.createdAt.toISOString(),
-    ].join(",");
-  });
+  const stream = createCsvStream<TransactionRow>(
+    [
+      { header: "id", value: (row) => row.id },
+      { header: "type", value: (row) => row.type },
+      { header: "status", value: (row) => row.status },
+      { header: "amount", value: (row) => Number(row.amount).toFixed(2) },
+      { header: "currency", value: (row) => row.currency },
+      { header: "createdAt", value: (row) => row.createdAt },
+    ],
+    (cursor, batchSize) =>
+      prisma.transaction.findMany({
+        where,
+        orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+        take: batchSize,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+        select: {
+          id: true,
+          type: true,
+          status: true,
+          amount: true,
+          currency: true,
+          createdAt: true,
+        },
+      }),
+  );
 
-  const csv = [header, ...rows].join("\n");
-
-  return new NextResponse(csv, {
+  return new NextResponse(stream, {
     status: 200,
     headers: {
       "Content-Type": "text/csv",

--- a/tests/api.routes-d.analytics-invoices.test.ts
+++ b/tests/api.routes-d.analytics-invoices.test.ts
@@ -100,4 +100,120 @@ describe('GET /api/routes-d/analytics/invoices', () => {
       _sum: { amount: true },
     })
   })
+
+  it('returns 401 when the user record is missing', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue(null)
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('handles a single status occupying 100% of distribution', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockResolvedValue([
+      { status: 'overdue', _count: { id: 10 }, _sum: { amount: '1000.00' } },
+    ])
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.invoices.total).toBe(10)
+    expect(body.invoices.overdue).toBe(10)
+    expect(body.invoices.distribution.overdue).toEqual({ count: 10, percentage: 100 })
+    expect(body.invoices.distribution.paid.percentage).toBe(0)
+    expect(body.invoices.distribution.pending.percentage).toBe(0)
+    expect(body.invoices.distribution.cancelled.percentage).toBe(0)
+  })
+
+  it('keeps distribution percentages summing to 100 within rounding tolerance', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockResolvedValue([
+      { status: 'paid', _count: { id: 1 }, _sum: { amount: '100' } },
+      { status: 'pending', _count: { id: 1 }, _sum: { amount: '100' } },
+      { status: 'overdue', _count: { id: 1 }, _sum: { amount: '100' } },
+    ])
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    const sum =
+      body.invoices.distribution.paid.percentage +
+      body.invoices.distribution.pending.percentage +
+      body.invoices.distribution.overdue.percentage +
+      body.invoices.distribution.cancelled.percentage
+
+    expect(sum).toBeCloseTo(100, 1)
+  })
+
+  it('ignores unknown statuses returned from groupBy', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockResolvedValue([
+      { status: 'paid', _count: { id: 2 }, _sum: { amount: '200' } },
+      { status: 'archived', _count: { id: 5 }, _sum: { amount: '500' } },
+    ])
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.invoices.total).toBe(2)
+    expect(body.invoices.paid).toBe(2)
+    expect(body.invoices.totalInvoiced).toBe(200)
+  })
+
+  it('returns zero percentages for an empty distribution range', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockResolvedValue([])
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(body.invoices.distribution.pending.percentage).toBe(0)
+    expect(body.invoices.distribution.paid.percentage).toBe(0)
+    expect(body.invoices.distribution.overdue.percentage).toBe(0)
+    expect(body.invoices.distribution.cancelled.percentage).toBe(0)
+  })
+
+  it('handles a single-invoice status boundary', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockResolvedValue([
+      { status: 'pending', _count: { id: 1 }, _sum: { amount: '42.00' } },
+    ])
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(body.invoices.total).toBe(1)
+    expect(body.invoices.pending).toBe(1)
+    expect(body.invoices.distribution.pending).toEqual({ count: 1, percentage: 100 })
+    expect(body.invoices.totalInvoiced).toBe(42)
+  })
+
+  it('returns 500 when the database query fails', async () => {
+    verifyAuthToken.mockResolvedValue({ userId: 'privy_1' })
+    userFindUnique.mockResolvedValue({ id: 'user_1' })
+    invoiceGroupBy.mockRejectedValue(new Error('db unavailable'))
+
+    const { GET } = await import('@/app/api/routes-d/analytics/invoices/route')
+    const response = await GET(makeRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Internal Server Error' })
+    expect(loggerError).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary

This PR implements three scoped changes on branch `feat/routes-d-817-806-825`, each in its own commit.

---

### #817 — Stream CSV in transactions export

`GET /api/routes-d/transactions/export` no longer buffers the full CSV in memory. Rows are now streamed via a `ReadableStream` using cursor-based batched `findMany` calls (500 rows/batch).

Preserved behavior:
- Required `from`/`to` query params
- Ascending `createdAt` order
- Same columns: `id`, `type`, `status`, `amount`, `currency`, `createdAt`
- Response headers: `Content-Type: text/csv`, `Content-Disposition: attachment; filename="transactions.csv"`

---

### #806 — Rate limit notifications read

`PATCH /api/routes-d/notifications/[id]/read` is now throttled per user at **30 requests / 60 seconds**. Exceeding the limit returns `429` with a `Retry-After` header (seconds until window reset), matching the routes-b token-bucket pattern.

---

### #825 — Analytics invoices edge case tests

Adds coverage for `GET /api/routes-d/analytics/invoices`:
- Empty distribution
- Single-invoice / single-status boundaries (100% bucket)
- Unknown statuses from `groupBy`
- Missing user (`401`)
- Percentage rounding
- DB failure (`500` + logger)

---

## Changes

| Area | Files |
|------|-------|
| CSV streaming | `app/api/routes-d/_lib/csv-stream.ts`, `app/api/routes-d/transactions/export/route.ts`, `app/api/routes-d/transactions/export/__tests__/route.test.ts` |
| Rate limiting | `app/api/routes-d/_lib/rate-limit.ts`, `app/api/routes-d/notifications/[id]/read/route.ts`, `app/api/routes-d/notifications/[id]/read/__tests__/rate-limit.test.ts` |
| Analytics tests | `tests/api.routes-d.analytics-invoices.test.ts` |

---

## Commits

```
fix(routes-d): stream CSV in transactions export (#817)
feat(routes-d): rate limit notification mark-as-read endpoint (#806)
test(routes-d): add analytics invoices edge case coverage (#825)
```

---

## Test Plan

**Run targeted tests:**

```bash
npm test -- app/api/routes-d/transactions/export/__tests__/route.test.ts \
  "app/api/routes-d/notifications/[id]/read/__tests__/" \
  tests/api.routes-d.analytics-invoices.test.ts
```

**Checklist:**

- [ ] **#817** — Authenticated export with `from`/`to` returns CSV with correct headers; response body is a stream; large ranges paginate via cursor (no full in-memory buffer)
- [ ] **#817** — Missing/invalid `from`/`to` returns `400`; unauthenticated requests return `401`
- [ ] **#806** — Under limit: `PATCH /notifications/[id]/read` returns `200`
- [ ] **#806** — Over limit (31st request within 60s): returns `429` with `Retry-After`; requests succeed again after window expires
- [ ] **#825** — Analytics invoices: empty data, single-status 100%, unknown statuses ignored, missing user `401`, DB error `500`

---

Closes #817
Closes  #806
Closes #825