### PR TITLE
feat(routes-b): GET transactions/[id] and POST notifications/mark-all-read (#719, #710)

### DIFF
--- a/app/api/routes-b/notifications/__tests__/mark-all-read-rate-limit.test.ts
+++ b/app/api/routes-b/notifications/__tests__/mark-all-read-rate-limit.test.ts
@@ -62,6 +62,11 @@ describe('POST /api/routes-b/notifications/mark-all-read rate limit', () => {
 
     expect(res.status).toBe(429)
     expect(res.headers.get('Retry-After')).toBe('60')
+    const json = await res.json()
+    expect(json.error).toMatchObject({
+      code: 'RATE_LIMITED',
+      message: 'Too many requests',
+    })
     expect(mockedUpdateMany).toHaveBeenCalledTimes(5)
   })
 

--- a/app/api/routes-b/notifications/mark-all-read/__tests__/route.test.ts
+++ b/app/api/routes-b/notifications/mark-all-read/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('../../../_lib/notification-cache', () => ({
+  bustUnreadCountCache: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    notification: { updateMany: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { bustUnreadCountCache } from '../../../_lib/notification-cache'
+import { POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedUpdateMany = vi.mocked(prisma.notification.updateMany)
+const mockedBustCache = vi.mocked(bustUnreadCountCache)
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('http://localhost/api/routes-b/notifications/mark-all-read', {
+    method: 'POST',
+    headers: { authorization: 'Bearer token', ...headers },
+  })
+}
+
+describe('POST /api/routes-b/notifications/mark-all-read', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+    mockedUpdateMany.mockResolvedValue({ count: 4 } as never)
+  })
+
+  it('marks unread notifications and returns the updated count', async () => {
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ updated: 4 })
+    expect(mockedUpdateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1', isRead: false },
+      data: { isRead: true },
+    })
+    expect(mockedBustCache).toHaveBeenCalledWith('user-1')
+  })
+
+  it('returns 401 without an authorization header', async () => {
+    const res = await POST(
+      new NextRequest('http://localhost/api/routes-b/notifications/mark-all-read', {
+        method: 'POST',
+      }),
+    )
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'UNAUTHORIZED', message: 'Unauthorized' })
+  })
+
+  it('returns 401 when the token is invalid', async () => {
+    mockedVerify.mockResolvedValueOnce(null as never)
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'UNAUTHORIZED', message: 'Invalid token' })
+  })
+
+  it('returns 404 when the user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValueOnce(null as never)
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'NOT_FOUND', message: 'User not found' })
+  })
+
+  it('returns structured error on unexpected failure', async () => {
+    mockedUpdateMany.mockRejectedValueOnce(new Error('database unavailable'))
+    const res = await POST(makeRequest({ 'x-request-id': 'req-error-2' }))
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toMatchObject({
+      code: 'INTERNAL',
+      message: 'Failed to mark notifications as read',
+    })
+    expect(json.requestId).toBeTruthy()
+  })
+})

--- a/app/api/routes-b/notifications/mark-all-read/route.ts
+++ b/app/api/routes-b/notifications/mark-all-read/route.ts
@@ -1,45 +1,65 @@
-import { withRequestId } from '../../_lib/with-request-id'
+import { withRequestId, getRequestId } from '../../_lib/with-request-id'
+import { withMethods } from '../../_lib/with-methods'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { checkRateLimit } from '../../_lib/rate-limit'
 import { bustUnreadCountCache } from '../../_lib/notification-cache'
+import { errorResponse } from '../../_lib/errors'
+import { logger } from '@/lib/logger'
 
 async function POSTHandler(request: NextRequest) {
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const requestId = getRequestId()
 
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return errorResponse('UNAUTHORIZED', 'Unauthorized', { requestId }, 401)
+    }
 
-  const rateLimit = checkRateLimit(`notifications:mark-all-read:${user.id}`, {
-    limit: 5,
-    windowMs: 60_000,
-  })
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return errorResponse('UNAUTHORIZED', 'Invalid token', { requestId }, 401)
+    }
 
-  if (!rateLimit.allowed) {
-    return NextResponse.json(
-      { error: 'Too many requests' },
-      {
-        status: 429,
-        headers: { 'Retry-After': String(rateLimit.retryAfter) },
-      },
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true },
+    })
+    if (!user) {
+      return errorResponse('NOT_FOUND', 'User not found', { requestId }, 404)
+    }
+
+    const rateLimit = checkRateLimit(`notifications:mark-all-read:${user.id}`, {
+      limit: 5,
+      windowMs: 60_000,
+    })
+
+    if (!rateLimit.allowed) {
+      const response = errorResponse('RATE_LIMITED', 'Too many requests', { requestId }, 429)
+      response.headers.set('Retry-After', String(rateLimit.retryAfter))
+      return response
+    }
+
+    const result = await prisma.notification.updateMany({
+      where: { userId: user.id, isRead: false },
+      data: { isRead: true },
+    })
+
+    bustUnreadCountCache(user.id)
+
+    return NextResponse.json({ updated: result.count })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B notifications/mark-all-read POST error')
+    return errorResponse(
+      'INTERNAL',
+      'Failed to mark notifications as read',
+      { requestId },
+      500,
     )
   }
-
-  const result = await prisma.notification.updateMany({
-    where: { userId: user.id, isRead: false },
-    data: { isRead: true },
-  })
-
-  bustUnreadCountCache(user.id)
-
-  return NextResponse.json({ updated: result.count })
 }
 
-export const POST = withRequestId(POSTHandler)
+export const { POST } = withMethods({
+  POST: withRequestId(POSTHandler),
+})

--- a/app/api/routes-b/transactions/[id]/__tests__/route.test.ts
+++ b/app/api/routes-b/transactions/[id]/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mockVerifyAuthToken = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: mockVerifyAuthToken }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    transaction: { findUnique: vi.fn() },
+  },
+}))
+
+import { prisma } from '@/lib/db'
+import { GET } from '../route'
+
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedTxFind = vi.mocked(prisma.transaction.findUnique)
+
+const TX_ID = '11111111-1111-7111-8111-111111111111'
+
+function makeGET(id = TX_ID, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/transactions/${id}`, {
+    method: 'GET',
+    headers: { authorization: 'Bearer token', ...headers },
+  })
+}
+
+describe('GET /api/routes-b/transactions/[id]', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockVerifyAuthToken.mockResolvedValue({ userId: 'privy-1' })
+    mockedUserFind.mockResolvedValue({ id: 'user-1' } as never)
+  })
+
+  it('returns the transaction for its owner', async () => {
+    mockedTxFind.mockResolvedValue({
+      id: TX_ID,
+      userId: 'user-1',
+      type: 'payment',
+      status: 'completed',
+      amount: 250,
+      currency: 'USDC',
+      error: null,
+      txHash: 'stellar-hash',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      invoice: { invoiceNumber: 'INV-42' },
+    } as never)
+
+    const res = await GET(makeGET(), { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.transaction).toEqual({
+      id: TX_ID,
+      type: 'payment',
+      status: 'completed',
+      amount: 250,
+      currency: 'USDC',
+      description: 'Invoice INV-42 paid',
+      stellarTxHash: 'stellar-hash',
+      createdAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+    })
+  })
+
+  it('returns 401 when auth token is missing', async () => {
+    const req = new NextRequest(`http://localhost/api/routes-b/transactions/${TX_ID}`, {
+      method: 'GET',
+    })
+    const res = await GET(req, { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'UNAUTHORIZED', message: 'Unauthorized' })
+  })
+
+  it('returns 401 when auth token is invalid', async () => {
+    mockVerifyAuthToken.mockResolvedValueOnce(null)
+    const res = await GET(makeGET(), { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'UNAUTHORIZED', message: 'Invalid token' })
+  })
+
+  it('returns 404 when user is not found', async () => {
+    mockedUserFind.mockResolvedValueOnce(null)
+    const res = await GET(makeGET(), { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'NOT_FOUND', message: 'User not found' })
+  })
+
+  it('returns 404 when the transaction does not exist', async () => {
+    mockedTxFind.mockResolvedValueOnce(null)
+    const res = await GET(makeGET(), { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'NOT_FOUND', message: 'Transaction not found' })
+  })
+
+  it('returns 404 when the transaction belongs to another user', async () => {
+    mockedTxFind.mockResolvedValue({
+      id: TX_ID,
+      userId: 'user-2',
+      type: 'payment',
+      status: 'completed',
+      amount: 100,
+      currency: 'USDC',
+      error: null,
+      txHash: null,
+      createdAt: new Date(),
+      invoice: null,
+    } as never)
+
+    const res = await GET(makeGET(), { params: Promise.resolve({ id: TX_ID }) })
+    expect(res.status).toBe(404)
+    const json = await res.json()
+    expect(json.error).toMatchObject({ code: 'NOT_FOUND', message: 'Transaction not found' })
+  })
+
+  it('returns 400 for an invalid transaction id', async () => {
+    const res = await GET(makeGET('not-a-uuid'), { params: Promise.resolve({ id: 'not-a-uuid' }) })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Invalid transaction id',
+      fields: { id: 'Must be a valid UUID' },
+    })
+  })
+
+  it('returns structured error on unexpected failure', async () => {
+    mockedUserFind.mockRejectedValueOnce(new Error('database unavailable'))
+    const res = await GET(makeGET('tx-1', { 'x-request-id': 'req-error-1' }), {
+      params: Promise.resolve({ id: TX_ID }),
+    })
+    expect(res.status).toBe(500)
+    const json = await res.json()
+    expect(json.error).toMatchObject({
+      code: 'INTERNAL',
+      message: 'Failed to fetch transaction',
+    })
+    expect(json.requestId).toBeTruthy()
+  })
+})

--- a/app/api/routes-b/transactions/[id]/route.ts
+++ b/app/api/routes-b/transactions/[id]/route.ts
@@ -1,55 +1,105 @@
-import { withRequestId } from '../../_lib/with-request-id'
-import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/db";
-import { verifyAuthToken } from "@/lib/auth";
-import { checkResourceOwnership } from '../../_lib/access-control'
+import { withRequestId, getRequestId } from '../../_lib/with-request-id'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { verifyAuthToken } from '@/lib/auth'
+import { errorResponse } from '../../_lib/errors'
+import { logger } from '@/lib/logger'
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function transactionDescription(transaction: {
+  type: string
+  error: string | null
+  invoice: { invoiceNumber: string } | null
+}) {
+  if (transaction.invoice?.invoiceNumber) {
+    return `Invoice ${transaction.invoice.invoiceNumber} paid`
+  }
+  if (transaction.type === 'withdrawal') {
+    return transaction.error ?? 'Withdrawal initiated'
+  }
+  return transaction.error ?? 'Transaction recorded'
+}
 
 async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params;
-  const authToken = request.headers
-    .get("authorization")
-    ?.replace("Bearer ", "");
-  if (!authToken)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const requestId = getRequestId()
 
-  const claims = await verifyAuthToken(authToken);
-  if (!claims)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+    if (!authToken) {
+      return errorResponse('UNAUTHORIZED', 'Unauthorized', { requestId }, 401)
+    }
 
-  const user = await prisma.user.findUnique({
-    where: { privyId: claims.userId },
-  });
-  if (!user)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const claims = await verifyAuthToken(authToken)
+    if (!claims) {
+      return errorResponse('UNAUTHORIZED', 'Invalid token', { requestId }, 401)
+    }
 
-  const transaction = await prisma.transaction.findUnique({
-    where: { id },
-  });
+    const user = await prisma.user.findUnique({
+      where: { privyId: claims.userId },
+      select: { id: true },
+    })
+    if (!user) {
+      return errorResponse('NOT_FOUND', 'User not found', { requestId }, 404)
+    }
 
-  if (!transaction)
-    return NextResponse.json(
-      { error: "Transaction not found" },
-      { status: 404 },
-    );
+    const { id } = await params
+    if (!id?.trim()) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid transaction id',
+        { fields: { id: 'Transaction id is required' }, requestId },
+        400,
+      )
+    }
 
-  const accessCheck = checkResourceOwnership(transaction.userId, user.id);
-  if (accessCheck) return accessCheck;
+    if (!UUID_PATTERN.test(id)) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid transaction id',
+        { fields: { id: 'Must be a valid UUID' }, requestId },
+        400,
+      )
+    }
 
-  return NextResponse.json({
-    transaction: {
-      id: transaction.id,
-      type: transaction.type,
-      status: transaction.status,
-      amount: Number(transaction.amount),
-      currency: transaction.currency,
-      description: transaction.error ?? null,
-      stellarTxHash: transaction.txHash ?? null,
-      createdAt: transaction.createdAt,
-    },
-  });
+    const transaction = await prisma.transaction.findUnique({
+      where: { id },
+      include: {
+        invoice: {
+          select: { invoiceNumber: true },
+        },
+      },
+    })
+
+    if (!transaction || transaction.userId !== user.id) {
+      return errorResponse('NOT_FOUND', 'Transaction not found', { requestId }, 404)
+    }
+
+    return NextResponse.json({
+      transaction: {
+        id: transaction.id,
+        type: transaction.type,
+        status: transaction.status,
+        amount: Number(transaction.amount),
+        currency: transaction.currency,
+        description: transactionDescription(transaction),
+        stellarTxHash: transaction.txHash ?? null,
+        createdAt: transaction.createdAt,
+      },
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B transactions/[id] GET error')
+    return errorResponse(
+      'INTERNAL',
+      'Failed to fetch transaction',
+      { requestId },
+      500,
+    )
+  }
 }
 
 export const GET = withRequestId(GETHandler)


### PR DESCRIPTION
## Summary

Implements and hardens two routes-b endpoints requested in upstream issues:

- **#719** — `GET /api/routes-b/transactions/[id]` — fetch a single transaction for the authenticated user
- **#710** — `POST /api/routes-b/notifications/mark-all-read` — bulk-mark all unread notifications as read

Both handlers now follow existing routes-b conventions: Privy bearer auth, ownership scoping, structured error envelopes (`error.code` + `requestId`), and Vitest coverage for happy paths and failure modes.

## Changes

### `GET /api/routes-b/transactions/[id]` (#719)

- Structured errors via `errorResponse` (`UNAUTHORIZED`, `NOT_FOUND`, `BAD_REQUEST`, `INTERNAL`)
- UUID validation on the path `id` parameter
- Ownership enforced by returning `404` for missing or cross-user transactions (anti-enumeration)
- Transaction `description` aligned with the list endpoint (invoice number, withdrawal text, fallback copy)
- Includes invoice relation for payment descriptions
- Unit tests: auth, not found, cross-user, invalid id, happy path, internal error

### `POST /api/routes-b/notifications/mark-all-read` (#710)

- Structured errors for auth, user resolution, rate limiting, and unexpected failures
- `withMethods` wrapper for method routing
- Preserves existing behavior: `updateMany` on unread rows, `bustUnreadCountCache`, 5 req/min rate limit with `Retry-After`
- Success response: `{ updated: number }`
- Unit tests: happy path, missing/invalid auth, user not found, internal error
- Rate-limit test updated for `RATE_LIMITED` structured error body

## Test plan

- [x] `npx vitest run app/api/routes-b/transactions/[id]/__tests__/route.test.ts`
- [x] `npx vitest run app/api/routes-b/notifications/mark-all-read/__tests__/route.test.ts`
- [x] `npx vitest run app/api/routes-b/notifications/__tests__/mark-all-read-rate-limit.test.ts`

Closes #719
Closes #710

Made with [Cursor](https://cursor.com)