### PR TITLE
fix: add tests and fix stats cache bug for routes-b

### DIFF
--- a/app/api/routes-b/stats/__tests__/stats.test.ts
+++ b/app/api/routes-b/stats/__tests__/stats.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { groupBy: vi.fn() },
+    transaction: { aggregate: vi.fn(), count: vi.fn() },
+  },
+}))
+
+vi.mock('../../_lib/authz', () => ({
+  requireScope: vi.fn(),
+  RoutesBForbiddenError: class RoutesBForbiddenError extends Error {
+    code = 'FORBIDDEN'
+  },
+}))
+
+vi.mock('../../_lib/stats-cache', () => ({
+  ensureStatsCacheInvalidationHooks: vi.fn(),
+  getCachedStats: vi.fn(),
+  setCachedStats: vi.fn(),
+}))
+
+vi.mock('../../_lib/with-compression', () => ({
+  withCompression: vi.fn((_req, res) => res),
+}))
+
+import { prisma } from '@/lib/db'
+import { requireScope } from '../../_lib/authz'
+import { getCachedStats, setCachedStats } from '../../_lib/stats-cache'
+
+function makeRequest(auth = 'Bearer test-token') {
+  return new NextRequest('http://localhost/api/routes-b/stats', {
+    headers: { authorization: auth },
+  })
+}
+
+describe('GET /api/routes-b/stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns cached stats when available', async () => {
+    const cached = {
+      invoices: { total: 5, pending: 1, paid: 3, cancelled: 0, overdue: 1 },
+      totalEarned: 1000,
+      pendingWithdrawals: 2,
+    }
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+    vi.mocked(getCachedStats).mockReturnValue(cached)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual(cached)
+    expect(res.headers.get('X-Cache')).toBe('HIT')
+  })
+
+  it('computes and caches stats on cache miss', async () => {
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+    vi.mocked(getCachedStats).mockReturnValue(null)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'u1' })
+    vi.mocked(prisma.invoice.groupBy).mockResolvedValue([
+      { status: 'paid', _count: { id: 3 } },
+      { status: 'pending', _count: { id: 1 } },
+    ])
+    vi.mocked(prisma.transaction.aggregate).mockResolvedValue({ _sum: { amount: 500 } })
+    vi.mocked(prisma.transaction.count).mockResolvedValue(2)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.invoices.total).toBe(4)
+    expect(body.invoices.paid).toBe(3)
+    expect(body.invoices.pending).toBe(1)
+    expect(body.totalEarned).toBe(500)
+    expect(body.pendingWithdrawals).toBe(2)
+    expect(res.headers.get('X-Cache')).toBe('MISS')
+    expect(setCachedStats).toHaveBeenCalledWith('u1', expect.any(Object))
+  })
+
+  it('returns 404 when user not found', async () => {
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+    vi.mocked(getCachedStats).mockReturnValue(null)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+  })
+
+  it('returns 403 for missing scope', async () => {
+    const { RoutesBForbiddenError } = await import('../../_lib/authz')
+    vi.mocked(requireScope).mockRejectedValue(new RoutesBForbiddenError('Missing required scope'))
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 401 for missing auth', async () => {
+    vi.mocked(requireScope).mockRejectedValue(new Error('no auth'))
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest(''))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+  })
+})

--- a/app/api/routes-b/stats/route.ts
+++ b/app/api/routes-b/stats/route.ts
@@ -113,7 +113,7 @@ async function GETHandler(request: NextRequest) {
       pendingWithdrawals,
     }
 
-    setCachedStats(auth.userId, payload)
+    setCachedStats(auth.userId, currentStats)
 
     return withCompression(
       request,

--- a/app/api/routes-b/transactions/export/__tests__/export.test.ts
+++ b/app/api/routes-b/transactions/export/__tests__/export.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    transaction: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('../../../_lib/csv-stream', () => ({
+  createCsvStream: vi.fn((_cols, fetcher) => {
+    const encoder = new TextEncoder()
+    return new ReadableStream({
+      async start(controller) {
+        const rows = await fetcher(null, 100)
+        for (const row of rows) {
+          controller.enqueue(encoder.encode(JSON.stringify(row) + '\n'))
+        }
+        controller.close()
+      },
+    })
+  }),
+}))
+
+vi.mock('../../../_lib/errors', () => ({
+  errorResponse: vi.fn((code, message, _opts, status) => {
+    return new Response(JSON.stringify({ error: { code, message } }), { status })
+  }),
+}))
+
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+
+function makeRequest(params = '') {
+  return new NextRequest(`http://localhost/api/routes-b/transactions/export${params}`, {
+    headers: { authorization: 'Bearer test-token' },
+  })
+}
+
+describe('GET /api/routes-b/transactions/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exports transactions as CSV stream', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.transaction.findMany).mockResolvedValue([
+      { id: 't1', type: 'payment', status: 'completed', amount: 100, currency: 'USDC', createdAt: new Date(), invoice: { description: 'Test' } },
+    ])
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/csv')
+    expect(res.headers.get('Content-Disposition')).toContain('transactions.csv')
+  })
+
+  it('filters by date range when provided', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.transaction.findMany).mockResolvedValue([])
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest('?from=2026-01-01&to=2026-03-31'))
+
+    expect(res.status).toBe(200)
+    expect(prisma.transaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'user-1',
+          createdAt: expect.objectContaining({
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          }),
+        }),
+      }),
+    )
+  })
+
+  it('returns 400 for invalid from date', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest('?from=not-a-date'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+  })
+
+  it('returns 400 for invalid to date', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest('?to=not-a-date'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+  })
+
+  it('returns 401 for missing auth token', async () => {
+    const { GET } = await import('../route')
+    const req = new NextRequest('http://localhost/api/routes-b/transactions/export')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 401 for invalid token', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 404 when user not found', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+  })
+})

--- a/app/api/routes-b/trust-score/__tests__/trust-score.test.ts
+++ b/app/api/routes-b/trust-score/__tests__/trust-score.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    invoice: { aggregate: vi.fn(), count: vi.fn() },
+    dispute: { count: vi.fn() },
+    userTrustScore: { upsert: vi.fn() },
+  },
+}))
+
+vi.mock('../../_lib/authz', () => ({
+  requireScope: vi.fn(),
+  RoutesBForbiddenError: class RoutesBForbiddenError extends Error {
+    code = 'FORBIDDEN'
+  },
+}))
+
+vi.mock('../../_lib/cache', () => ({
+  getCacheValue: vi.fn(),
+  setCacheValue: vi.fn(),
+}))
+
+vi.mock('../../_lib/trust-score-history', () => ({
+  recordTrustScoreSnapshot: vi.fn(),
+}))
+
+vi.mock('../../_lib/trust-score-components', () => ({
+  computeTrustScore: vi.fn(() => 75),
+}))
+
+import { prisma } from '@/lib/db'
+import { requireScope } from '../../_lib/authz'
+import { getCacheValue, setCacheValue } from '../../_lib/cache'
+import { computeTrustScore } from '../../_lib/trust-score-components'
+
+function makeRequest(params = '') {
+  const url = `http://localhost/api/routes-b/trust-score${params}`
+  return new NextRequest(url, {
+    headers: { authorization: 'Bearer test-token' },
+  })
+}
+
+describe('GET /api/routes-b/trust-score', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns cached trust score on HIT', async () => {
+    const cached = {
+      trustScore: { score: 80, totalVolumeUsdc: 5000, disputeCount: 0, updatedAt: new Date() },
+    }
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+    vi.mocked(getCacheValue).mockReturnValue(cached)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.trustScore.score).toBe(80)
+    expect(res.headers.get('X-Cache')).toBe('HIT')
+  })
+
+  it('recomputes trust score on cache miss', async () => {
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+    vi.mocked(getCacheValue).mockReturnValue(null)
+    vi.mocked(prisma.invoice.aggregate).mockResolvedValue({ _sum: { amount: 1000 } })
+    vi.mocked(prisma.invoice.count).mockResolvedValue(5)
+    vi.mocked(prisma.dispute.count).mockResolvedValue(1)
+    vi.mocked(computeTrustScore).mockReturnValue(75)
+    vi.mocked(prisma.userTrustScore.upsert).mockResolvedValue({
+      score: 75,
+      totalVolumeUsdc: 1000,
+      disputeCount: 1,
+      lastUpdatedAt: new Date(),
+    })
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.trustScore.score).toBe(75)
+    expect(body.trustScore.totalVolumeUsdc).toBe(1000)
+    expect(body.trustScore.disputeCount).toBe(1)
+    expect(res.headers.get('X-Cache')).toBe('MISS')
+    expect(setCacheValue).toHaveBeenCalled()
+  })
+
+  it('force recomputes for admin users', async () => {
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'admin', scopes: ['routes-b:read'] })
+    vi.mocked(prisma.invoice.aggregate).mockResolvedValue({ _sum: { amount: 2000 } })
+    vi.mocked(prisma.invoice.count).mockResolvedValue(10)
+    vi.mocked(prisma.dispute.count).mockResolvedValue(0)
+    vi.mocked(computeTrustScore).mockReturnValue(95)
+    vi.mocked(prisma.userTrustScore.upsert).mockResolvedValue({
+      score: 95,
+      totalVolumeUsdc: 2000,
+      disputeCount: 0,
+      lastUpdatedAt: new Date(),
+    })
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest('?force=true'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.trustScore.score).toBe(95)
+    expect(getCacheValue).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for force=true with non-admin role', async () => {
+    vi.mocked(requireScope).mockResolvedValue({ userId: 'u1', role: 'user', scopes: ['routes-b:read'] })
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest('?force=true'))
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toBe('Forbidden')
+    expect(body.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 403 for missing scope', async () => {
+    const { RoutesBForbiddenError } = await import('../../_lib/authz')
+    vi.mocked(requireScope).mockRejectedValue(new RoutesBForbiddenError('Missing required scope'))
+
+    const { GET } = await import('../route')
+    const res = await GET(makeRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toBe('Forbidden')
+    expect(body.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 401 for missing auth token', async () => {
+    vi.mocked(requireScope).mockRejectedValue(new Error('no auth'))
+
+    const { GET } = await import('../route')
+    const req = new NextRequest('http://localhost/api/routes-b/trust-score')
+    const res = await GET(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error).toBe('Unauthorized')
+  })
+})

--- a/app/api/routes-b/webhooks/__tests__/webhooks.test.ts
+++ b/app/api/routes-b/webhooks/__tests__/webhooks.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    userWebhook: { findMany: vi.fn(), count: vi.fn(), create: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuthToken: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn() },
+}))
+
+vi.mock('../../_lib/idempotency', () => ({
+  getIdempotentResponse: vi.fn(),
+  setIdempotentResponse: vi.fn(),
+}))
+
+vi.mock('../../_lib/webhook-events', () => ({
+  validateEventTypes: vi.fn((types) => types),
+  getDefaultEventTypes: vi.fn(() => ['invoice.created']),
+}))
+
+vi.mock('../../_lib/openapi', () => ({
+  registerRoute: vi.fn(),
+}))
+
+vi.mock('../../_lib/webhook-fingerprint', () => ({
+  generateSecretFingerprint: vi.fn(() => 'fp-abc123'),
+}))
+
+vi.mock('../../_lib/hmac', () => ({
+  generateWebhookSecret: vi.fn(() => 'whsec_test123'),
+}))
+
+vi.mock('../../_lib/webhook-custom-headers', () => ({
+  getCustomHeaders: vi.fn(() => ({})),
+  setCustomHeaders: vi.fn(),
+  validateCustomHeaders: vi.fn(() => ({ ok: true, headers: {} })),
+}))
+
+vi.mock('../../_lib/with-request-id', () => ({
+  withRequestId: vi.fn((handler) => handler),
+}))
+
+vi.mock('../../_lib/with-body-limit', () => ({
+  withBodyLimit: vi.fn((handler) => handler),
+}))
+
+vi.mock('../../_lib/with-methods', () => ({
+  withMethods: vi.fn((handlers) => handlers),
+}))
+
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { getIdempotentResponse } from '../../_lib/idempotency'
+import { validateCustomHeaders } from '../../_lib/webhook-custom-headers'
+
+function makeGetRequest() {
+  return new NextRequest('http://localhost/api/routes-b/webhooks', {
+    headers: { authorization: 'Bearer test-token' },
+  })
+}
+
+function makePostRequest(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/routes-b/webhooks', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer test-token',
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('GET /api/routes-b/webhooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns webhooks for authenticated user', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.userWebhook.findMany).mockResolvedValue([
+      {
+        id: 'wh-1',
+        targetUrl: 'https://example.com/hook',
+        description: 'Test webhook',
+        isActive: true,
+        subscribedEvents: ['invoice.created'],
+        lastTriggeredAt: null,
+        signingSecret: 'whsec_abc',
+        createdAt: new Date(),
+      },
+    ])
+
+    const { GET } = await import('../route')
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.webhooks).toHaveLength(1)
+    expect(body.webhooks[0].id).toBe('wh-1')
+    expect(body.webhooks[0].secretFingerprint).toBe('fp-abc123')
+    expect(body.webhooks[0].signingSecret).toBeUndefined()
+  })
+
+  it('returns 401 for unauthenticated request', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null)
+
+    const { GET } = await import('../route')
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error).toBe('Unauthorized')
+  })
+
+  it('returns empty array when user has no webhooks', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.userWebhook.findMany).mockResolvedValue([])
+
+    const { GET } = await import('../route')
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.webhooks).toEqual([])
+  })
+
+  it('returns 500 on internal error', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockRejectedValue(new Error('db error'))
+
+    const { GET } = await import('../route')
+    const res = await GET(makeGetRequest())
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.error).toBe('Failed to get webhooks')
+  })
+})
+
+describe('POST /api/routes-b/webhooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a webhook successfully', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.userWebhook.count).mockResolvedValue(0)
+    vi.mocked(prisma.userWebhook.create).mockResolvedValue({
+      id: 'wh-new',
+      targetUrl: 'https://example.com/hook',
+      description: 'My webhook',
+      signingSecret: 'whsec_new',
+      subscribedEvents: ['invoice.created'],
+      createdAt: new Date(),
+    })
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({
+      targetUrl: 'https://example.com/hook',
+      description: 'My webhook',
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(body.id).toBe('wh-new')
+    expect(body.signingSecret).toBe('whsec_test123')
+  })
+
+  it('returns 401 for unauthenticated request', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ targetUrl: 'https://example.com/hook' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error).toBe('Unauthorized')
+  })
+
+  it('returns 400 for missing targetUrl', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({}))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('targetUrl is required')
+  })
+
+  it('returns 400 for non-HTTPS targetUrl', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ targetUrl: 'http://example.com/hook' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('Invalid HTTPS targetUrl')
+  })
+
+  it('returns 400 for description too long', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({
+      targetUrl: 'https://example.com/hook',
+      description: 'x'.repeat(101),
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('Invalid description')
+  })
+
+  it('returns 429 when webhook limit reached', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(prisma.userWebhook.count).mockResolvedValue(10)
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({ targetUrl: 'https://example.com/hook' }))
+    const body = await res.json()
+
+    expect(res.status).toBe(429)
+    expect(body.error).toBe('Webhook limit reached')
+  })
+
+  it('returns 409 on idempotency conflict', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(getIdempotentResponse).mockReturnValue({
+      bodyHash: 'different-hash',
+      status: 201,
+      body: { id: 'wh-old' },
+    })
+
+    const { POST } = await import('../route')
+    const res = await POST(
+      makePostRequest({ targetUrl: 'https://example.com/hook' }, { 'idempotency-key': 'key-123' }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(409)
+    expect(body.error).toBe('Idempotency conflict')
+  })
+
+  it('returns 400 for invalid custom headers', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-123' })
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' })
+    vi.mocked(validateCustomHeaders).mockReturnValue({ ok: false, error: 'Invalid headers' })
+
+    const { POST } = await import('../route')
+    const res = await POST(makePostRequest({
+      targetUrl: 'https://example.com/hook',
+      headers: { bad: 'header' },
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('Invalid headers')
+  })
+})


### PR DESCRIPTION
Fixes #725
Fixes #722
Fixes #720
Fixes #716

## What changed
- Fix variable name bug in stats route (`payload` -> `currentStats`) causing cache writes to fail
- Add unit tests for stats endpoint (happy path, cache hit/miss, auth failures)
- Add unit tests for trust-score endpoint (cache, force recomputation, admin checks, auth)
- Add unit tests for transactions/export endpoint (CSV streaming, date filtering, auth)
- Add unit tests for webhooks endpoint (CRUD, validation, idempotency, custom headers, auth)

## Why
- Stats route had a bug where `setCachedStats` was called with undefined `payload` instead of `currentStats`
- All 4 routes needed unit tests covering happy path and key failure modes as specified in the issues

## How to test
- Run `npx vitest run app/api/routes-b/stats/__tests__/stats.test.ts app/api/routes-b/trust-score/__tests__/trust-score.test.ts app/api/routes-b/transactions/export/__tests__/export.test.ts app/api/routes-b/webhooks/__tests__/webhooks.test.ts`
- All 30 tests should pass

Closes #725
Closes #722
Closes #720
Closes #716