### PR TITLE
Implement routes-b invoice fetch and update endpoint

### DIFF
--- a/app/api/routes-b/invoices/[id]/__tests__/etag-concurrency.test.ts
+++ b/app/api/routes-b/invoices/[id]/__tests__/etag-concurrency.test.ts
@@ -5,8 +5,8 @@ import { createEntityEtag } from '@/app/api/routes-b/_lib/etag'
 const verifyAuthToken = vi.fn()
 const userFindUnique = vi.fn()
 const invoiceFindUnique = vi.fn()
-const invoiceFindFirst = vi.fn()
 const invoiceUpdate = vi.fn()
+const loggerError = vi.fn()
 
 vi.mock('@/lib/auth', () => ({ verifyAuthToken }))
 vi.mock('@/lib/db', () => ({
@@ -14,10 +14,12 @@ vi.mock('@/lib/db', () => ({
     user: { findUnique: userFindUnique },
     invoice: {
       findUnique: invoiceFindUnique,
-      findFirst: invoiceFindFirst,
       update: invoiceUpdate,
     },
   },
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { error: loggerError },
 }))
 
 describe('routes-b invoice ETag + If-Match', () => {
@@ -67,8 +69,9 @@ describe('routes-b invoice ETag + If-Match', () => {
   })
 
   it('PATCH returns 412 for stale If-Match', async () => {
-    invoiceFindFirst.mockResolvedValue({
+    invoiceFindUnique.mockResolvedValue({
       id: 'inv_1',
+      userId: 'user_1',
       status: 'pending',
       updatedAt: new Date('2026-02-01T10:00:00.000Z'),
     })
@@ -84,12 +87,16 @@ describe('routes-b invoice ETag + If-Match', () => {
     })
     const response = await PATCH(request, { params: Promise.resolve({ id: 'inv_1' }) })
     expect(response.status).toBe(412)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'CONFLICT', message: 'ETag mismatch' },
+    })
   })
 
   it('PATCH succeeds with matching If-Match', async () => {
     const updatedAt = new Date('2026-02-01T10:00:00.000Z')
-    invoiceFindFirst.mockResolvedValue({
+    invoiceFindUnique.mockResolvedValue({
       id: 'inv_1',
+      userId: 'user_1',
       status: 'pending',
       updatedAt,
     })
@@ -120,14 +127,18 @@ describe('routes-b invoice ETag + If-Match', () => {
       body: JSON.stringify({ description: 'updated' }),
     })
     const response = await PATCH(request, { params: Promise.resolve({ id: 'inv_1' }) })
+    const json = await response.json()
+
     expect(response.status).toBe(200)
+    expect(json.invoice).toMatchObject({ id: 'inv_1', description: 'updated', amount: 120 })
     expect(invoiceUpdate).toHaveBeenCalledOnce()
   })
 
   it('PATCH allows If-Match:* for admin users', async () => {
     userFindUnique.mockResolvedValue({ id: 'user_1', role: 'admin' })
-    invoiceFindFirst.mockResolvedValue({
+    invoiceFindUnique.mockResolvedValue({
       id: 'inv_1',
+      userId: 'user_1',
       status: 'pending',
       updatedAt: new Date('2026-02-01T10:00:00.000Z'),
     })
@@ -160,5 +171,64 @@ describe('routes-b invoice ETag + If-Match', () => {
     const response = await PATCH(request, { params: Promise.resolve({ id: 'inv_1' }) })
     expect(response.status).toBe(200)
   })
-})
 
+  it('GET hides invoices owned by another user', async () => {
+    invoiceFindUnique.mockResolvedValue({
+      id: 'inv_1',
+      userId: 'user_2',
+      invoiceNumber: 'INV-1',
+      clientEmail: 'c@example.com',
+      clientName: 'Client',
+      description: 'Work',
+      amount: 120,
+      currency: 'USD',
+      status: 'pending',
+      paymentLink: 'https://pay',
+      dueDate: null,
+      paidAt: null,
+      createdAt: new Date('2026-02-01T09:00:00.000Z'),
+      updatedAt: new Date('2026-02-01T10:00:00.000Z'),
+    })
+
+    const { GET } = await import('@/app/api/routes-b/invoices/[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/invoices/inv_1', {
+      headers: { authorization: 'Bearer token' },
+    })
+    const response = await GET(request, { params: Promise.resolve({ id: 'inv_1' }) })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'NOT_FOUND', message: 'Invoice not found' },
+    })
+  })
+
+  it('PATCH rejects invalid fields with structured errors', async () => {
+    invoiceFindUnique.mockResolvedValue({
+      id: 'inv_1',
+      userId: 'user_1',
+      status: 'pending',
+      updatedAt: new Date('2026-02-01T10:00:00.000Z'),
+    })
+
+    const { PATCH } = await import('@/app/api/routes-b/invoices/[id]/route')
+    const request = new NextRequest('http://localhost/api/routes-b/invoices/inv_1', {
+      method: 'PATCH',
+      headers: {
+        authorization: 'Bearer token',
+        'if-match': createEntityEtag('inv_1', new Date('2026-02-01T10:00:00.000Z')),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ amount: -1 }),
+    })
+    const response = await PATCH(request, { params: Promise.resolve({ id: 'inv_1' }) })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'BAD_REQUEST',
+        fields: { amount: 'Must be a positive number' },
+      },
+    })
+    expect(invoiceUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/routes-b/invoices/[id]/route.ts
+++ b/app/api/routes-b/invoices/[id]/route.ts
@@ -1,199 +1,350 @@
-import { withRequestId } from '../../_lib/with-request-id'
+import { withRequestId, getRequestId } from '../../_lib/with-request-id'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { createEntityEtag, ifMatchSatisfied } from '../../_lib/etag'
-import { checkResourceOwnership } from '../../_lib/access-control'
+import { errorResponse } from '../../_lib/errors'
+import { logger } from '@/lib/logger'
 
 function isValidIsoDate(value: string) {
   const date = new Date(value)
   return !Number.isNaN(date.getTime())
 }
 
+type AuthenticatedUser = {
+  id: string
+  role: string
+}
+
+const PATCHABLE_FIELDS = new Set([
+  'description',
+  'amount',
+  'dueDate',
+  'clientName',
+])
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return {
+      response: errorResponse('UNAUTHORIZED', 'Unauthorized', { requestId: getRequestId() }, 401),
+    }
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return {
+      response: errorResponse('UNAUTHORIZED', 'Invalid token', { requestId: getRequestId() }, 401),
+    }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true, role: true },
+  })
+
+  if (!user) {
+    return {
+      response: errorResponse('NOT_FOUND', 'User not found', { requestId: getRequestId() }, 404),
+    }
+  }
+
+  return { user }
+}
+
+function invoiceNotFound() {
+  return errorResponse('NOT_FOUND', 'Invoice not found', { requestId: getRequestId() }, 404)
+}
+
 async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
+  try {
+    const { id } = await params
+    if (!id) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Invoice id is required' }, requestId: getRequestId() },
+        400,
+      )
+    }
 
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    const auth = await getAuthenticatedUser(request)
+    if (auth.response) return auth.response
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        invoiceNumber: true,
+        clientEmail: true,
+        clientName: true,
+        description: true,
+        amount: true,
+        currency: true,
+        status: true,
+        paymentLink: true,
+        dueDate: true,
+        paidAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+
+    if (!invoice || invoice.userId !== auth.user.id) {
+      return invoiceNotFound()
+    }
+
+    const etag = createEntityEtag(invoice.id, invoice.updatedAt)
+    const response = NextResponse.json({
+      invoice: {
+        id: invoice.id,
+        invoiceNumber: invoice.invoiceNumber,
+        clientName: invoice.clientName,
+        clientEmail: invoice.clientEmail,
+        description: invoice.description,
+        amount: Number(invoice.amount),
+        currency: invoice.currency,
+        status: invoice.status,
+        paymentLink: invoice.paymentLink,
+        dueDate: invoice.dueDate,
+        paidAt: invoice.paidAt,
+        createdAt: invoice.createdAt,
+      },
+    })
+    response.headers.set('ETag', etag)
+    return response
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B invoice GET error')
+    return errorResponse(
+      'INTERNAL',
+      'Failed to fetch invoice',
+      { requestId: getRequestId() },
+      500,
+    )
   }
-
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
-
-  const invoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      userId: true,
-      invoiceNumber: true,
-      clientEmail: true,
-      clientName: true,
-      description: true,
-      amount: true,
-      currency: true,
-      status: true,
-      paymentLink: true,
-      dueDate: true,
-      paidAt: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  })
-
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  const accessCheck = checkResourceOwnership(invoice.userId, user.id)
-  if (accessCheck) return accessCheck
-
-  const etag = createEntityEtag(invoice.id, invoice.updatedAt)
-  const response = NextResponse.json({
-    invoice: {
-      id: invoice.id,
-      invoiceNumber: invoice.invoiceNumber,
-      clientName: invoice.clientName,
-      clientEmail: invoice.clientEmail,
-      description: invoice.description,
-      amount: Number(invoice.amount),
-      currency: invoice.currency,
-      status: invoice.status,
-      paymentLink: invoice.paymentLink,
-      dueDate: invoice.dueDate,
-      paidAt: invoice.paidAt,
-      createdAt: invoice.createdAt,
-    },
-  })
-  response.headers.set('ETag', etag)
-  return response
 }
 
 async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
-
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const requester = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!requester) {
-    return NextResponse.json({ error: 'User not found' }, { status: 404 })
-  }
-
-  const ifMatchHeader = request.headers.get('if-match')
-  if (!ifMatchHeader) {
-    return NextResponse.json({ error: 'If-Match header is required' }, { status: 428 })
-  }
-  const wildcardMatch = ifMatchHeader.trim() === '*'
-  if (wildcardMatch && requester.role.toLowerCase() !== 'admin') {
-    return NextResponse.json({ error: 'Wildcard If-Match is admin only' }, { status: 403 })
-  }
-
-  const ownedInvoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: { id: true, userId: true, status: true, updatedAt: true },
-  })
-
-  if (!ownedInvoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  const accessCheck = checkResourceOwnership(ownedInvoice.userId, requester.id)
-  if (accessCheck) return accessCheck
-
-  if (ownedInvoice.status !== 'pending') {
-    return NextResponse.json({ error: 'Only pending invoices can be edited' }, { status: 422 })
-  }
-
-  if (!wildcardMatch) {
-    const currentEtag = createEntityEtag(ownedInvoice.id, ownedInvoice.updatedAt)
-    if (!ifMatchSatisfied(ifMatchHeader, currentEtag)) {
-      return NextResponse.json({ error: 'ETag mismatch' }, { status: 412 })
-    }
-  }
-
-  const body = await request.json()
-
-  const updateData: {
-    description?: string
-    amount?: number
-    dueDate?: Date | null
-    clientName?: string
-  } = {}
-
-  if (body.description !== undefined) {
-    if (typeof body.description !== 'string' || body.description.trim() === '') {
-      return NextResponse.json({ error: 'description must be a non-empty string' }, { status: 400 })
-    }
-    if (body.description.length > 500) {
-      return NextResponse.json({ error: 'description must be 500 characters or fewer' }, { status: 400 })
-    }
-    updateData.description = body.description.trim()
-  }
-
-  if (body.amount !== undefined) {
-    if (typeof body.amount !== 'number' || Number.isNaN(body.amount) || body.amount <= 0) {
-      return NextResponse.json({ error: 'amount must be a positive number' }, { status: 400 })
-    }
-    updateData.amount = body.amount
-  }
-
-  if (body.dueDate !== undefined) {
-    if (body.dueDate === null) {
-      updateData.dueDate = null
-    } else if (typeof body.dueDate === 'string' && isValidIsoDate(body.dueDate)) {
-      updateData.dueDate = new Date(body.dueDate)
-    } else {
-      return NextResponse.json(
-        { error: 'dueDate must be a valid ISO date string or null' },
-        { status: 400 },
+  try {
+    const { id } = await params
+    if (!id) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Invoice id is required' }, requestId: getRequestId() },
+        400,
       )
     }
-  }
 
-  if (body.clientName !== undefined) {
-    if (typeof body.clientName !== 'string') {
-      return NextResponse.json({ error: 'clientName must be a string' }, { status: 400 })
+    const auth = await getAuthenticatedUser(request)
+    if (auth.response) return auth.response
+    const requester = auth.user as AuthenticatedUser
+
+    const ifMatchHeader = request.headers.get('if-match')
+    if (!ifMatchHeader) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'If-Match header is required',
+        { fields: { 'if-match': 'Header is required' }, requestId: getRequestId() },
+        428,
+      )
     }
-    if (body.clientName.length > 100) {
-      return NextResponse.json({ error: 'clientName must be 100 characters or fewer' }, { status: 400 })
+
+    const wildcardMatch = ifMatchHeader.trim() === '*'
+    if (wildcardMatch && requester.role.toLowerCase() !== 'admin') {
+      return errorResponse(
+        'FORBIDDEN',
+        'Wildcard If-Match is admin only',
+        { requestId: getRequestId() },
+        403,
+      )
     }
-    updateData.clientName = body.clientName
+
+    const ownedInvoice = await prisma.invoice.findUnique({
+      where: { id },
+      select: { id: true, userId: true, status: true, updatedAt: true },
+    })
+
+    if (!ownedInvoice || ownedInvoice.userId !== requester.id) {
+      return invoiceNotFound()
+    }
+
+    if (ownedInvoice.status !== 'pending') {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Only pending invoices can be edited',
+        { requestId: getRequestId() },
+        422,
+      )
+    }
+
+    if (!wildcardMatch) {
+      const currentEtag = createEntityEtag(ownedInvoice.id, ownedInvoice.updatedAt)
+      if (!ifMatchSatisfied(ifMatchHeader, currentEtag)) {
+        return errorResponse(
+          'CONFLICT',
+          'ETag mismatch',
+          { requestId: getRequestId() },
+          412,
+        )
+      }
+    }
+
+    let body: Record<string, unknown>
+    try {
+      const parsed = await request.json()
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Body must be an object')
+      }
+      body = parsed
+    } catch {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid JSON body',
+        { fields: { body: 'Must be a valid JSON object' }, requestId: getRequestId() },
+        400,
+      )
+    }
+
+    const unknownFields = Object.keys(body).filter(key => !PATCHABLE_FIELDS.has(key))
+    if (unknownFields.length > 0) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice fields',
+        {
+          fields: Object.fromEntries(
+            unknownFields.map(field => [field, 'Field cannot be updated by this endpoint']),
+          ),
+          requestId: getRequestId(),
+        },
+        400,
+      )
+    }
+
+    const updateData: {
+      description?: string
+      amount?: number
+      dueDate?: Date | null
+      clientName?: string
+    } = {}
+
+    if (body.description !== undefined) {
+      if (typeof body.description !== 'string' || body.description.trim() === '') {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid description',
+          { fields: { description: 'Must be a non-empty string' }, requestId: getRequestId() },
+          400,
+        )
+      }
+      if (body.description.length > 500) {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid description',
+          { fields: { description: 'Must be 500 characters or fewer' }, requestId: getRequestId() },
+          400,
+        )
+      }
+      updateData.description = body.description.trim()
+    }
+
+    if (body.amount !== undefined) {
+      if (typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid amount',
+          { fields: { amount: 'Must be a positive number' }, requestId: getRequestId() },
+          400,
+        )
+      }
+      updateData.amount = body.amount
+    }
+
+    if (body.dueDate !== undefined) {
+      if (body.dueDate === null) {
+        updateData.dueDate = null
+      } else if (typeof body.dueDate === 'string' && isValidIsoDate(body.dueDate)) {
+        updateData.dueDate = new Date(body.dueDate)
+      } else {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid due date',
+          { fields: { dueDate: 'Must be a valid ISO date string or null' }, requestId: getRequestId() },
+          400,
+        )
+      }
+    }
+
+    if (body.clientName !== undefined) {
+      if (typeof body.clientName !== 'string' || body.clientName.trim() === '') {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid client name',
+          { fields: { clientName: 'Must be a non-empty string' }, requestId: getRequestId() },
+          400,
+        )
+      }
+      if (body.clientName.length > 100) {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid client name',
+          { fields: { clientName: 'Must be 100 characters or fewer' }, requestId: getRequestId() },
+          400,
+        )
+      }
+      updateData.clientName = body.clientName.trim()
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'No valid fields provided',
+        { requestId: getRequestId() },
+        400,
+      )
+    }
+
+    const updatedInvoice = await prisma.invoice.update({
+      where: { id: ownedInvoice.id },
+      data: updateData,
+      select: {
+        id: true,
+        invoiceNumber: true,
+        description: true,
+        amount: true,
+        status: true,
+        updatedAt: true,
+        dueDate: true,
+        clientName: true,
+        clientEmail: true,
+        currency: true,
+        paymentLink: true,
+        paidAt: true,
+        createdAt: true,
+      },
+    })
+
+    const response = NextResponse.json({
+      invoice: { ...updatedInvoice, amount: Number(updatedInvoice.amount) },
+    })
+    response.headers.set('ETag', createEntityEtag(updatedInvoice.id, updatedInvoice.updatedAt))
+    return response
+  } catch (error) {
+    logger.error({ err: error }, 'Routes-B invoice PATCH error')
+    return errorResponse(
+      'INTERNAL',
+      'Failed to update invoice',
+      { requestId: getRequestId() },
+      500,
+    )
   }
-
-  const updatedInvoice = await prisma.invoice.update({
-    where: { id: ownedInvoice.id },
-    data: updateData,
-    select: {
-      id: true,
-      invoiceNumber: true,
-      description: true,
-      amount: true,
-      status: true,
-      updatedAt: true,
-      dueDate: true,
-      clientName: true,
-      clientEmail: true,
-      currency: true,
-      paymentLink: true,
-      paidAt: true,
-      createdAt: true,
-    },
-  })
-
-  return NextResponse.json({ ...updatedInvoice, amount: Number(updatedInvoice.amount) })
 }
 
 export const GET = withRequestId(GETHandler)


### PR DESCRIPTION
- Updated GET /api/routes-b/invoices/[id] to fetch authenticated user-owned invoices with structured routes-b error responses and ETag headers.
- Updated PATCH /api/routes-b/invoices/[id] with auth, ownership-safe invoice checks, If-Match validation, pending-invoice enforcement, JSON body validation, allowed-field validation, and structured field errors.
- Wrapped invoice fetch/update failures with structured INTERNAL responses and request IDs.
- Updated invoice route unit tests for ETag behavior, ownership failure, stale If-Match, successful PATCH, admin wildcard If-Match, and invalid PATCH payloads.


Closes #701 