### PR TITLE
feat: add routes-b invoice reminder endpoint

### DIFF
--- a/app/api/routes-b/invoices/[id]/remind/__tests__/route.test.ts
+++ b/app/api/routes-b/invoices/[id]/remind/__tests__/route.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/auth', () => ({ verifyAuthToken: vi.fn() }))
+vi.mock('@/lib/email', () => ({ sendEmail: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    invoice: { findUnique: vi.fn() },
+  },
+}))
+
+import { verifyAuthToken } from '@/lib/auth'
+import { sendEmail } from '@/lib/email'
+import { prisma } from '@/lib/db'
+import { POST } from '../route'
+
+const mockedVerify = vi.mocked(verifyAuthToken)
+const mockedSendEmail = vi.mocked(sendEmail)
+const mockedUserFind = vi.mocked(prisma.user.findUnique)
+const mockedInvoiceFind = vi.mocked(prisma.invoice.findUnique)
+
+const invoiceId = '550e8400-e29b-41d4-a716-446655440000'
+const userId = 'user-1'
+
+const pendingInvoice = {
+  id: invoiceId,
+  userId,
+  status: 'pending',
+  clientEmail: 'client@example.com',
+  invoiceNumber: 'INV-001',
+  amount: '500.00',
+  currency: 'USD',
+  dueDate: new Date('2099-01-15T00:00:00.000Z'),
+  paymentLink: 'https://app.example/pay/INV-001',
+}
+
+function makePOST(id = invoiceId, auth = true): NextRequest {
+  return new NextRequest(`http://localhost/api/routes-b/invoices/${id}/remind`, {
+    method: 'POST',
+    headers: auth ? { authorization: 'Bearer token' } : {},
+  })
+}
+
+function makeParams(id = invoiceId) {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('POST /api/routes-b/invoices/[id]/remind', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockedVerify.mockResolvedValue({ userId: 'privy-1' } as never)
+    mockedUserFind.mockResolvedValue({ id: userId } as never)
+    mockedInvoiceFind.mockResolvedValue(pendingInvoice as never)
+    mockedSendEmail.mockResolvedValue(undefined as never)
+  })
+
+  it('sends a reminder for an owned pending invoice', async () => {
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({
+      sent: true,
+      invoiceId,
+      clientEmail: 'client@example.com',
+      invoiceNumber: 'INV-001',
+    })
+    expect(mockedInvoiceFind).toHaveBeenCalledWith({
+      where: { id: invoiceId },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+        clientEmail: true,
+        invoiceNumber: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        paymentLink: true,
+      },
+    })
+    expect(mockedSendEmail).toHaveBeenCalledWith({
+      to: 'client@example.com',
+      subject: 'Payment reminder: INV-001',
+      html: expect.stringContaining('500.00 USD'),
+    })
+  })
+
+  it('renders Not set when due date is absent', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      ...pendingInvoice,
+      dueDate: null,
+    } as never)
+
+    const res = await POST(makePOST(), makeParams())
+
+    expect(res.status).toBe(200)
+    expect(mockedSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining('Not set'),
+      }),
+    )
+  })
+
+  it('returns 401 when authorization is missing', async () => {
+    const res = await POST(makePOST(invoiceId, false), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when token verification fails', async () => {
+    mockedVerify.mockResolvedValue(null as never)
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHORIZED')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for a non-UUID invoice id', async () => {
+    const res = await POST(makePOST('not-a-uuid'), makeParams('not-a-uuid'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.fields.id).toBe('Must be a valid UUID')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user cannot be resolved', async () => {
+    mockedUserFind.mockResolvedValue(null)
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('User not found')
+    expect(mockedInvoiceFind).not.toHaveBeenCalled()
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice does not exist', async () => {
+    mockedInvoiceFind.mockResolvedValue(null)
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(body.error.message).toBe('Invoice not found')
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invoice belongs to another user', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      ...pendingInvoice,
+      userId: 'other-user',
+    } as never)
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.error.code).toBe('NOT_FOUND')
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 422 when the invoice is not pending', async () => {
+    mockedInvoiceFind.mockResolvedValue({
+      ...pendingInvoice,
+      status: 'paid',
+    } as never)
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(422)
+    expect(body.error.code).toBe('BAD_REQUEST')
+    expect(body.error.message).toBe('Reminders can only be sent for pending invoices')
+    expect(mockedSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when email sending fails', async () => {
+    mockedSendEmail.mockRejectedValue(new Error('resend down'))
+
+    const res = await POST(makePOST(), makeParams())
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe('INTERNAL')
+    expect(body.error.message).toBe('Failed to send invoice reminder')
+  })
+})

--- a/app/api/routes-b/invoices/[id]/remind/route.ts
+++ b/app/api/routes-b/invoices/[id]/remind/route.ts
@@ -1,8 +1,39 @@
 import { withRequestId } from '../../../_lib/with-request-id'
+import { withMethods } from '../../../_lib/with-methods'
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { verifyAuthToken } from '@/lib/auth'
 import { sendEmail } from '@/lib/email'
+import { errorResponse } from '../../../_lib/errors'
+import { logger } from '@/lib/logger'
+import { z } from 'zod'
+
+const invoiceIdParamsSchema = z.object({
+  id: z.string().uuid('Invoice id must be a valid UUID'),
+})
+
+async function getAuthenticatedUser(request: NextRequest) {
+  const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
+  if (!authToken) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
+
+  const claims = await verifyAuthToken(authToken)
+  if (!claims) {
+    return { error: errorResponse('UNAUTHORIZED', 'Unauthorized', undefined, 401) }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { privyId: claims.userId },
+    select: { id: true },
+  })
+
+  if (!user) {
+    return { error: errorResponse('NOT_FOUND', 'User not found', undefined, 404) }
+  }
+
+  return { user }
+}
 
 async function POSTHandler(
   request: NextRequest,
@@ -10,78 +41,79 @@ async function POSTHandler(
 ) {
   try {
     const { id } = await params
-    const authToken = request.headers.get('authorization')?.replace('Bearer ', '')
-    if (!authToken) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const claims = await verifyAuthToken(authToken)
-    if (!claims) {
-      return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { privyId: claims.userId },
-    })
-    if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 401 })
-    }
-
-    const invoice = await prisma.invoice.findUnique({
-      where: { id },
-    })
-
-    if (!invoice) {
-      return NextResponse.json({ error: 'Invoice not found' }, { status: 404 })
-    }
-
-    if (invoice.userId !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-
-    if (invoice.status !== 'pending') {
-      return NextResponse.json(
-        { error: 'Reminders can only be sent for pending invoices' },
-        { status: 422 }
+    const parsedParams = invoiceIdParamsSchema.safeParse({ id })
+    if (!parsedParams.success) {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Invalid invoice id',
+        { fields: { id: 'Must be a valid UUID' } },
+        400,
       )
     }
 
-    // Send reminder email
+    const auth = await getAuthenticatedUser(request)
+    if ('error' in auth) return auth.error
+
+    const invoice = await prisma.invoice.findUnique({
+      where: { id: parsedParams.data.id },
+      select: {
+        id: true,
+        userId: true,
+        status: true,
+        clientEmail: true,
+        invoiceNumber: true,
+        amount: true,
+        currency: true,
+        dueDate: true,
+        paymentLink: true,
+      },
+    })
+
+    if (!invoice || invoice.userId !== auth.user.id) {
+      return errorResponse('NOT_FOUND', 'Invoice not found', undefined, 404)
+    }
+
+    if (invoice.status !== 'pending') {
+      return errorResponse(
+        'BAD_REQUEST',
+        'Reminders can only be sent for pending invoices',
+        undefined,
+        422,
+      )
+    }
+
     const dueDateStr = invoice.dueDate
       ? new Date(invoice.dueDate).toLocaleDateString()
       : 'Not set'
+    const amountStr = Number(invoice.amount).toFixed(2)
     
-    try {
-      await sendEmail({
-        to: invoice.clientEmail,
-        subject: `Payment reminder: ${invoice.invoiceNumber}`,
-        html: `
-          <div style="font-family: system-ui, sans-serif; max-width: 500px; margin: 0 auto; padding: 24px;">
-            <h2>Payment Reminder</h2>
-            <p>This is a reminder for invoice <strong>${invoice.invoiceNumber}</strong>.</p>
-            <p><strong>Amount:</strong> ${Number(invoice.amount).toFixed(2)} ${invoice.currency}</p>
-            <p><strong>Due Date:</strong> ${dueDateStr}</p>
-            <div style="margin: 24px 0;">
-              <a href="${invoice.paymentLink}" style="display: inline-block; background: #10b981; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: bold;">Pay Now</a>
-            </div>
-            <p style="color: #666; font-size: 12px; margin-top: 20px;">LancePay - Get paid globally, withdraw locally</p>
-          </div>
-        `,
-      })
-    } catch (emailError) {
-      console.error('Failed to send reminder email:', emailError)
-      // Email failure does NOT cause the API to error as per requirements
-    }
+    await sendEmail({
+      to: invoice.clientEmail,
+      subject: `Payment reminder: ${invoice.invoiceNumber}`,
+      html: `
+        <div style="font-family: system-ui, sans-serif; max-width: 500px; margin: 0 auto; padding: 24px;">
+          <h2>Payment reminder</h2>
+          <p>This is a friendly reminder about invoice <strong>${invoice.invoiceNumber}</strong>.</p>
+          <p><strong>Amount owed:</strong> ${amountStr} ${invoice.currency}</p>
+          <p><strong>Due date:</strong> ${dueDateStr}</p>
+          <p><a href="${invoice.paymentLink}" style="display: inline-block; background: #10b981; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: bold;">Pay now</a></p>
+          <p style="color: #666; font-size: 12px; margin-top: 20px;">LancePay - Get paid globally, withdraw locally</p>
+        </div>
+      `,
+    })
 
     return NextResponse.json({
       sent: true,
+      invoiceId: invoice.id,
       clientEmail: invoice.clientEmail,
       invoiceNumber: invoice.invoiceNumber,
     })
   } catch (error) {
-    console.error('Reminder POST error:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    logger.error({ err: error }, 'POST /api/routes-b/invoices/[id]/remind error')
+    return errorResponse('INTERNAL', 'Failed to send invoice reminder', undefined, 500)
   }
 }
 
-export const POST = withRequestId(POSTHandler)
+export const { POST } = withMethods({
+  POST: withRequestId(POSTHandler),
+})


### PR DESCRIPTION
Closes #700

---

## Summary
- Harden POST /api/routes-b/invoices/[id]/remind with UUID validation, auth, ownership checks, and routes-b error envelopes.
- Send payment reminder emails for owned pending invoices and return a structured confirmation payload.
- Add focused unit tests for success, due-date display, auth, validation, ownership, status, and email failure paths.

## Tests
- npx vitest run app/api/routes-b/invoices/[id]/remind/__tests__/route.test.ts
- npx eslint app/api/routes-b/invoices/[id]/remind/route.ts app/api/routes-b/invoices/[id]/remind/__tests__/route.test.ts

Note: npm run build currently fails on existing unrelated errors in app/api/routes-b/stats/route.ts, app/api/routes-b/_lib/error.ts, and app/api/routes-b/invoices/[id]/tags/[tagId]/route.ts.