### PR TITLE
Add routes-b branding preview endpoint and routes-d audit-log filters

### DIFF
--- a/app/api/routes-b/branding/preview/route.ts
+++ b/app/api/routes-b/branding/preview/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { withBodyLimit } from '../../_lib/with-body-limit'
+import { withRequestId } from '../../_lib/with-request-id'
+import { registerRoute } from '../../_lib/openapi'
+import { errorResponse } from '../../_lib/errors'
+import { verifyAuthToken } from '@/lib/auth'
+import { brandingSchema } from '../schema'
+
+registerRoute({
+  method: 'POST',
+  path: '/branding/preview',
+  summary: 'Preview branding settings',
+  description:
+    'Validate a candidate branding payload and render a small inline HTML preview without persisting changes.',
+  requestSchema: brandingSchema,
+  responseSchema: { html: 'string' } as unknown,
+  tags: ['branding'],
+})
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function buildPreviewHtml(branding: Record<string, string | null | undefined>) {
+  const primaryColor = branding.primaryColor ?? '#6366f1'
+  const secondaryColor = branding.secondaryColor ?? '#eef2ff'
+  const accentColor = branding.accentColor ?? '#2563eb'
+  const logoUrl = branding.logoUrl ? escapeHtml(branding.logoUrl) : null
+  const footerText = branding.footerText ? escapeHtml(branding.footerText) : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Branding Preview</title>
+    <style>
+      body { margin: 0; font-family: system-ui, sans-serif; background: #f8fafc; color: #0f172a; }
+      .preview { max-width: 600px; margin: 24px auto; border: 1px solid #e2e8f0; border-radius: 16px; overflow: hidden; box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08); }
+      .header { display: flex; align-items: center; justify-content: space-between; background: ${primaryColor}; color: white; padding: 20px; gap: 16px; }
+      .header-branding { display: flex; flex-direction: column; gap: 4px; }
+      .header-title { margin: 0; font-size: 1rem; letter-spacing: 0.03em; text-transform: uppercase; font-weight: 700; }
+      .header-subtitle { margin: 0; font-size: 1.3rem; }
+      .logo { max-height: 48px; max-width: 160px; object-fit: contain; border-radius: 8px; background: white; padding: 8px; }
+      .invoice-meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; padding: 20px; background: ${secondaryColor}; }
+      .invoice-meta div { padding: 16px; border-radius: 12px; background: white; }
+      .label { margin: 0 0 8px 0; font-size: 0.8rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.04em; }
+      .value { margin: 0; font-size: 1.1rem; font-weight: 600; }
+      .line-items { padding: 20px; }
+      .line-item { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+      .line-item:last-child { margin-bottom: 0; }
+      .legend { display: inline-flex; align-items: center; gap: 8px; margin-top: 16px; font-size: 0.9rem; color: #475569; }
+      .chip { display: inline-flex; align-items: center; justify-content: center; width: 12px; height: 12px; border-radius: 9999px; }
+      .footer { padding: 20px; background: #ffffff; border-top: 1px solid #e2e8f0; color: #475569; }
+      .accent { color: ${accentColor}; }
+    </style>
+  </head>
+  <body>
+    <div class="preview">
+      <div class="header">
+        <div class="header-branding">
+          <p class="header-title">Invoice Preview</p>
+          <h1 class="header-subtitle">Acme Corporation</h1>
+        </div>
+        ${logoUrl ? `<img class="logo" src="${logoUrl}" alt="Logo preview" />` : ''}
+      </div>
+      <div class="invoice-meta">
+        <div>
+          <p class="label">Invoice #</p>
+          <p class="value">12345</p>
+        </div>
+        <div>
+          <p class="label">Due date</p>
+          <p class="value">2026-06-30</p>
+        </div>
+      </div>
+      <div class="line-items">
+        <div class="line-item">
+          <span>Consulting Services</span>
+          <span class="accent">$1,250.00</span>
+        </div>
+        <div class="line-item">
+          <span>Platform fee</span>
+          <span class="accent">$120.00</span>
+        </div>
+      </div>
+      <div class="footer">
+        <p class="legend">Sample branding uses primary color <span class="chip" style="background:${primaryColor}"></span> and accent <span class="chip" style="background:${accentColor}"></span>.</p>
+        ${footerText ? `<p>${footerText}</p>` : ''}
+      </div>
+    </div>
+  </body>
+</html>`
+}
+
+async function POSTHandler(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return errorResponse('UNAUTHORIZED', 'Unauthorized', {}, 401)
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return errorResponse('UNAUTHORIZED', 'Unauthorized', {}, 401)
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return errorResponse('BAD_REQUEST', 'Invalid request body', { fields: { body: 'Invalid JSON' } }, 422)
+  }
+
+  const parsed = brandingSchema.safeParse(body)
+  if (!parsed.success) {
+    const fields = parsed.error.issues.reduce<Record<string, string>>((result, issue) => {
+      const key = typeof issue.path[0] === 'string' ? issue.path[0] : 'body'
+      if (!result[key]) result[key] = issue.message
+      return result
+    }, {})
+
+    return errorResponse('BAD_REQUEST', 'Invalid branding payload', { fields }, 422)
+  }
+
+  const html = buildPreviewHtml(parsed.data)
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  })
+}
+
+export const POST = withRequestId(withBodyLimit(POSTHandler, { limitBytes: 1024 * 1024 }))

--- a/app/api/routes-b/tests/branding-preview.test.ts
+++ b/app/api/routes-b/tests/branding-preview.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({ prisma: { brandingSettings: { upsert: vi.fn() } } }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { POST } from '../branding/preview/route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUpsert = vi.mocked(prisma.brandingSettings.upsert)
+
+const URL = 'http://localhost/api/routes-b/branding/preview'
+
+function makeRequest(body: unknown, auth = 'Bearer token') {
+  return new NextRequest(URL, {
+    method: 'POST',
+    headers: auth ? { authorization: auth } : {},
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/routes-b/branding/preview', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUpsert.mockResolvedValue(null as never)
+  })
+
+  it('returns 200 and renders safe HTML for valid branding', async () => {
+    const res = await POST(
+      makeRequest({
+        primaryColor: '#112233',
+        accentColor: '#00ff00',
+        footerText: '<script>alert(1)</script>',
+        logoUrl: 'https://example.com/logo.png',
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    const html = await res.text()
+    expect(html).toContain('Invoice Preview')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('src="https://example.com/logo.png"')
+    expect(mockedUpsert).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 for invalid branding and does not write to the database', async () => {
+    const res = await POST(makeRequest({ primaryColor: 'not-a-hex' }))
+    expect(res.status).toBe(422)
+    const json = await res.json()
+    expect(json.error).toBeDefined()
+    expect(json.error.fields?.primaryColor).toBe('Must be a valid 6-digit hex color')
+    expect(mockedUpsert).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+    const res = await POST(makeRequest({ primaryColor: '#112233' }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/app/api/routes-d/audit-log/__tests__/route.test.ts
+++ b/app/api/routes-d/audit-log/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/db', () => ({ prisma: { user: { findUnique: vi.fn() }, auditEvent: { findMany: vi.fn() } } }))
+vi.mock('../_shared/logger', () => ({ createRouteLogger: vi.fn(() => ({ error: vi.fn() })) }))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFindUnique = vi.mocked(prisma.user.findUnique)
+const mockedAuditFindMany = vi.mocked(prisma.auditEvent.findMany)
+
+function makeRequest(query = '') {
+  return new NextRequest(`http://localhost/api/routes-d/audit-log${query}`, {
+    method: 'GET',
+    headers: { authorization: 'Bearer token' },
+  })
+}
+
+describe('GET /api/routes-d/audit-log', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFindUnique.mockResolvedValue({ id: 'user-1' } as never)
+    mockedAuditFindMany.mockResolvedValue([] as never)
+  })
+
+  it('returns 400 when the date range is invalid', async () => {
+    const res = await GET(makeRequest('?from=2026-04-03T00:00:00.000Z&to=2026-04-02T00:00:00.000Z'))
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toBe('from must be before or equal to to')
+    expect(mockedAuditFindMany).not.toHaveBeenCalled()
+  })
+
+  it('applies actor filter and date range', async () => {
+    await GET(makeRequest('?from=2026-04-01T00:00:00.000Z&to=2026-04-02T00:00:00.000Z&actor=user-2'))
+
+    expect(mockedAuditFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          actorId: 'user-2',
+          createdAt: {
+            gte: new Date('2026-04-01T00:00:00.000Z'),
+            lte: new Date('2026-04-02T00:00:00.000Z'),
+          },
+        }),
+      }),
+    )
+  })
+
+  it('defaults to a bounded 90-day range when no from/to provided', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T12:00:00.000Z'))
+
+    await GET(makeRequest(''))
+
+    expect(mockedAuditFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date('2026-01-31T12:00:00.000Z'),
+            lte: new Date('2026-05-01T12:00:00.000Z'),
+          },
+        }),
+      }),
+    )
+
+    vi.useRealTimers()
+  })
+})

--- a/app/api/routes-d/audit-log/route.ts
+++ b/app/api/routes-d/audit-log/route.ts
@@ -1,36 +1,81 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { createRouteLogger } from '../_shared/logger'
+
+const log = createRouteLogger({ route: '/api/routes-d/audit-log' })
+const MAX_DATE_RANGE_DAYS = 365
+const DEFAULT_DATE_RANGE_DAYS = 90
+
+function parseAuditFilters(searchParams: URLSearchParams) {
+  const fromParam = searchParams.get('from')
+  const toParam = searchParams.get('to')
+  const actor = searchParams.get('actor') || undefined
+
+  const now = new Date()
+  const from = fromParam ? new Date(fromParam) : new Date(now.getTime() - DEFAULT_DATE_RANGE_DAYS * 24 * 60 * 60 * 1000)
+  const to = toParam ? new Date(toParam) : now
+
+  if (fromParam && isNaN(from.getTime())) {
+    return { ok: false, error: 'Invalid from date' as const }
+  }
+  if (toParam && isNaN(to.getTime())) {
+    return { ok: false, error: 'Invalid to date' as const }
+  }
+  if (from > to) {
+    return { ok: false, error: 'from must be before or equal to to' as const }
+  }
+
+  const rangeMs = to.getTime() - from.getTime()
+  if (rangeMs > MAX_DATE_RANGE_DAYS * 24 * 60 * 60 * 1000) {
+    return { ok: false, error: `date range cannot exceed ${MAX_DATE_RANGE_DAYS} days` as const }
+  }
+
+  return { ok: true, value: { from, to, actor } }
+}
 
 export async function GET(request: NextRequest) {
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    const claims = await verifyAuthToken(authToken || '')
+    if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
 
-  const { searchParams } = new URL(request.url)
-  const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100)
-  const action = searchParams.get('action')
+    const { searchParams } = new URL(request.url)
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100)
+    const action = searchParams.get('action')
 
-  const events = await prisma.auditEvent.findMany({
-    where: {
-      actorId: user.id,
-      ...(action ? { eventType: action } : {}),
-    },
-    orderBy: { createdAt: 'desc' },
-    take: limit,
-  })
+    const parsedFilters = parseAuditFilters(searchParams)
+    if (!parsedFilters.ok) {
+      return NextResponse.json({ error: parsedFilters.error }, { status: 400 })
+    }
 
-  return NextResponse.json({
-    events: events.map(event => ({
-      id: event.id,
-      action: event.eventType,
-      resourceType: 'invoice', // Current schema ties AuditEvent to Invoice
-      resourceId: event.invoiceId,
-      createdAt: event.createdAt,
-      // ipAddress is not in the current AuditEvent model, omitting per "Check the schema for the full field list"
-    })),
-  })
+    const events = await prisma.auditEvent.findMany({
+      where: {
+        actorId: parsedFilters.value.actor ? parsedFilters.value.actor : user.id,
+        ...(action ? { eventType: action } : {}),
+        createdAt: {
+          gte: parsedFilters.value.from,
+          lte: parsedFilters.value.to,
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    })
+
+    return NextResponse.json({
+      events: events.map(event => ({
+        id: event.id,
+        action: event.eventType,
+        resourceType: 'invoice',
+        resourceId: event.invoiceId,
+        createdAt: event.createdAt,
+      })),
+    })
+  } catch (error) {
+    log.error({ err: error }, 'Audit log GET error')
+    return NextResponse.json({ error: 'Failed to get audit log' }, { status: 500 })
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,7 +2247,6 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -2296,7 +2295,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2536,7 +2534,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5404,7 +5401,6 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -5905,7 +5901,6 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
       "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/codecs": "5.5.1",
@@ -6712,6 +6707,17 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.5.1.tgz",
@@ -7157,6 +7163,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
       "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -7351,7 +7358,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7476,7 +7482,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -9283,7 +9288,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -9319,7 +9323,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9370,7 +9373,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -10024,7 +10026,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10397,7 +10398,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -10690,7 +10690,6 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -11603,7 +11602,6 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
       "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -11999,7 +11997,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12173,7 +12170,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12607,8 +12603,7 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -13504,7 +13499,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16306,7 +16300,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -16524,7 +16517,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -16584,7 +16576,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16607,7 +16598,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -16741,8 +16731,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -17546,7 +17535,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -18400,7 +18388,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18696,7 +18683,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18999,7 +18985,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -19010,7 +18995,6 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -19064,7 +19048,6 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -19095,7 +19078,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -19205,7 +19187,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -19313,7 +19294,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19444,7 +19424,6 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -19692,7 +19671,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -19924,7 +19902,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Summary
Implemented the requested feature work for both [routes-b](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/) and [routes-d](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/):

Added [POST /api/routes-b/branding/preview](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)

Validates candidate branding using the existing [brandingSchema](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
Returns a synchronous preview as sanitized inline HTML
Does not persist anything to the database
Extended [GET /api/routes-d/audit-log](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)

Supports [from](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/), [to](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/), and [actor](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/) query params
Validates date boundaries and enforces a maximum 365-day range
Defaults to a bounded 90-day window when no dates are provided
Files changed
[route.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
[branding-preview.test.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
[route.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
[route.test.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
Tests
Verified with targeted Vitest:
[branding-preview.test.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
[route.test.ts](https://cautious-happiness-4xpw5rxjqr9f7qrv.github.dev/)
Result: 6 passed

Closes : #818
Closes : #824
Closes  : #827 
Closes  : #627