### PR TITLE
feat(routes-b): add GET /api/routes-b/invoices/[id]/pdf for invoice PDF download

### DIFF
--- a/app/api/routes-b/invoices/[id]/pdf/__tests__/route.test.ts
+++ b/app/api/routes-b/invoices/[id]/pdf/__tests__/route.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@react-pdf/renderer', () => ({
+  renderToStream: vi.fn(),
+}))
+vi.mock('@/lib/pdf', () => ({
+  InvoicePDF: vi.fn(() => null),
+}))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    brandingSettings: { findUnique: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { renderToStream } from '@react-pdf/renderer'
+import { GET } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+const mockedBrandingFind = vi.mocked(prisma.brandingSettings.findUnique)
+const mockedRenderToStream = vi.mocked(renderToStream)
+
+const invoiceId = '550e8400-e29b-41d4-a716-446655440000'
+const otherUserId = '660e8400-e29b-41d4-a716-446655440001'
+
+const baseInvoice = {
+  id: invoiceId,
+  userId: 'user-1',
+  invoiceNumber: 'INV-100',
+  clientEmail: 'client@example.com',
+  clientName: 'ACME',
+  description: 'Design work',
+  amount: 250,
+  currency: 'USD',
+  status: 'pending',
+  paymentLink: 'https://pay.example/inv-100',
+  dueDate: null,
+  paidAt: null,
+  createdAt: new Date('2026-01-15T00:00:00.000Z'),
+}
+
+function makeGET(id = invoiceId, auth = true): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/invoices/${id}/pdf`, {
+    method: 'GET',
+    headers: auth ? { authorization: 'Bearer token' } : {},
+  })
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('GET /api/routes-b/invoices/[id]/pdf', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({
+      id: 'user-1',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+    } as never)
+    mockedBrandingFind.mockResolvedValue(null)
+    mockedRenderToStream.mockResolvedValue(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([37, 80, 68, 70]))
+          controller.close()
+        },
+      }) as never,
+    )
+  })
+
+  it('returns a PDF attachment for an owned invoice', async () => {
+    mockedInvoiceFind.mockResolvedValue(baseInvoice as never)
+
+    const res = await GET(makeGET(), makeParams(invoiceId))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/pdf')
+    expect(res.headers.get('Content-Disposition')).toBe(
+      'attachment; filename="invoice-INV-100.pdf"',
+    )
+    expect(mockedRenderToStream).toHaveBeenCalledTimes(1)
+    expect(mockedInvoiceFind).toHaveBeenCalledWith({
+      where: { id: invoiceId },
+      select: expect.objectContaining({ invoiceNumber: true, userId: true }),
+    })
+  })
+
+  it('returns 401 when authorization is missing', async () => {
+    const res = await GET(makeGET(invoiceId, false), makeParams(invoiceId))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when the auth token is invalid', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+
+    const res = await GET(makeGET(), makeParams(invoiceId))
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-UUID invoice id', async () => {
+    const res = await GET(makeGET('not-a-uuid'), makeParams('not-a-uuid'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields?.id).toBe('Must be a valid UUID')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null)
+
+    const res = await GET(makeGET(), makeParams(invoiceId))
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('Invoice not found')
+  })
+
+  it('returns 404 when the invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      ...baseInvoice,
+      userId: otherUserId,
+    } as never)
+
+    const res = await GET(makeGET(), makeParams(invoiceId))
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('Invoice not found')
+    expect(mockedRenderToStream).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when PDF rendering fails', async () => {
+    mockedInvoiceFind.mockResolvedValue(baseInvoice as never)
+    mockedRenderToStream.mockRejectedValue(new Error('render failed'))
+
+    const res = await GET(makeGET(), makeParams(invoiceId))
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL')
+    expect(body.error.message).toBe('Failed to generate PDF')
+  })
+})

--- a/app/api/routes-b/invoices/[id]/pdf/route.ts
+++ b/app/api/routes-b/invoices/[id]/pdf/route.ts
@@ -1,87 +1,128 @@
 import { withRequestId } from '../../../_lib/with-request-id'
+import { withMethods } from '../../../_lib/with-methods'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { checkResourceOwnership } from '../../../_lib/access-control'
+import { errorResponse } from '../../../_lib/errors'
+import { registerRoute } from '../../../_lib/openapi'
 import { renderToStream } from '@react-pdf/renderer'
 import type { DocumentProps } from '@react-pdf/renderer'
 import { InvoicePDF } from '@/lib/pdf'
+import { logger } from '@/lib/logger'
 import React from 'react'
+import { z } from 'zod'
 
 export const runtime = 'nodejs'
+
+const invoiceIdParamsSchema = z.object({
+  id: z.string().uuid('Invoice id must be a valid UUID'),
+})
+
+registerRoute({
+  method: 'GET',
+  path: '/invoices/{id}/pdf',
+  summary: 'Download invoice PDF',
+  description: 'Generate and download a PDF for an invoice owned by the authenticated user.',
+  requestSchema: invoiceIdParamsSchema,
+  responseSchema: z.any(),
+  tags: ['invoices'],
+})
 
 async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
+  try {
+    const { id } = await params
+    const parsedParams = invoiceIdParamsSchema.safeParse({ id })
+    if (!parsedParams.success) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Must be a valid UUID' } },
+        400,
+      )
+    }
 
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401)
+    }
 
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401)
+    }
 
-  const invoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      userId: true,
-      invoiceNumber: true,
-      clientEmail: true,
-      clientName: true,
-      description: true,
-      amount: true,
-      currency: true,
-      status: true,
-      paymentLink: true,
-      dueDate: true,
-      paidAt: true,
-      createdAt: true,
-    },
-  })
+    const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
+    if (!user) {
+      return errorResponse('NOT_FOUND', 'User not found', undefined, 404)
+    }
 
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  if (invoice.userId !== user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  const branding = await prisma.brandingSettings.findUnique({ where: { userId: user.id } })
-
-  const stream = await renderToStream(
-    React.createElement(InvoicePDF, {
-      invoice: {
-        invoiceNumber: invoice.invoiceNumber,
-        freelancerName: user.name || user.email,
-        freelancerEmail: user.email,
-        clientName: invoice.clientName || 'Client',
-        clientEmail: invoice.clientEmail,
-        description: invoice.description,
-        amount: Number(invoice.amount),
-        currency: invoice.currency,
-        status: invoice.status,
-        dueDate: invoice.dueDate ? invoice.dueDate.toISOString() : null,
-        createdAt: invoice.createdAt.toISOString(),
-        paidAt: invoice.paidAt ? invoice.paidAt.toISOString() : null,
-        paymentLink: invoice.paymentLink,
+    const invoice = await prisma.invoice.findUnique({
+      where: { id: parsedParams.data.id },
+      select: {
+        id: true,
+        userId: true,
+        invoiceNumber: true,
+        clientEmail: true,
+        clientName: true,
+        description: true,
+        amount: true,
+        currency: true,
+        status: true,
+        paymentLink: true,
+        dueDate: true,
+        paidAt: true,
+        createdAt: true,
       },
-      branding: branding ?? undefined,
-    }) as unknown as React.ReactElement<DocumentProps>,
-  )
+    })
 
-  return new NextResponse(stream as unknown as ReadableStream, {
-    headers: {
-      'Content-Type': 'application/pdf',
-      'Content-Disposition': `attachment; filename="invoice-${invoice.invoiceNumber}.pdf"`,
-    },
-  })
+    if (!invoice) {
+      return errorResponse('NOT_FOUND', 'Invoice not found', undefined, 404)
+    }
+
+    const accessCheck = checkResourceOwnership(invoice.userId, user.id)
+    if (accessCheck) {
+      return errorResponse('NOT_FOUND', 'Invoice not found', undefined, 404)
+    }
+
+    const branding = await prisma.brandingSettings.findUnique({ where: { userId: user.id } })
+
+    const stream = await renderToStream(
+      React.createElement(InvoicePDF, {
+        invoice: {
+          invoiceNumber: invoice.invoiceNumber,
+          freelancerName: user.name || user.email,
+          freelancerEmail: user.email,
+          clientName: invoice.clientName || 'Client',
+          clientEmail: invoice.clientEmail,
+          description: invoice.description,
+          amount: Number(invoice.amount),
+          currency: invoice.currency,
+          status: invoice.status,
+          dueDate: invoice.dueDate ? invoice.dueDate.toISOString() : null,
+          createdAt: invoice.createdAt.toISOString(),
+          paidAt: invoice.paidAt ? invoice.paidAt.toISOString() : null,
+          paymentLink: invoice.paymentLink,
+        },
+        branding: branding ?? undefined,
+      }) as unknown as React.ReactElement<DocumentProps>,
+    )
+
+    return new NextResponse(stream as unknown as ReadableStream, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="invoice-${invoice.invoiceNumber}.pdf"`,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to generate invoice PDF')
+    return errorResponse('INTERNAL', 'Failed to generate PDF', undefined, 500)
+  }
 }
 
-export const GET = withRequestId(GETHandler)
+export const { GET } = withMethods({
+  GET: withRequestId(GETHandler),
+})


### PR DESCRIPTION
Summary
Add GET /api/routes-b/invoices/[id]/pdf to generate and download an invoice PDF for the authenticated owner.
Validate the invoice id as a UUID, enforce Bearer auth, and apply ownership checks (cross-user access returns NOT_FOUND).
Return structured errors via errorResponse and stream the PDF with Content-Type: application/pdf and an attachment Content-Disposition header.
Register the route in OpenAPI and add unit tests for the happy path and main failure modes (401, 400, 404, 500).


Closes #698