### PR TITLE
feat: add routes-b invoice messages endpoint

### DIFF
--- a/app/api/routes-b/invoices/[id]/messages/__tests__/route.test.ts
+++ b/app/api/routes-b/invoices/[id]/messages/__tests__/route.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+    invoiceMessage: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { GET, POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+const mockedMessageFindMany = vi.mocked(prisma.invoiceMessage.findMany)
+const mockedMessageCreate = vi.mocked(prisma.invoiceMessage.create)
+
+const invoiceId = '550e8400-e29b-41d4-a716-446655440000'
+const baseUser = {
+  id: 'user-1',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+}
+
+function makeGET(id = invoiceId, auth = true): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/invoices/${id}/messages`, {
+    method: 'GET',
+    headers: auth ? { authorization: 'Bearer token' } : {},
+  })
+}
+
+function makePOST(body: unknown, id = invoiceId, auth = true): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/invoices/${id}/messages`, {
+    method: 'POST',
+    headers: auth ? { authorization: 'Bearer token' } : {},
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function makeParams(id = invoiceId) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('GET /api/routes-b/invoices/[id]/messages', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue(baseUser as never)
+    mockedInvoiceFind.mockResolvedValue({ id: invoiceId, userId: 'user-1' } as never)
+  })
+
+  it('lists messages for the invoice owner', async () => {
+    const createdAt = new Date('2026-01-01T12:00:00.000Z')
+    mockedMessageFindMany.mockResolvedValue([
+      {
+        id: 'msg-1',
+        invoiceId,
+        senderId: 'user-1',
+        senderType: 'freelancer',
+        senderName: 'Ada Lovelace',
+        content: 'Thanks for the update.',
+        attachmentUrl: null,
+        isInternal: false,
+        createdAt,
+      },
+    ] as never)
+
+    const res = await GET(makeGET(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.messages).toEqual([
+      {
+        id: 'msg-1',
+        invoiceId,
+        senderId: 'user-1',
+        senderType: 'freelancer',
+        senderName: 'Ada Lovelace',
+        content: 'Thanks for the update.',
+        attachmentUrl: null,
+        isInternal: false,
+        createdAt: createdAt.toISOString(),
+      },
+    ])
+    expect(mockedMessageFindMany).toHaveBeenCalledWith({
+      where: { invoiceId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        invoiceId: true,
+        senderId: true,
+        senderType: true,
+        senderName: true,
+        content: true,
+        attachmentUrl: true,
+        isInternal: true,
+        createdAt: true,
+      },
+    })
+  })
+
+  it('returns 401 when authorization is missing', async () => {
+    const res = await GET(makeGET(invoiceId, false), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-UUID invoice id', async () => {
+    const res = await GET(makeGET('not-a-uuid'), makeParams('not-a-uuid'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.id).toBe('Must be a valid UUID')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null)
+
+    const res = await GET(makeGET(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('Invoice not found')
+    expect(mockedMessageFindMany).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({ id: invoiceId, userId: 'other-user' } as never)
+
+    const res = await GET(makeGET(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(mockedMessageFindMany).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/routes-b/invoices/[id]/messages', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue(baseUser as never)
+    mockedInvoiceFind.mockResolvedValue({ id: invoiceId, userId: 'user-1' } as never)
+  })
+
+  it('creates a freelancer message for the invoice owner', async () => {
+    const createdAt = new Date('2026-01-01T12:00:00.000Z')
+    mockedMessageCreate.mockResolvedValue({
+      id: 'msg-1',
+      invoiceId,
+      senderId: 'user-1',
+      senderType: 'freelancer',
+      senderName: 'Ada Lovelace',
+      content: 'Hello client',
+      attachmentUrl: null,
+      isInternal: false,
+      createdAt,
+    } as never)
+
+    const res = await POST(makePOST({ content: '  Hello client  ' }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(body.message.content).toBe('Hello client')
+    expect(body.message.createdAt).toBe(createdAt.toISOString())
+    expect(mockedMessageCreate).toHaveBeenCalledWith({
+      data: {
+        invoiceId,
+        senderId: 'user-1',
+        senderType: 'freelancer',
+        senderName: 'Ada Lovelace',
+        content: 'Hello client',
+      },
+      select: {
+        id: true,
+        invoiceId: true,
+        senderId: true,
+        senderType: true,
+        senderName: true,
+        content: true,
+        attachmentUrl: true,
+        isInternal: true,
+        createdAt: true,
+      },
+    })
+  })
+
+  it('returns 400 when content is missing', async () => {
+    const res = await POST(makePOST({}), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.content).toContain('Required')
+    expect(mockedMessageCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when content is too long', async () => {
+    const res = await POST(makePOST({ content: 'x'.repeat(1001) }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.content).toContain('Content must be 1000 characters or fewer')
+    expect(mockedMessageCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when JSON is malformed', async () => {
+    const res = await POST(makePOST('{'), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.message).toBe('Invalid JSON body')
+    expect(mockedMessageCreate).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/routes-b/invoices/[id]/messages/route.ts
+++ b/app/api/routes-b/invoices/[id]/messages/route.ts
@@ -1,118 +1,169 @@
 import { withRequestId } from '../../../_lib/with-request-id'
+import { withMethods } from '../../../_lib/with-methods'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { errorResponse } from '../../../_lib/errors'
+import { logger } from '@/lib/logger'
+import { z } from 'zod'
+
+const invoiceIdParamsSchema = z.object({
+  id: z.string().uuid('Invoice id must be a valid UUID'),
+})
+
+const createMessageSchema = z.object({
+  content: z
+    .string()
+    .trim()
+    .min(1, 'Content is required')
+    .max(1000, 'Content must be 1000 characters or fewer'),
+})
+
+function messageValidationFields(error: z.ZodError) {
+  const fields = error.flatten().fieldErrors
+  return {
+    ...(fields.content ? { content: fields.content } : {}),
+  }
+}
 
 async function getAuthenticatedUser(request: NextRequest) {
   const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  if (!authToken) return null
+  if (!authToken) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
 
   const claims = await verifyAuthToken(authToken)
-  if (!claims) return null
+  if (!claims) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
 
-  return prisma.user.findUnique({
+  const user = await prisma.user.findUnique({
     where: { privyId: claims.userId },
     select: { id: true, name: true, email: true },
   })
+
+  if (!user) {
+    return { error: errorResponse('NOT_FOUND', 'User not found', undefined, 404) }
+  }
+
+  return { user }
+}
+
+async function authorizeInvoiceAccess(request: NextRequest, id: string) {
+  const parsedParams = invoiceIdParamsSchema.safeParse({ id })
+  if (!parsedParams.success) {
+    return {
+      error: errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Must be a valid UUID' } },
+        400,
+      ),
+    }
+  }
+
+  const auth = await getAuthenticatedUser(request)
+  if ('error' in auth) return auth
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id: parsedParams.data.id },
+    select: { id: true, userId: true },
+  })
+
+  if (!invoice || invoice.userId !== auth.user.id) {
+    return { error: errorResponse('NOT_FOUND', 'Invoice not found', undefined, 404) }
+  }
+
+  return { user: auth.user, invoice }
 }
 
 async function GETHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id: invoiceId } = await params
-  const user = await getAuthenticatedUser(request)
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  try {
+    const { id } = await params
+    const auth = await authorizeInvoiceAccess(request, id)
+    if ('error' in auth) return auth.error
+
+    const messages = await prisma.invoiceMessage.findMany({
+      where: { invoiceId: auth.invoice.id },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        invoiceId: true,
+        senderId: true,
+        senderType: true,
+        senderName: true,
+        content: true,
+        attachmentUrl: true,
+        isInternal: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json({ messages })
+  } catch (error) {
+    logger.error({ err: error }, 'GET /api/routes-b/invoices/[id]/messages error')
+    return errorResponse('INTERNAL', 'Failed to list invoice messages', undefined, 500)
   }
-
-  const invoice = await prisma.invoice.findUnique({
-    where: { id: invoiceId },
-    select: { id: true, userId: true },
-  })
-
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  if (invoice.userId !== user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  const messages = await prisma.invoiceMessage.findMany({
-    where: { invoiceId },
-    orderBy: { createdAt: 'asc' },
-    select: {
-      id: true,
-      senderType: true,
-      senderName: true,
-      content: true,
-      createdAt: true,
-    },
-  })
-
-  return NextResponse.json({ messages })
 }
 
 async function POSTHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
-  const user = await getAuthenticatedUser(request)
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const invoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: { id: true, userId: true },
-  })
-
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  if (invoice.userId !== user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  let body: { content?: unknown }
   try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    const { id } = await params
+    const auth = await authorizeInvoiceAccess(request, id)
+    if ('error' in auth) return auth.error
+
+    const body = await request.json().catch(() => null)
+    if (!body) {
+      return errorResponse('BAD_REQUEST', 'Invalid JSON body', undefined, 400)
+    }
+
+    const parsedBody = createMessageSchema.safeParse(body)
+    if (!parsedBody.success) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid message payload',
+        {
+          fields: messageValidationFields(parsedBody.error),
+        },
+        400,
+      )
+    }
+
+    const message = await prisma.invoiceMessage.create({
+      data: {
+        invoiceId: auth.invoice.id,
+        senderId: auth.user.id,
+        senderType: 'freelancer',
+        senderName: auth.user.name ?? auth.user.email,
+        content: parsedBody.data.content,
+      },
+      select: {
+        id: true,
+        invoiceId: true,
+        senderId: true,
+        senderType: true,
+        senderName: true,
+        content: true,
+        attachmentUrl: true,
+        isInternal: true,
+        createdAt: true,
+      },
+    })
+
+    return NextResponse.json({ message }, { status: 201 })
+  } catch (error) {
+    logger.error({ err: error }, 'POST /api/routes-b/invoices/[id]/messages error')
+    return errorResponse('INTERNAL', 'Failed to create invoice message', undefined, 500)
   }
-
-  const { content } = body
-
-  if (!content || typeof content !== 'string' || content.trim() === '') {
-    return NextResponse.json({ error: 'content is required and must be a non-empty string' }, { status: 400 })
-  }
-
-  if (content.length > 1000) {
-    return NextResponse.json({ error: 'content must be 1000 characters or fewer' }, { status: 400 })
-  }
-
-  const message = await prisma.invoiceMessage.create({
-    data: {
-      invoiceId: invoice.id,
-      senderType: 'freelancer',
-      senderName: user.name ?? user.email,
-      content: content.trim(),
-    },
-    select: {
-      id: true,
-      invoiceId: true,
-      senderType: true,
-      senderName: true,
-      content: true,
-      createdAt: true,
-    },
-  })
-
-  return NextResponse.json(message, { status: 201 })
 }
 
-export const GET = withRequestId(GETHandler)
-export const POST = withRequestId(POSTHandler)
+export const { GET, POST } = withMethods({
+  GET: withRequestId(GETHandler),
+  POST: withRequestId(POSTHandler),
+})


### PR DESCRIPTION
Closes #696

---

## Summary
- Harden GET/POST /api/routes-b/invoices/[id]/messages with validation, auth, ownership checks, and routes-b error envelopes.
- Return invoice messages and create freelancer messages with sender metadata.
- Add focused unit tests for happy paths and auth, validation, and not-found failures.

## Tests
- npx vitest run app/api/routes-b/invoices/[id]/messages/__tests__/route.test.ts
- npx eslint app/api/routes-b/invoices/[id]/messages/route.ts app/api/routes-b/invoices/[id]/messages/__tests__/route.test.ts

Note: npm run build currently fails on existing unrelated errors in app/api/routes-b/stats/route.ts, app/api/routes-b/_lib/error.ts, and app/api/routes-b/invoices/[id]/tags/[tagId]/route.ts.