### PR TITLE
feat(routes-b): invoice summary, paid, overdue, and tags endpoints

### DIFF
--- a/app/api/routes-b/invoices/overdue/route.ts
+++ b/app/api/routes-b/invoices/overdue/route.ts
@@ -2,89 +2,161 @@ import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
 import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 import { decodeCursor, encodeCursor } from '../../_lib/cursor'
+import {
+  emptyAgeingBuckets,
+  getAgeingBucket,
+  getDaysOverdueUtc,
+  type AgeingBucketKey,
+} from '../../_lib/ageing'
 
 async function GETHandler(request: NextRequest) {
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
 
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+    }
 
-  const { searchParams } = new URL(request.url)
-  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
 
-  const limit = Math.min(
-    100,
-    Math.max(1, Number.parseInt(searchParams.get('limit') || '25', 10) || 25),
-  )
+    const { searchParams } = new URL(request.url)
+    const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
+    const now = new Date()
 
-  const cursorParam = searchParams.get('cursor')
-  const decodedCursor = cursorParam ? decodeCursor(cursorParam) : null
+    if (searchParams.get('bucketed') === 'true') {
+      const invoices = await prisma.invoice.findMany({
+        where: {
+          userId: user.id,
+          status: 'pending',
+          dueDate: { lt: now, not: null },
+          ...getArchiveFilter(includeArchived),
+        },
+        orderBy: { dueDate: 'asc' },
+        select: {
+          id: true,
+          invoiceNumber: true,
+          clientName: true,
+          amount: true,
+          currency: true,
+          dueDate: true,
+          createdAt: true,
+        },
+      })
 
-  if (cursorParam && !decodedCursor) {
-    return NextResponse.json({ error: 'Invalid cursor' }, { status: 400 })
+      const buckets = emptyAgeingBuckets<{
+        id: string
+        invoiceNumber: string
+        clientName: string
+        amount: number
+        currency: string
+        dueDate: Date
+        createdAt: Date
+        daysOverdue: number
+      }>()
+      const totals: Record<AgeingBucketKey, { count: number; amount: number }> = {
+        '1_30': { count: 0, amount: 0 },
+        '31_60': { count: 0, amount: 0 },
+        '61_90': { count: 0, amount: 0 },
+        '90_plus': { count: 0, amount: 0 },
+      }
+
+      for (const invoice of invoices) {
+        const daysOverdue = getDaysOverdueUtc(invoice.dueDate!, now)
+        const bucket = getAgeingBucket(daysOverdue)
+        const amount = Number(invoice.amount)
+        buckets[bucket].push({
+          ...invoice,
+          amount,
+          daysOverdue,
+        })
+        totals[bucket].count += 1
+        totals[bucket].amount += amount
+      }
+
+      return NextResponse.json({ buckets, totals })
+    }
+
+    const limit = Math.min(
+      100,
+      Math.max(1, Number.parseInt(searchParams.get('limit') || '25', 10) || 25),
+    )
+
+    const cursorParam = searchParams.get('cursor')
+    const decodedCursor = cursorParam ? decodeCursor(cursorParam) : null
+
+    if (cursorParam && !decodedCursor) {
+      return NextResponse.json({ error: 'Invalid cursor' }, { status: 400 })
+    }
+
+    const where = {
+      userId: user.id,
+      status: 'pending',
+      dueDate: { lt: now, not: null },
+      ...getArchiveFilter(includeArchived),
+      ...(decodedCursor
+        ? {
+            OR: [
+              { createdAt: { lt: new Date(decodedCursor.createdAt) } },
+              {
+                AND: [
+                  { createdAt: new Date(decodedCursor.createdAt) },
+                  { id: { lt: decodedCursor.id } },
+                ],
+              },
+            ],
+          }
+        : {}),
+    }
+
+    const invoices = await prisma.invoice.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        createdAt: true,
+      },
+    })
+
+    const hasNext = invoices.length > limit
+    const page = hasNext ? invoices.slice(0, limit) : invoices
+    const last = page[page.length - 1]
+
+    return NextResponse.json({
+      invoices: page.map((invoice) => ({
+        ...invoice,
+        amount: Number(invoice.amount),
+        daysOverdue: Math.floor(
+          (now.getTime() - invoice.dueDate!.getTime()) / (1000 * 60 * 60 * 24),
+        ),
+      })),
+      nextCursor:
+        hasNext && last
+          ? encodeCursor({
+              createdAt: last.createdAt.toISOString(),
+              id: last.id,
+            })
+          : null,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B invoice overdue GET error')
+    return NextResponse.json({ error: 'Failed to list overdue invoices' }, { status: 500 })
   }
-
-  const now = new Date()
-
-  const where = {
-    userId: user.id,
-    status: 'pending',
-    dueDate: { lt: now, not: null },
-    ...getArchiveFilter(includeArchived),
-    ...(decodedCursor
-      ? {
-          OR: [
-            { createdAt: { lt: new Date(decodedCursor.createdAt) } },
-            {
-              AND: [
-                { createdAt: new Date(decodedCursor.createdAt) },
-                { id: { lt: decodedCursor.id } },
-              ],
-            },
-          ],
-        }
-      : {}),
-  }
-
-  const invoices = await prisma.invoice.findMany({
-    where,
-    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-    take: limit + 1,
-    select: {
-      id: true,
-      invoiceNumber: true,
-      clientName: true,
-      amount: true,
-      currency: true,
-      dueDate: true,
-      createdAt: true,
-    },
-  })
-
-  const hasNext = invoices.length > limit
-  const page = hasNext ? invoices.slice(0, limit) : invoices
-  const last = page[page.length - 1]
-
-  return NextResponse.json({
-    invoices: page.map((invoice) => ({
-      ...invoice,
-      amount: Number(invoice.amount),
-      daysOverdue: Math.floor(
-        (now.getTime() - invoice.dueDate!.getTime()) / (1000 * 60 * 60 * 24)
-      ),
-    })),
-    nextCursor:
-      hasNext && last
-        ? encodeCursor({
-            createdAt: last.createdAt.toISOString(),
-            id: last.id,
-          })
-        : null,
-  })
 }
 
 export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/invoices/paid/route.ts
+++ b/app/api/routes-b/invoices/paid/route.ts
@@ -2,89 +2,99 @@ import { withRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { logger } from '@/lib/logger'
 import { getArchiveFilter, parseIncludeArchivedParam } from '../../_lib/invoice-archive'
 
 import { decodeCursor, encodeCursor } from '../../_lib/cursor'
 
 async function GETHandler(request: NextRequest) {
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
+
+    const limit = Math.min(
+      100,
+      Math.max(1, Number.parseInt(searchParams.get('limit') || '25', 10) || 25),
+    )
+
+    const cursorParam = searchParams.get('cursor')
+    const decodedCursor = cursorParam ? decodeCursor(cursorParam) : null
+
+    if (cursorParam && !decodedCursor) {
+      return NextResponse.json({ error: 'Invalid cursor' }, { status: 400 })
+    }
+
+    const where = {
+      userId: user.id,
+      status: 'paid',
+      ...getArchiveFilter(includeArchived),
+      ...(decodedCursor
+        ? {
+            OR: [
+              { createdAt: { lt: new Date(decodedCursor.createdAt) } },
+              {
+                AND: [
+                  { createdAt: new Date(decodedCursor.createdAt) },
+                  { id: { lt: decodedCursor.id } },
+                ],
+              },
+            ],
+          }
+        : {}),
+    }
+
+    const invoices = await prisma.invoice.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        clientName: true,
+        clientEmail: true,
+        amount: true,
+        currency: true,
+        paidAt: true,
+        createdAt: true,
+      },
+    })
+
+    const hasNext = invoices.length > limit
+    const page = hasNext ? invoices.slice(0, limit) : invoices
+    const last = page[page.length - 1]
+
+    return NextResponse.json({
+      invoices: page.map((invoice) => ({
+        ...invoice,
+        amount: Number(invoice.amount),
+      })),
+      nextCursor:
+        hasNext && last
+          ? encodeCursor({
+              createdAt: last.createdAt.toISOString(),
+              id: last.id,
+            })
+          : null,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B invoice paid GET error')
+    return NextResponse.json({ error: 'Failed to list paid invoices' }, { status: 500 })
   }
-
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
-
-  const { searchParams } = new URL(request.url)
-  const includeArchived = parseIncludeArchivedParam(searchParams.get('includeArchived'))
-
-  const limit = Math.min(
-    100,
-    Math.max(1, Number.parseInt(searchParams.get('limit') || '25', 10) || 25),
-  )
-
-  const cursorParam = searchParams.get('cursor')
-  const decodedCursor = cursorParam ? decodeCursor(cursorParam) : null
-
-  if (cursorParam && !decodedCursor) {
-    return NextResponse.json({ error: 'Invalid cursor' }, { status: 400 })
-  }
-
-  const where = {
-    userId: user.id,
-    status: 'paid',
-    ...getArchiveFilter(includeArchived),
-    ...(decodedCursor
-      ? {
-          OR: [
-            { createdAt: { lt: new Date(decodedCursor.createdAt) } },
-            {
-              AND: [
-                { createdAt: new Date(decodedCursor.createdAt) },
-                { id: { lt: decodedCursor.id } },
-              ],
-            },
-          ],
-        }
-      : {}),
-  }
-
-  const invoices = await prisma.invoice.findMany({
-    where,
-    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-    take: limit + 1,
-    select: {
-      id: true,
-      invoiceNumber: true,
-      clientName: true,
-      clientEmail: true,
-      amount: true,
-      currency: true,
-      paidAt: true,
-      createdAt: true,
-    },
-  })
-
-  const hasNext = invoices.length > limit
-  const page = hasNext ? invoices.slice(0, limit) : invoices
-  const last = page[page.length - 1]
-
-  return NextResponse.json({
-    invoices: page.map((invoice) => ({
-      ...invoice,
-      amount: Number(invoice.amount),
-    })),
-    nextCursor:
-      hasNext && last
-        ? encodeCursor({
-            createdAt: last.createdAt.toISOString(),
-            id: last.id,
-          })
-        : null,
-  })
 }
 
 export const GET = withRequestId(GETHandler)

--- a/app/api/routes-b/tests/issue-703-invoice-tags.test.ts
+++ b/app/api/routes-b/tests/issue-703-invoice-tags.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for issue #703 — GET,POST /api/routes-b/invoices/[id]/tags
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    tag: { findMany: vi.fn() },
+    invoiceTag: { findMany: vi.fn(), create: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, POST } from '../invoices/[id]/tags/route'
+
+const params = Promise.resolve({ id: 'inv-1' })
+
+function makeGetRequest(authHeader: string | null = 'Bearer token') {
+  return new NextRequest('http://localhost/api/routes-b/invoices/inv-1/tags', {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+function makePostRequest(body: unknown, authHeader: string | null = 'Bearer token') {
+  return new NextRequest('http://localhost/api/routes-b/invoices/inv-1/tags', {
+    method: 'POST',
+    headers: {
+      ...(authHeader ? { authorization: authHeader } : {}),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('GET /api/routes-b/invoices/[id]/tags (#703)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null as never)
+    const res = await GET(makeGetRequest(), { params })
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns 404 when invoice does not exist', async () => {
+    vi.mocked(prisma.invoice.findUnique).mockResolvedValue(null as never)
+    const res = await GET(makeGetRequest(), { params })
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Invoice not found' })
+  })
+
+  it('returns 403 when invoice belongs to another user', async () => {
+    vi.mocked(prisma.invoice.findUnique).mockResolvedValue({ id: 'inv-1', userId: 'user-2' } as never)
+    const res = await GET(makeGetRequest(), { params })
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Forbidden' })
+  })
+
+  it('returns tags attached to the invoice', async () => {
+    vi.mocked(prisma.invoice.findUnique).mockResolvedValue({ id: 'inv-1', userId: 'user-1' } as never)
+    vi.mocked(prisma.invoiceTag.findMany).mockResolvedValue([
+      { tag: { id: 'tag-1', name: 'Priority', color: '#ff0000' } },
+    ] as never)
+
+    const res = await GET(makeGetRequest(), { params })
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      tags: [{ id: 'tag-1', name: 'Priority', color: '#ff0000' }],
+    })
+  })
+})
+
+describe('POST /api/routes-b/invoices/[id]/tags (#703)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    vi.mocked(prisma.invoice.findUnique).mockResolvedValue({ id: 'inv-1', userId: 'user-1' } as never)
+  })
+
+  it('returns 400 for invalid tagIds payload', async () => {
+    const res = await POST(makePostRequest({ tagIds: [''] }), { params })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'tagIds must be a non-empty string array' })
+  })
+
+  it('returns 403 when attaching tags owned by another user', async () => {
+    vi.mocked(prisma.tag.findMany).mockResolvedValue([
+      { id: 'tag-1', name: 'Other', color: '#000', userId: 'user-2' },
+    ] as never)
+
+    const res = await POST(makePostRequest({ tagIds: ['tag-1'] }), { params })
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Foreign tags are not allowed' })
+  })
+
+  it('attaches owned tags to the invoice', async () => {
+    vi.mocked(prisma.tag.findMany).mockResolvedValue([
+      { id: 'tag-1', name: 'Alpha', color: '#111', userId: 'user-1' },
+      { id: 'tag-2', name: 'Beta', color: '#222', userId: 'user-1' },
+    ] as never)
+    vi.mocked(prisma.invoiceTag.create).mockResolvedValue({} as never)
+
+    const res = await POST(makePostRequest({ tagIds: ['tag-1', 'tag-2'] }), { params })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body).toEqual({
+      invoiceId: 'inv-1',
+      attachedTagIds: ['tag-1', 'tag-2'],
+      createdTagIds: ['tag-1', 'tag-2'],
+    })
+    expect(prisma.invoiceTag.create).toHaveBeenCalledTimes(2)
+  })
+})

--- a/app/api/routes-b/tests/issue-705-invoice-overdue.test.ts
+++ b/app/api/routes-b/tests/issue-705-invoice-overdue.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for issue #705 — GET /api/routes-b/invoices/overdue
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../invoices/overdue/route'
+
+const BASE_URL = 'http://localhost/api/routes-b/invoices/overdue'
+const THREE_DAYS_AGO = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+
+function makeRequest(query = '', authHeader: string | null = 'Bearer token') {
+  return new NextRequest(`${BASE_URL}${query}`, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('GET /api/routes-b/invoices/overdue (#705)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+  })
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await GET(makeRequest('', null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid token' })
+  })
+
+  it('returns 404 when user does not exist', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'User not found' })
+  })
+
+  it('returns paginated overdue invoices with daysOverdue', async () => {
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([
+      {
+        id: 'inv-1',
+        invoiceNumber: 'INV-001',
+        clientName: 'Acme',
+        amount: '100',
+        currency: 'USDC',
+        dueDate: THREE_DAYS_AGO,
+        createdAt: THREE_DAYS_AGO,
+      },
+    ] as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.invoices).toHaveLength(1)
+    expect(body.invoices[0].daysOverdue).toBeGreaterThanOrEqual(2)
+    expect(body.invoices[0].amount).toBe(100)
+    expect(prisma.invoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'user-1',
+          status: 'pending',
+          dueDate: expect.objectContaining({ lt: expect.any(Date), not: null }),
+        }),
+      }),
+    )
+  })
+
+  it('returns bucketed ageing response when bucketed=true', async () => {
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([] as never)
+
+    const res = await GET(makeRequest('?bucketed=true'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(Object.keys(body.buckets)).toEqual(['1_30', '31_60', '61_90', '90_plus'])
+    expect(body.buckets['1_30']).toEqual([])
+    expect(body.totals['90_plus']).toEqual({ count: 0, amount: 0 })
+  })
+
+  it('returns 500 on unexpected database error', async () => {
+    vi.mocked(prisma.invoice.findMany).mockRejectedValue(new Error('DB failure') as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to list overdue invoices' })
+  })
+})

--- a/app/api/routes-b/tests/issue-706-invoice-paid.test.ts
+++ b/app/api/routes-b/tests/issue-706-invoice-paid.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for issue #706 — GET /api/routes-b/invoices/paid
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../invoices/paid/route'
+
+const BASE_URL = 'http://localhost/api/routes-b/invoices/paid'
+
+function makeRequest(query = '', authHeader: string | null = 'Bearer token') {
+  return new NextRequest(`${BASE_URL}${query}`, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('GET /api/routes-b/invoices/paid (#706)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await GET(makeRequest('', null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid token' })
+  })
+
+  it('returns 404 when user does not exist', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'User not found' })
+  })
+
+  it('returns 400 for an invalid cursor', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    const res = await GET(makeRequest('?cursor=not-valid'))
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid cursor' })
+  })
+
+  it('returns paid invoices scoped to the authenticated user', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    const paidAt = new Date('2026-01-15T00:00:00.000Z')
+    vi.mocked(prisma.invoice.findMany).mockResolvedValue([
+      {
+        id: 'inv-1',
+        invoiceNumber: 'INV-001',
+        clientName: 'Acme',
+        clientEmail: 'acme@example.com',
+        amount: '250.50',
+        currency: 'USDC',
+        paidAt,
+        createdAt: paidAt,
+      },
+    ] as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.invoices).toHaveLength(1)
+    expect(body.invoices[0]).toMatchObject({
+      id: 'inv-1',
+      invoiceNumber: 'INV-001',
+      amount: 250.5,
+    })
+    expect(body.nextCursor).toBeNull()
+    expect(prisma.invoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: 'user-1', status: 'paid' }),
+      }),
+    )
+  })
+
+  it('returns 500 on unexpected database error', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    vi.mocked(prisma.invoice.findMany).mockRejectedValue(new Error('DB failure') as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to list paid invoices' })
+  })
+})

--- a/app/api/routes-b/tests/issue-709-invoice-summary.test.ts
+++ b/app/api/routes-b/tests/issue-709-invoice-summary.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for issue #709 — GET /api/routes-b/invoices/summary
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { groupBy: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET } from '../invoices/summary/route'
+
+const BASE_URL = 'http://localhost/api/routes-b/invoices/summary'
+
+function makeRequest(authHeader: string | null = 'Bearer token') {
+  return new NextRequest(BASE_URL, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  })
+}
+
+describe('GET /api/routes-b/invoices/summary (#709)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 401 when authorization header is missing', async () => {
+    const res = await GET(makeRequest(null))
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+    expect(verifyAuthToken).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid token' })
+  })
+
+  it('returns 404 when user does not exist', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null as never)
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'User not found' })
+    expect(prisma.invoice.groupBy).not.toHaveBeenCalled()
+  })
+
+  it('returns status summary with all known statuses for authenticated user', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    vi.mocked(prisma.invoice.groupBy).mockResolvedValue([
+      { status: 'paid', _count: { id: 2 }, _sum: { amount: 150 } },
+      { status: 'pending', _count: { id: 1 }, _sum: { amount: 50 } },
+    ] as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.summary).toEqual([
+      { status: 'pending', count: 1, total: 50 },
+      { status: 'paid', count: 2, total: 150 },
+      { status: 'cancelled', count: 0, total: 0 },
+      { status: 'overdue', count: 0, total: 0 },
+    ])
+    expect(prisma.invoice.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'user-1' } }),
+    )
+  })
+
+  it('returns 500 on unexpected database error', async () => {
+    vi.mocked(verifyAuthToken).mockResolvedValue({ userId: 'privy-1' } as never)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: 'user-1' } as never)
+    vi.mocked(prisma.invoice.groupBy).mockRejectedValue(new Error('DB failure') as never)
+
+    const res = await GET(makeRequest())
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to get invoice summary' })
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for GET `/api/routes-b/invoices/summary` covering auth failures, user lookup, status aggregation, and database errors.
- Harden GET `/api/routes-b/invoices/paid` with explicit bearer validation, structured error handling, and unit tests for auth, cursor validation, scoped listing, and failures.
- Extend GET `/api/routes-b/invoices/overdue` with `bucketed=true` ageing buckets, structured error handling, and unit tests for pagination, bucketed mode, and failures.
- Add unit tests for GET and POST `/api/routes-b/invoices/[id]/tags` covering ownership checks, validation, and tag attachment.

## Verification
- Ran targeted Vitest: `npx vitest run --config app/api/routes-b/tests/vitest.config.ts app/api/routes-b/tests/issue-709-invoice-summary.test.ts app/api/routes-b/tests/issue-706-invoice-paid.test.ts app/api/routes-b/tests/issue-705-invoice-overdue.test.ts app/api/routes-b/tests/issue-703-invoice-tags.test.ts app/api/routes-b/tests/ageing.test.ts` — 26 tests passed.

Closes #709
Closes #706
Closes #705
Closes #703

Made with [Cursor](https://cursor.com)