### PR TITLE
feat: add routes-b invoice due date endpoint

### DIFF
--- a/app/api/routes-b/invoices/[id]/due-date/__tests__/route.test.ts
+++ b/app/api/routes-b/invoices/[id]/due-date/__tests__/route.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('../../../../_lib/events', () => ({ emitStatsInvalidated: vi.fn() }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { emitStatsInvalidated } from '../../../../_lib/events'
+import { PATCH } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+const mockedInvoiceUpdate = vi.mocked(prisma.invoice.update)
+const mockedEmitStatsInvalidated = vi.mocked(emitStatsInvalidated)
+
+const invoiceId = '550e8400-e29b-41d4-a716-446655440000'
+const userId = 'user-1'
+
+function makePATCH(body: unknown, id = invoiceId, auth = true): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/invoices/${id}/due-date`, {
+    method: 'PATCH',
+    headers: auth ? { authorization: 'Bearer token' } : {},
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function makeParams(id = invoiceId) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('PATCH /api/routes-b/invoices/[id]/due-date', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({ id: userId } as never)
+    mockedInvoiceFind.mockResolvedValue({
+      id: invoiceId,
+      userId,
+      status: 'pending',
+    } as never)
+    mockedInvoiceUpdate.mockResolvedValue({
+      id: invoiceId,
+      invoiceNumber: 'INV-001',
+      dueDate: new Date('2099-01-15T00:00:00.000Z'),
+    } as never)
+  })
+
+  it('updates an owned pending invoice due date', async () => {
+    const res = await PATCH(
+      makePATCH({ dueDate: '2099-01-15T00:00:00.000Z' }),
+      makeParams(),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.invoice).toEqual({
+      id: invoiceId,
+      invoiceNumber: 'INV-001',
+      dueDate: '2099-01-15T00:00:00.000Z',
+    })
+    expect(mockedInvoiceUpdate).toHaveBeenCalledWith({
+      where: { id: invoiceId },
+      data: { dueDate: new Date('2099-01-15T00:00:00.000Z') },
+      select: {
+        id: true,
+        invoiceNumber: true,
+        dueDate: true,
+      },
+    })
+    expect(mockedEmitStatsInvalidated).toHaveBeenCalledWith({ userId })
+  })
+
+  it('clears the due date when dueDate is null', async () => {
+    mockedInvoiceUpdate.mockResolvedValue({
+      id: invoiceId,
+      invoiceNumber: 'INV-001',
+      dueDate: null,
+    } as never)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.invoice.dueDate).toBeNull()
+    expect(mockedInvoiceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { dueDate: null },
+      }),
+    )
+  })
+
+  it('returns 401 when authorization is missing', async () => {
+    const res = await PATCH(makePATCH({ dueDate: null }, invoiceId, false), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token verification fails', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-UUID invoice id', async () => {
+    const res = await PATCH(makePATCH({ dueDate: null }, 'not-a-uuid'), makeParams('not-a-uuid'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.id).toBe('Must be a valid UUID')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValue(null)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('User not found')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('Invoice not found')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      id: invoiceId,
+      userId: 'other-user',
+      status: 'pending',
+    } as never)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when the invoice is not pending', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      id: invoiceId,
+      userId,
+      status: 'paid',
+    } as never)
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(422)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.message).toBe('Due date can only be updated on pending invoices')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when JSON is malformed', async () => {
+    const res = await PATCH(makePATCH('{'), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.message).toBe('Invalid JSON body')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dueDate is missing', async () => {
+    const res = await PATCH(makePATCH({}), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.dueDate).toBe('Must be an ISO date string or null')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dueDate is not a string or null', async () => {
+    const res = await PATCH(makePATCH({ dueDate: 123 }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.dueDate).toBe('Must be an ISO date string or null')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dueDate is invalid', async () => {
+    const res = await PATCH(makePATCH({ dueDate: 'not-a-date' }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.dueDate).toBe('Must be a valid ISO date string')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when dueDate is in the past', async () => {
+    const res = await PATCH(makePATCH({ dueDate: '2000-01-01T00:00:00.000Z' }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.dueDate).toBe('Due date cannot be in the past')
+    expect(mockedInvoiceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when the update fails', async () => {
+    mockedInvoiceUpdate.mockRejectedValue(new Error('db down'))
+
+    const res = await PATCH(makePATCH({ dueDate: null }), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL')
+    expect(body.error.message).toBe('Failed to update invoice due date')
+  })
+})

--- a/app/api/routes-b/invoices/[id]/due-date/route.ts
+++ b/app/api/routes-b/invoices/[id]/due-date/route.ts
@@ -1,96 +1,157 @@
 import { withRequestId } from '../../../_lib/with-request-id'
+import { withMethods } from '../../../_lib/with-methods'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
+import { errorResponse } from '../../../_lib/errors'
+import { emitStatsInvalidated } from '../../../_lib/events'
+import { logger } from '@/lib/logger'
+import { z } from 'zod'
+
+const invoiceIdParamsSchema = z.object({
+  id: z.string().uuid('Invoice id must be a valid UUID'),
+})
+
+const dueDateBodySchema = z.object({
+  dueDate: z.union([z.string(), z.null()]),
+})
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+
+  if (!user) {
+    return { error: errorResponse('NOT_FOUND', 'User not found', undefined, 404) }
+  }
+
+  return { user }
+}
+
+function parseDueDate(value: string) {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return { error: 'Must be a valid ISO date string' }
+  }
+
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  const normalizedDueDate = new Date(parsed)
+  normalizedDueDate.setUTCHours(0, 0, 0, 0)
+
+  if (normalizedDueDate < today) {
+    return { error: 'Due date cannot be in the past' }
+  }
+
+  return { dueDate: parsed }
+}
 
 async function PATCHHandler(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const { id } = await params
-
-  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-  const claims = await verifyAuthToken(authToken || '')
-  if (!claims) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const user = await prisma.user.findUnique({ where: { privyId: claims.userId } })
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-
-  const invoice = await prisma.invoice.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      userId: true,
-      status: true,
-    },
-  })
-
-  if (!invoice) {
-    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-  }
-
-  if (invoice.userId !== user.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  if (invoice.status !== 'pending') {
-    return NextResponse.json(
-      { error: 'Due date can only be updated on pending invoices' },
-      { status: 422 },
-    )
-  }
-
-  let body: { dueDate?: string | null }
   try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
-  }
-
-  if (!('dueDate' in body)) {
-    return NextResponse.json({ error: 'dueDate is required' }, { status: 400 })
-  }
-
-  let dueDate: Date | null = null
-
-  if (body.dueDate !== null) {
-    if (typeof body.dueDate !== 'string') {
-      return NextResponse.json({ error: 'dueDate must be a string or null' }, { status: 400 })
+    const { id } = await params
+    const parsedParams = invoiceIdParamsSchema.safeParse({ id })
+    if (!parsedParams.success) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Must be a valid UUID' } },
+        400,
+      )
     }
 
-    const parsedDate = new Date(body.dueDate)
-    if (Number.isNaN(parsedDate.getTime())) {
-      return NextResponse.json({ error: 'Invalid date format' }, { status: 400 })
+    const auth = await getAuthenticatedUser(request)
+    if ('error' in auth) return auth.error
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id: parsedParams.data.id },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+      },
+    })
+
+    if (!invoice || invoice.userId !== auth.user.id) {
+      return errorResponse('NOT_FOUND', 'Invoice not found', undefined, 404)
     }
 
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-
-    const normalizedDate = new Date(parsedDate)
-    normalizedDate.setHours(0, 0, 0, 0)
-
-    if (normalizedDate < today) {
-      return NextResponse.json({ error: 'Due date cannot be in the past' }, { status: 400 })
+    if (invoice.status !== 'pending') {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Due date can only be updated on pending invoices',
+        undefined,
+        422,
+      )
     }
 
-    dueDate = parsedDate
+    const body = await request.json().catch(() => null)
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid JSON body',
+        { fields: { body: 'Must be a valid JSON object' } },
+        400,
+      )
+    }
+
+    const parsedBody = dueDateBodySchema.safeParse(body)
+    if (!parsedBody.success) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid due date payload',
+        { fields: { dueDate: 'Must be an ISO date string or null' } },
+        400,
+      )
+    }
+
+    let dueDate: Date | null = null
+    if (parsedBody.data.dueDate !== null) {
+      const parsedDueDate = parseDueDate(parsedBody.data.dueDate)
+      if ('error' in parsedDueDate) {
+        return errorResponse(
+          'BAD_REQUEST',
+          'Invalid due date',
+          { fields: { dueDate: parsedDueDate.error } },
+          400,
+        )
+      }
+      dueDate = parsedDueDate.dueDate
+    }
+
+    const updatedInvoice = await prisma.invoice.update({
+      where: { id: invoice.id },
+      data: { dueDate },
+      select: {
+        id: true,
+        invoiceNumber: true,
+        dueDate: true,
+      },
+    })
+
+    emitStatsInvalidated({ userId: auth.user.id })
+
+    return NextResponse.json({ invoice: updatedInvoice }, { status: 200 })
+  } catch (error) {
+    logger.error({ err: error }, 'PATCH /api/routes-b/invoices/[id]/due-date error')
+    return errorResponse('INTERNAL', 'Failed to update invoice due date', undefined, 500)
   }
-
-  const updatedInvoice = await prisma.invoice.update({
-    where: { id },
-    data: { dueDate },
-    select: {
-      id: true,
-      invoiceNumber: true,
-      dueDate: true,
-    },
-  })
-
-  return NextResponse.json(updatedInvoice, { status: 200 })
 }
 
-export const PATCH = withRequestId(PATCHHandler)
+export const { PATCH } = withMethods({
+  PATCH: withRequestId(PATCHHandler),
+})


### PR DESCRIPTION
Closes #694

---

## Summary
- Harden PATCH /api/routes-b/invoices/[id]/due-date with UUID/body validation, auth, ownership checks, and routes-b error envelopes.
- Support setting an ISO due date or clearing it with null for owned pending invoices.
- Add focused unit tests for success, clear, auth, validation, ownership, editability, and failure paths.

## Tests
- npx vitest run app/api/routes-b/invoices/[id]/due-date/__tests__/route.test.ts
- npx eslint app/api/routes-b/invoices/[id]/due-date/route.ts app/api/routes-b/invoices/[id]/due-date/__tests__/route.test.ts

Note: npm run build currently fails on existing unrelated errors in app/api/routes-b/stats/route.ts, app/api/routes-b/_lib/error.ts, and app/api/routes-b/invoices/[id]/tags/[tagId]/route.ts.